### PR TITLE
remove upgrade and user data collection code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ include_package_data = True
 gui_scripts =
     fsgissue=FreeSimpleGui.FreeSimpleGui:main_open_github_issue
     fsgmain=FreeSimpleGui.FreeSimpleGui:_main_entry_point
-    fsgupgrade=FreeSimpleGui.FreeSimpleGui:_upgrade_entry_point
     fsghelp=FreeSimpleGui.FreeSimpleGui:main_sdk_help
     fsgver=FreeSimpleGui.FreeSimpleGui:main_get_debug_data
     fsgsettings=FreeSimpleGui.FreeSimpleGui:main_global_pysimplegui_settings


### PR DESCRIPTION
Prior to the creation of this fork, PySimpleGUI included code that would collect user system data and send it to an 'upgrade server' as well as perform upgrades by receiving responses from the upgrade server and downloading files from GitHub dynamically. This functionality was not only insecure but, in my personal estimations, violated the privacy of PySimpleGUI users.

This functionality **was already effectively disabled prior to the first PyPI release of `FreeSimpleGUI`** (the addresses to the remote servers, presumably controlled by the author(s) of PySimpleGUI were removed from the source code, so attempted data collections/upgrades would simply fail) -- this change is just a cleanup effort and completely removes this now-dead/ineffective code.

To be certain and for the avoidance of any doubt: the maintainers of `FreeSimpleGUI` (me) have never used the `FreeSimpleGUI` software to collect data of its users without consent (or otherwise) and it will never do so. We firmly believe in your rights to privacy and promise to continue working to respect that privacy.