### PR TITLE
add black, flake8, reorder imports to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,27 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: double-quote-string-fixer
-        files: ^(FreeSimpleGUI.*)/.*\.py
+        files: ^(FreeSimpleGUI(?:Qt|Web|Wx)?)/(?!Demo).*\.py
+-   repo: https://github.com/asottile/reorder-python-imports
+    rev: v3.12.0
+    hooks:
+    -   id: reorder-python-imports
+        files: ^(FreeSimpleGUI(?:Qt|Web|Wx)?)/(?!Demo).*\.py
+-   repo: https://github.com/psf/black
+    rev: '24.4.2'
+    hooks:
+    -   id: black
+        args:
+            - "-S"
+            - "-l"
+            - "120"
+        files: ^(FreeSimpleGUI(?:Qt|Web|Wx)?)/(?!Demo).*\.py
+
+-   repo: https://github.com/pycqa/flake8
+    rev: '7.0.0'  # pick a git hash / tag to point to
+    hooks:
+    -   id: flake8
+        args:
+          - "--ignore"
+          - "E501,E704,E301,W503,E701,E722,E266,E203"
+        files: FreeSimpleGUI/FreeSimpleGUI.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args:
             - "-S"
             - "-l"
-            - "120"
+            - "360"
         files: ^(FreeSimpleGUI(?:Qt|Web|Wx)?)/(?!Demo).*\.py
 
 -   repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,5 +31,5 @@ repos:
     -   id: flake8
         args:
           - "--ignore"
-          - "E501,E704,E301,W503,E701,E722,E266,E203"
+          - "E501,E704,E301,W503,E701,E722,E266,E203,E231"
         files: FreeSimpleGUI/FreeSimpleGUI.py

--- a/FreeSimpleGUI/FreeSimpleGUI.py
+++ b/FreeSimpleGUI/FreeSimpleGUI.py
@@ -135,7 +135,7 @@ def _timeit(func):
         start = time.time()
         result = func(*args, **kwargs)
         end = time.time()
-        print('{} executed in {:.4f} seconds'.format(func.__name__, end - start))
+        print(f'{func.__name__} executed in {end - start:.4f} seconds')
         return result
 
     return wrapper
@@ -167,7 +167,7 @@ def _timeit_summary(func):
         _timeit_counter += 1
         _timeit_total += end - start
         if _timeit_counter > MAX_TIMEIT_COUNT:
-            print('{} executed in {:.4f} seconds'.format(func.__name__, _timeit_total / MAX_TIMEIT_COUNT))
+            print(f'{func.__name__} executed in {_timeit_total / MAX_TIMEIT_COUNT:.4f} seconds')
             _timeit_counter = 0
             _timeit_total = 0
         return result
@@ -342,9 +342,7 @@ NICE_BUTTON_COLORS = (
     (YELLOWS[0], BLUES[2]),
 )
 
-COLOR_SYSTEM_DEFAULT = (
-    '1234567890'  # A Magic Number kind of signal to PySimpleGUI that the color should not be set at all
-)
+COLOR_SYSTEM_DEFAULT = '1234567890'  # A Magic Number kind of signal to PySimpleGUI that the color should not be set at all
 DEFAULT_BUTTON_COLOR = ('white', BLUES[0])  # Foreground, Background (None, None) == System Default
 OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR = ('white', BLUES[0])
 
@@ -360,15 +358,6 @@ DEFAULT_TEXT_COLOR = COLOR_SYSTEM_DEFAULT
 DEFAULT_INPUT_ELEMENTS_COLOR = COLOR_SYSTEM_DEFAULT
 DEFAULT_INPUT_TEXT_COLOR = COLOR_SYSTEM_DEFAULT
 DEFAULT_SCROLLBAR_COLOR = None
-# DEFAULT_BUTTON_COLOR = (YELLOWS[0], PURPLES[0])    # (Text, Background) or (Color "on", Color) as a way to remember
-# DEFAULT_BUTTON_COLOR = (GREENS[3], TANS[0])    # Foreground, Background (None, None) == System Default
-# DEFAULT_BUTTON_COLOR = (YELLOWS[0], GREENS[4])    # Foreground, Background (None, None) == System Default
-# DEFAULT_BUTTON_COLOR = ('white', 'black')    # Foreground, Background (None, None) == System Default
-# DEFAULT_BUTTON_COLOR = (YELLOWS[0], PURPLES[2])    # Foreground, Background (None, None) == System Default
-# DEFAULT_PROGRESS_BAR_COLOR = (GREENS[2], GREENS[0])     # a nice green progress bar
-# DEFAULT_PROGRESS_BAR_COLOR = (BLUES[1], BLUES[1])     # a nice green progress bar
-# DEFAULT_PROGRESS_BAR_COLOR = (BLUES[0], BLUES[0])     # a nice green progress bar
-# DEFAULT_PROGRESS_BAR_COLOR = (PURPLES[1],PURPLES[0])    # a nice purple progress bar
 
 
 # A transparent button is simply one that matches the background
@@ -433,9 +422,7 @@ TABLE_SELECT_MODE_NONE = tk.NONE
 TABLE_SELECT_MODE_BROWSE = tk.BROWSE
 TABLE_SELECT_MODE_EXTENDED = tk.EXTENDED
 DEFAULT_TABLE_SELECT_MODE = TABLE_SELECT_MODE_EXTENDED
-TABLE_CLICKED_INDICATOR = (
-    '+CLICKED+'  # Part of the tuple returned as an event when a Table element has click events enabled
-)
+TABLE_CLICKED_INDICATOR = '+CLICKED+'  # Part of the tuple returned as an event when a Table element has click events enabled
 DEFAULT_MODAL_WINDOWS_ENABLED = True
 DEFAULT_MODAL_WINDOWS_FORCED = False
 
@@ -588,9 +575,7 @@ DEFAULT_USER_SETTINGS_REPLIT_PATH = r'.'
 DEFAULT_USER_SETTINGS_UNKNOWN_OS_PATH = r'~/Library/Application Support/PySimpleGUI/settings'
 DEFAULT_USER_SETTINGS_PATH = None  # value set by user to override all paths above
 DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH = None  # location of the global PySimpleGUI settings
-DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME = (
-    '_PySimpleGUI_settings_global_.json'  # location of the global PySimpleGUI settings
-)
+DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME = '_PySimpleGUI_settings_global_.json'  # location of the global PySimpleGUI settings
 
 
 # ====================================================================== #
@@ -611,7 +596,7 @@ def rgb(red, green, blue):
     red = min(int(red), 255) if red > 0 else 0
     blue = min(int(blue), 255) if blue > 0 else 0
     green = min(int(green), 255) if green > 0 else 0
-    return '#%02x%02x%02x' % (red, green, blue)
+    return '#{:02x}{:02x}{:02x}'.format(red, green, blue)
 
 
 # ====================================================================== #
@@ -765,1077 +750,16 @@ ttk_part_overrides_from_options = TTKPartOverrides()
 
 
 # -------------------------  tkinter BASIC cursors... there are some OS dependent ones too  ------------------------- #
-TKINTER_CURSORS = [
-    'X_cursor',
-    'arrow',
-    'based_arrow_down',
-    'based_arrow_up',
-    'boat',
-    'bogosity',
-    'bottom_left_corner',
-    'bottom_right_corner',
-    'bottom_side',
-    'bottom_tee',
-    'box_spiral',
-    'center_ptr',
-    'circle',
-    'clock',
-    'coffee_mug',
-    'cross',
-    'cross_reverse',
-    'crosshair',
-    'diamond_cross',
-    'dot',
-    'dotbox',
-    'double_arrow',
-    'draft_large',
-    'draft_small',
-    'draped_box',
-    'exchange',
-    'fleur',
-    'gobbler',
-    'gumby',
-    'hand1',
-    'hand2',
-    'heart',
-    'icon',
-    'iron_cross',
-    'left_ptr',
-    'left_side',
-    'left_tee',
-    'leftbutton',
-    'll_angle',
-    'lr_angle',
-    'man',
-    'middlebutton',
-    'mouse',
-    'pencil',
-    'pirate',
-    'plus',
-    'question_arrow',
-    'right_ptr',
-    'right_side',
-    'right_tee',
-    'rightbutton',
-    'rtl_logo',
-    'sailboat',
-    'sb_down_arrow',
-    'sb_h_double_arrow',
-    'sb_left_arrow',
-    'sb_right_arrow',
-    'sb_up_arrow',
-    'sb_v_double_arrow',
-    'shuttle',
-    'sizing',
-    'spider',
-    'spraycan',
-    'star',
-    'target',
-    'tcross',
-    'top_left_arrow',
-    'top_left_corner',
-    'top_right_corner',
-    'top_side',
-    'top_tee',
-    'trek',
-    'ul_angle',
-    'umbrella',
-    'ur_angle',
-    'watch',
-    'xterm',
-]
+# TKINTER_CURSORS = ['X_cursor', 'arrow', 'based_arrow_down', 'based_arrow_up', 'boat', 'bogosity', 'bottom_left_corner', 'bottom_right_corner', 'bottom_side', 'bottom_tee', 'box_spiral', 'center_ptr', 'circle', 'clock', 'coffee_mug', 'cross', 'cross_reverse', 'crosshair', 'diamond_cross', 'dot', 'dotbox', 'double_arrow', 'draft_large', 'draft_small', 'draped_box', 'exchange', 'fleur', 'gobbler', 'gumby', 'hand1', 'hand2', 'heart', 'icon', 'iron_cross', 'left_ptr', 'left_side', 'left_tee', 'leftbutton', 'll_angle', 'lr_angle', 'man', 'middlebutton', 'mouse', 'pencil', 'pirate', 'plus', 'question_arrow', 'right_ptr', 'right_side', 'right_tee', 'rightbutton', 'rtl_logo', 'sailboat', 'sb_down_arrow', 'sb_h_double_arrow', 'sb_left_arrow', 'sb_right_arrow', 'sb_up_arrow', 'sb_v_double_arrow', 'shuttle', 'sizing', 'spider', 'spraycan', 'star', 'target', 'tcross', 'top_left_arrow', 'top_left_corner', 'top_right_corner', 'top_side', 'top_tee', 'trek', 'ul_angle', 'umbrella', 'ur_angle', 'watch', 'xterm',]
 
-
-TKINTER_CURSORS = [
-    'X_cursor',
-    'arrow',
-    'based_arrow_down',
-    'based_arrow_up',
-    'boat',
-    'bogosity',
-    'bottom_left_corner',
-    'bottom_right_corner',
-    'bottom_side',
-    'bottom_tee',
-    'box_spiral',
-    'center_ptr',
-    'circle',
-    'clock',
-    'coffee_mug',
-    'cross',
-    'cross_reverse',
-    'crosshair',
-    'diamond_cross',
-    'dot',
-    'dotbox',
-    'double_arrow',
-    'draft_large',
-    'draft_small',
-    'draped_box',
-    'exchange',
-    'fleur',
-    'gobbler',
-    'gumby',
-    'hand1',
-    'hand2',
-    'heart',
-    'ibeam',
-    'icon',
-    'iron_cross',
-    'left_ptr',
-    'left_side',
-    'left_tee',
-    'leftbutton',
-    'll_angle',
-    'lr_angle',
-    'man',
-    'middlebutton',
-    'mouse',
-    'no',
-    'none',
-    'pencil',
-    'pirate',
-    'plus',
-    'question_arrow',
-    'right_ptr',
-    'right_side',
-    'right_tee',
-    'rightbutton',
-    'rtl_logo',
-    'sailboat',
-    'sb_down_arrow',
-    'sb_h_double_arrow',
-    'sb_left_arrow',
-    'sb_right_arrow',
-    'sb_up_arrow',
-    'sb_v_double_arrow',
-    'shuttle',
-    'size',
-    'size_ne_sw',
-    'size_ns',
-    'size_nw_se',
-    'size_we',
-    'sizing',
-    'spider',
-    'spraycan',
-    'star',
-    'starting',
-    'target',
-    'tcross',
-    'top_left_arrow',
-    'top_left_corner',
-    'top_right_corner',
-    'top_side',
-    'top_tee',
-    'trek',
-    'ul_angle',
-    'umbrella',
-    'uparrow',
-    'ur_angle',
-    'wait',
-    'watch',
-    'xterm',
-]
+# fmt: off
+TKINTER_CURSORS = ['X_cursor', 'arrow', 'based_arrow_down', 'based_arrow_up', 'boat', 'bogosity', 'bottom_left_corner', 'bottom_right_corner', 'bottom_side', 'bottom_tee', 'box_spiral', 'center_ptr', 'circle', 'clock', 'coffee_mug', 'cross', 'cross_reverse', 'crosshair', 'diamond_cross', 'dot', 'dotbox', 'double_arrow', 'draft_large', 'draft_small', 'draped_box', 'exchange', 'fleur', 'gobbler', 'gumby', 'hand1', 'hand2', 'heart', 'ibeam', 'icon', 'iron_cross', 'left_ptr', 'left_side', 'left_tee', 'leftbutton', 'll_angle', 'lr_angle', 'man', 'middlebutton', 'mouse', 'no', 'none', 'pencil', 'pirate', 'plus', 'question_arrow', 'right_ptr', 'right_side', 'right_tee', 'rightbutton', 'rtl_logo', 'sailboat', 'sb_down_arrow', 'sb_h_double_arrow', 'sb_left_arrow', 'sb_right_arrow', 'sb_up_arrow', 'sb_v_double_arrow', 'shuttle', 'size', 'size_ne_sw', 'size_ns', 'size_nw_se', 'size_we', 'sizing', 'spider', 'spraycan', 'star', 'starting', 'target', 'tcross', 'top_left_arrow', 'top_left_corner', 'top_right_corner', 'top_side', 'top_tee', 'trek', 'ul_angle', 'umbrella', 'uparrow', 'ur_angle', 'wait', 'watch', 'xterm',]
 # -------------------------  tkinter key codes for bindings  ------------------------- #
-
 # The keycode that when pressed will take a snapshot of the current window
 DEFAULT_WINDOW_SNAPSHOT_KEY_CODE = None
 DEFAULT_WINDOW_SNAPSHOT_KEY = '--SCREENSHOT THIS WINDOW--'
-
-tkinter_keysyms = (
-    'space',
-    'exclam',
-    'quotedbl',
-    'numbersign',
-    'dollar',
-    'percent',
-    'ampersand',
-    'quoteright',
-    'parenleft',
-    'parenright',
-    'asterisk',
-    'plus',
-    'comma',
-    'minus',
-    'period',
-    'slash',
-    '0',
-    '1',
-    '2',
-    '3',
-    '4',
-    '5',
-    '6',
-    '7',
-    '8',
-    '9',
-    'colon',
-    'semicolon',
-    'less',
-    'equal',
-    'greater',
-    'question',
-    'at',
-    'A',
-    'B',
-    'C',
-    'D',
-    'E',
-    'F',
-    'G',
-    'H',
-    'I',
-    'J',
-    'K',
-    'L',
-    'M',
-    'N',
-    'O',
-    'P',
-    'Q',
-    'R',
-    'S',
-    'T',
-    'U',
-    'V',
-    'W',
-    'X',
-    'Y',
-    'Z',
-    'bracketleft',
-    'backslash',
-    'bracketright',
-    'asciicircum',
-    'underscore',
-    'quoteleft',
-    'a',
-    'b',
-    'c',
-    'd',
-    'e',
-    'f',
-    'g',
-    'h',
-    'i',
-    'j',
-    'k',
-    'l',
-    'm',
-    'n',
-    'o',
-    'p',
-    'q',
-    'r',
-    's',
-    't',
-    'u',
-    'v',
-    'w',
-    'x',
-    'y',
-    'z',
-    'braceleft',
-    'bar',
-    'braceright',
-    'asciitilde',
-    'nobreakspace',
-    'exclamdown',
-    'cent',
-    'sterling',
-    'currency',
-    'yen',
-    'brokenbar',
-    'section',
-    'diaeresis',
-    'copyright',
-    'ordfeminine',
-    'guillemotleft',
-    'notsign',
-    'hyphen',
-    'registered',
-    'macron',
-    'degree',
-    'plusminus',
-    'twosuperior',
-    'threesuperior',
-    'acute',
-    'mu',
-    'paragraph',
-    'periodcentered',
-    'cedilla',
-    'onesuperior',
-    'masculine',
-    'guillemotright',
-    'onequarter',
-    'onehalf',
-    'threequarters',
-    'questiondown',
-    'Agrave',
-    'Aacute',
-    'Acircumflex',
-    'Atilde',
-    'Adiaeresis',
-    'Aring',
-    'AE',
-    'Ccedilla',
-    'Egrave',
-    'Eacute',
-    'Ecircumflex',
-    'Ediaeresis',
-    'Igrave',
-    'Iacute',
-    'Icircumflex',
-    'Idiaeresis',
-    'Eth',
-    'Ntilde',
-    'Ograve',
-    'Oacute',
-    'Ocircumflex',
-    'Otilde',
-    'Odiaeresis',
-    'multiply',
-    'Ooblique',
-    'Ugrave',
-    'Uacute',
-    'Ucircumflex',
-    'Udiaeresis',
-    'Yacute',
-    'Thorn',
-    'ssharp',
-    'agrave',
-    'aacute',
-    'acircumflex',
-    'atilde',
-    'adiaeresis',
-    'aring',
-    'ae',
-    'ccedilla',
-    'egrave',
-    'eacute',
-    'ecircumflex',
-    'ediaeresis',
-    'igrave',
-    'iacute',
-    'icircumflex',
-    'idiaeresis',
-    'eth',
-    'ntilde',
-    'ograve',
-    'oacute',
-    'ocircumflex',
-    'otilde',
-    'odiaeresis',
-    'division',
-    'oslash',
-    'ugrave',
-    'uacute',
-    'ucircumflex',
-    'udiaeresis',
-    'yacute',
-    'thorn',
-    'ydiaeresis',
-    'Aogonek',
-    'breve',
-    'Lstroke',
-    'Lcaron',
-    'Sacute',
-    'Scaron',
-    'Scedilla',
-    'Tcaron',
-    'Zacute',
-    'Zcaron',
-    'Zabovedot',
-    'aogonek',
-    'ogonek',
-    'lstroke',
-    'lcaron',
-    'sacute',
-    'caron',
-    'scaron',
-    'scedilla',
-    'tcaron',
-    'zacute',
-    'doubleacute',
-    'zcaron',
-    'zabovedot',
-    'Racute',
-    'Abreve',
-    'Cacute',
-    'Ccaron',
-    'Eogonek',
-    'Ecaron',
-    'Dcaron',
-    'Nacute',
-    'Ncaron',
-    'Odoubleacute',
-    'Rcaron',
-    'Uring',
-    'Udoubleacute',
-    'Tcedilla',
-    'racute',
-    'abreve',
-    'cacute',
-    'ccaron',
-    'eogonek',
-    'ecaron',
-    'dcaron',
-    'nacute',
-    'ncaron',
-    'odoubleacute',
-    'rcaron',
-    'uring',
-    'udoubleacute',
-    'tcedilla',
-    'abovedot',
-    'Hstroke',
-    'Hcircumflex',
-    'Iabovedot',
-    'Gbreve',
-    'Jcircumflex',
-    'hstroke',
-    'hcircumflex',
-    'idotless',
-    'gbreve',
-    'jcircumflex',
-    'Cabovedot',
-    'Ccircumflex',
-    'Gabovedot',
-    'Gcircumflex',
-    'Ubreve',
-    'Scircumflex',
-    'cabovedot',
-    'ccircumflex',
-    'gabovedot',
-    'gcircumflex',
-    'ubreve',
-    'scircumflex',
-    'kappa',
-    'Rcedilla',
-    'Itilde',
-    'Lcedilla',
-    'Emacron',
-    'Gcedilla',
-    'Tslash',
-    'rcedilla',
-    'itilde',
-    'lcedilla',
-    'emacron',
-    'gacute',
-    'tslash',
-    'ENG',
-    'eng',
-    'Amacron',
-    'Iogonek',
-    'Eabovedot',
-    'Imacron',
-    'Ncedilla',
-    'Omacron',
-    'Kcedilla',
-    'Uogonek',
-    'Utilde',
-    'Umacron',
-    'amacron',
-    'iogonek',
-    'eabovedot',
-    'imacron',
-    'ncedilla',
-    'omacron',
-    'kcedilla',
-    'uogonek',
-    'utilde',
-    'umacron',
-    'overline',
-    'kana_fullstop',
-    'kana_openingbracket',
-    'kana_closingbracket',
-    'kana_comma',
-    'kana_middledot',
-    'kana_WO',
-    'kana_a',
-    'kana_i',
-    'kana_u',
-    'kana_e',
-    'kana_o',
-    'kana_ya',
-    'kana_yu',
-    'kana_yo',
-    'kana_tu',
-    'prolongedsound',
-    'kana_A',
-    'kana_I',
-    'kana_U',
-    'kana_E',
-    'kana_O',
-    'kana_KA',
-    'kana_KI',
-    'kana_KU',
-    'kana_KE',
-    'kana_KO',
-    'kana_SA',
-    'kana_SHI',
-    'kana_SU',
-    'kana_SE',
-    'kana_SO',
-    'kana_TA',
-    'kana_TI',
-    'kana_TU',
-    'kana_TE',
-    'kana_TO',
-    'kana_NA',
-    'kana_NI',
-    'kana_NU',
-    'kana_NE',
-    'kana_NO',
-    'kana_HA',
-    'kana_HI',
-    'kana_HU',
-    'kana_HE',
-    'kana_HO',
-    'kana_MA',
-    'kana_MI',
-    'kana_MU',
-    'kana_ME',
-    'kana_MO',
-    'kana_YA',
-    'kana_YU',
-    'kana_YO',
-    'kana_RA',
-    'kana_RI',
-    'kana_RU',
-    'kana_RE',
-    'kana_RO',
-    'kana_WA',
-    'kana_N',
-    'voicedsound',
-    'semivoicedsound',
-    'Arabic_comma',
-    'Arabic_semicolon',
-    'Arabic_question_mark',
-    'Arabic_hamza',
-    'Arabic_maddaonalef',
-    'Arabic_hamzaonalef',
-    'Arabic_hamzaonwaw',
-    'Arabic_hamzaunderalef',
-    'Arabic_hamzaonyeh',
-    'Arabic_alef',
-    'Arabic_beh',
-    'Arabic_tehmarbuta',
-    'Arabic_teh',
-    'Arabic_theh',
-    'Arabic_jeem',
-    'Arabic_hah',
-    'Arabic_khah',
-    'Arabic_dal',
-    'Arabic_thal',
-    'Arabic_ra',
-    'Arabic_zain',
-    'Arabic_seen',
-    'Arabic_sheen',
-    'Arabic_sad',
-    'Arabic_dad',
-    'Arabic_tah',
-    'Arabic_zah',
-    'Arabic_ain',
-    'Arabic_ghain',
-    'Arabic_tatweel',
-    'Arabic_feh',
-    'Arabic_qaf',
-    'Arabic_kaf',
-    'Arabic_lam',
-    'Arabic_meem',
-    'Arabic_noon',
-    'Arabic_heh',
-    'Arabic_waw',
-    'Arabic_alefmaksura',
-    'Arabic_yeh',
-    'Arabic_fathatan',
-    'Arabic_dammatan',
-    'Arabic_kasratan',
-    'Arabic_fatha',
-    'Arabic_damma',
-    'Arabic_kasra',
-    'Arabic_shadda',
-    'Arabic_sukun',
-    'Serbian_dje',
-    'Macedonia_gje',
-    'Cyrillic_io',
-    'Ukranian_je',
-    'Macedonia_dse',
-    'Ukranian_i',
-    'Ukranian_yi',
-    'Serbian_je',
-    'Serbian_lje',
-    'Serbian_nje',
-    'Serbian_tshe',
-    'Macedonia_kje',
-    'Byelorussian_shortu',
-    'Serbian_dze',
-    'numerosign',
-    'Serbian_DJE',
-    'Macedonia_GJE',
-    'Cyrillic_IO',
-    'Ukranian_JE',
-    'Macedonia_DSE',
-    'Ukranian_I',
-    'Ukranian_YI',
-    'Serbian_JE',
-    'Serbian_LJE',
-    'Serbian_NJE',
-    'Serbian_TSHE',
-    'Macedonia_KJE',
-    'Byelorussian_SHORTU',
-    'Serbian_DZE',
-    'Cyrillic_yu',
-    'Cyrillic_a',
-    'Cyrillic_be',
-    'Cyrillic_tse',
-    'Cyrillic_de',
-    'Cyrillic_ie',
-    'Cyrillic_ef',
-    'Cyrillic_ghe',
-    'Cyrillic_ha',
-    'Cyrillic_i',
-    'Cyrillic_shorti',
-    'Cyrillic_ka',
-    'Cyrillic_el',
-    'Cyrillic_em',
-    'Cyrillic_en',
-    'Cyrillic_o',
-    'Cyrillic_pe',
-    'Cyrillic_ya',
-    'Cyrillic_er',
-    'Cyrillic_es',
-    'Cyrillic_te',
-    'Cyrillic_u',
-    'Cyrillic_zhe',
-    'Cyrillic_ve',
-    'Cyrillic_softsign',
-    'Cyrillic_yeru',
-    'Cyrillic_ze',
-    'Cyrillic_sha',
-    'Cyrillic_e',
-    'Cyrillic_shcha',
-    'Cyrillic_che',
-    'Cyrillic_hardsign',
-    'Cyrillic_YU',
-    'Cyrillic_A',
-    'Cyrillic_BE',
-    'Cyrillic_TSE',
-    'Cyrillic_DE',
-    'Cyrillic_IE',
-    'Cyrillic_EF',
-    'Cyrillic_GHE',
-    'Cyrillic_HA',
-    'Cyrillic_I',
-    'Cyrillic_SHORTI',
-    'Cyrillic_KA',
-    'Cyrillic_EL',
-    'Cyrillic_EM',
-    'Cyrillic_EN',
-    'Cyrillic_O',
-    'Cyrillic_PE',
-    'Cyrillic_YA',
-    'Cyrillic_ER',
-    'Cyrillic_ES',
-    'Cyrillic_TE',
-    'Cyrillic_U',
-    'Cyrillic_ZHE',
-    'Cyrillic_VE',
-    'Cyrillic_SOFTSIGN',
-    'Cyrillic_YERU',
-    'Cyrillic_ZE',
-    'Cyrillic_SHA',
-    'Cyrillic_E',
-    'Cyrillic_SHCHA',
-    'Cyrillic_CHE',
-    'Cyrillic_HARDSIGN',
-    'Greek_ALPHAaccent',
-    'Greek_EPSILONaccent',
-    'Greek_ETAaccent',
-    'Greek_IOTAaccent',
-    'Greek_IOTAdiaeresis',
-    'Greek_IOTAaccentdiaeresis',
-    'Greek_OMICRONaccent',
-    'Greek_UPSILONaccent',
-    'Greek_UPSILONdieresis',
-    'Greek_UPSILONaccentdieresis',
-    'Greek_OMEGAaccent',
-    'Greek_alphaaccent',
-    'Greek_epsilonaccent',
-    'Greek_etaaccent',
-    'Greek_iotaaccent',
-    'Greek_iotadieresis',
-    'Greek_iotaaccentdieresis',
-    'Greek_omicronaccent',
-    'Greek_upsilonaccent',
-    'Greek_upsilondieresis',
-    'Greek_upsilonaccentdieresis',
-    'Greek_omegaaccent',
-    'Greek_ALPHA',
-    'Greek_BETA',
-    'Greek_GAMMA',
-    'Greek_DELTA',
-    'Greek_EPSILON',
-    'Greek_ZETA',
-    'Greek_ETA',
-    'Greek_THETA',
-    'Greek_IOTA',
-    'Greek_KAPPA',
-    'Greek_LAMBDA',
-    'Greek_MU',
-    'Greek_NU',
-    'Greek_XI',
-    'Greek_OMICRON',
-    'Greek_PI',
-    'Greek_RHO',
-    'Greek_SIGMA',
-    'Greek_TAU',
-    'Greek_UPSILON',
-    'Greek_PHI',
-    'Greek_CHI',
-    'Greek_PSI',
-    'Greek_OMEGA',
-    'Greek_alpha',
-    'Greek_beta',
-    'Greek_gamma',
-    'Greek_delta',
-    'Greek_epsilon',
-    'Greek_zeta',
-    'Greek_eta',
-    'Greek_theta',
-    'Greek_iota',
-    'Greek_kappa',
-    'Greek_lambda',
-    'Greek_mu',
-    'Greek_nu',
-    'Greek_xi',
-    'Greek_omicron',
-    'Greek_pi',
-    'Greek_rho',
-    'Greek_sigma',
-    'Greek_finalsmallsigma',
-    'Greek_tau',
-    'Greek_upsilon',
-    'Greek_phi',
-    'Greek_chi',
-    'Greek_psi',
-    'Greek_omega',
-    'leftradical',
-    'topleftradical',
-    'horizconnector',
-    'topintegral',
-    'botintegral',
-    'vertconnector',
-    'topleftsqbracket',
-    'botleftsqbracket',
-    'toprightsqbracket',
-    'botrightsqbracket',
-    'topleftparens',
-    'botleftparens',
-    'toprightparens',
-    'botrightparens',
-    'leftmiddlecurlybrace',
-    'rightmiddlecurlybrace',
-    'topleftsummation',
-    'botleftsummation',
-    'topvertsummationconnector',
-    'botvertsummationconnector',
-    'toprightsummation',
-    'botrightsummation',
-    'rightmiddlesummation',
-    'lessthanequal',
-    'notequal',
-    'greaterthanequal',
-    'integral',
-    'therefore',
-    'variation',
-    'infinity',
-    'nabla',
-    'approximate',
-    'similarequal',
-    'ifonlyif',
-    'implies',
-    'identical',
-    'radical',
-    'includedin',
-    'includes',
-    'intersection',
-    'union',
-    'logicaland',
-    'logicalor',
-    'partialderivative',
-    'function',
-    'leftarrow',
-    'uparrow',
-    'rightarrow',
-    'downarrow',
-    'blank',
-    'soliddiamond',
-    'checkerboard',
-    'ht',
-    'ff',
-    'cr',
-    'lf',
-    'nl',
-    'vt',
-    'lowrightcorner',
-    'uprightcorner',
-    'upleftcorner',
-    'lowleftcorner',
-    'crossinglines',
-    'horizlinescan1',
-    'horizlinescan3',
-    'horizlinescan5',
-    'horizlinescan7',
-    'horizlinescan9',
-    'leftt',
-    'rightt',
-    'bott',
-    'topt',
-    'vertbar',
-    'emspace',
-    'enspace',
-    'em3space',
-    'em4space',
-    'digitspace',
-    'punctspace',
-    'thinspace',
-    'hairspace',
-    'emdash',
-    'endash',
-    'signifblank',
-    'ellipsis',
-    'doubbaselinedot',
-    'onethird',
-    'twothirds',
-    'onefifth',
-    'twofifths',
-    'threefifths',
-    'fourfifths',
-    'onesixth',
-    'fivesixths',
-    'careof',
-    'figdash',
-    'leftanglebracket',
-    'decimalpoint',
-    'rightanglebracket',
-    'marker',
-    'oneeighth',
-    'threeeighths',
-    'fiveeighths',
-    'seveneighths',
-    'trademark',
-    'signaturemark',
-    'trademarkincircle',
-    'leftopentriangle',
-    'rightopentriangle',
-    'emopencircle',
-    'emopenrectangle',
-    'leftsinglequotemark',
-    'rightsinglequotemark',
-    'leftdoublequotemark',
-    'rightdoublequotemark',
-    'prescription',
-    'minutes',
-    'seconds',
-    'latincross',
-    'hexagram',
-    'filledrectbullet',
-    'filledlefttribullet',
-    'filledrighttribullet',
-    'emfilledcircle',
-    'emfilledrect',
-    'enopencircbullet',
-    'enopensquarebullet',
-    'openrectbullet',
-    'opentribulletup',
-    'opentribulletdown',
-    'openstar',
-    'enfilledcircbullet',
-    'enfilledsqbullet',
-    'filledtribulletup',
-    'filledtribulletdown',
-    'leftpointer',
-    'rightpointer',
-    'club',
-    'diamond',
-    'heart',
-    'maltesecross',
-    'dagger',
-    'doubledagger',
-    'checkmark',
-    'ballotcross',
-    'musicalsharp',
-    'musicalflat',
-    'malesymbol',
-    'femalesymbol',
-    'telephone',
-    'telephonerecorder',
-    'phonographcopyright',
-    'caret',
-    'singlelowquotemark',
-    'doublelowquotemark',
-    'cursor',
-    'leftcaret',
-    'rightcaret',
-    'downcaret',
-    'upcaret',
-    'overbar',
-    'downtack',
-    'upshoe',
-    'downstile',
-    'underbar',
-    'jot',
-    'quad',
-    'uptack',
-    'circle',
-    'upstile',
-    'downshoe',
-    'rightshoe',
-    'leftshoe',
-    'lefttack',
-    'righttack',
-    'hebrew_aleph',
-    'hebrew_beth',
-    'hebrew_gimmel',
-    'hebrew_daleth',
-    'hebrew_he',
-    'hebrew_waw',
-    'hebrew_zayin',
-    'hebrew_het',
-    'hebrew_teth',
-    'hebrew_yod',
-    'hebrew_finalkaph',
-    'hebrew_kaph',
-    'hebrew_lamed',
-    'hebrew_finalmem',
-    'hebrew_mem',
-    'hebrew_finalnun',
-    'hebrew_nun',
-    'hebrew_samekh',
-    'hebrew_ayin',
-    'hebrew_finalpe',
-    'hebrew_pe',
-    'hebrew_finalzadi',
-    'hebrew_zadi',
-    'hebrew_kuf',
-    'hebrew_resh',
-    'hebrew_shin',
-    'hebrew_taf',
-    'BackSpace',
-    'Tab',
-    'Linefeed',
-    'Clear',
-    'Return',
-    'Pause',
-    'Scroll_Lock',
-    'Sys_Req',
-    'Escape',
-    'Multi_key',
-    'Kanji',
-    'Home',
-    'Left',
-    'Up',
-    'Right',
-    'Down',
-    'Prior',
-    'Next',
-    'End',
-    'Begin',
-    'Win_L',
-    'Win_R',
-    'App',
-    'Select',
-    'Print',
-    'Execute',
-    'Insert',
-    'Undo',
-    'Redo',
-    'Menu',
-    'Find',
-    'Cancel',
-    'Help',
-    'Break',
-    'Hebrew_switch',
-    'Num_Lock',
-    'KP_Space',
-    'KP_Tab',
-    'KP_Enter',
-    'KP_F1',
-    'KP_F2',
-    'KP_F3',
-    'KP_F4',
-    'KP_Multiply',
-    'KP_Add',
-    'KP_Separator',
-    'KP_Subtract',
-    'KP_Decimal',
-    'KP_Divide',
-    'KP_0',
-    'KP_1',
-    'KP_2',
-    'KP_3',
-    'KP_4',
-    'KP_5',
-    'KP_6',
-    'KP_7',
-    'KP_8',
-    'KP_9',
-    'KP_Equal',
-    'F1',
-    'F2',
-    'F3',
-    'F4',
-    'F5',
-    'F6',
-    'F7',
-    'F8',
-    'F9',
-    'F10',
-    'F11',
-    'F12',
-    'L1',
-    'L2',
-    'L3',
-    'L4',
-    'L5',
-    'L6',
-    'L7',
-    'L8',
-    'L9',
-    'L10',
-    'R1',
-    'R2',
-    'R3',
-    'R4',
-    'R5',
-    'R6',
-    'R7',
-    'R8',
-    'R9',
-    'R10',
-    'R11',
-    'R12',
-    'F33',
-    'R14',
-    'R15',
-    'Shift_L',
-    'Shift_R',
-    'Control_L',
-    'Control_R',
-    'Caps_Lock',
-    'Shift_Lock',
-    'Meta_L',
-    'Meta_R',
-    'Alt_L',
-    'Alt_R',
-    'Super_L',
-    'Super_R',
-    'Hyper_L',
-    'Hyper_R',
-    'Delete',
-)
-
+tkinter_keysyms = ('space', 'exclam', 'quotedbl', 'numbersign', 'dollar', 'percent', 'ampersand', 'quoteright', 'parenleft', 'parenright', 'asterisk', 'plus', 'comma', 'minus', 'period', 'slash', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'colon', 'semicolon', 'less', 'equal', 'greater', 'question', 'at', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'bracketleft', 'backslash', 'bracketright', 'asciicircum', 'underscore', 'quoteleft', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'braceleft', 'bar', 'braceright', 'asciitilde', 'nobreakspace', 'exclamdown', 'cent', 'sterling', 'currency', 'yen', 'brokenbar', 'section', 'diaeresis', 'copyright', 'ordfeminine', 'guillemotleft', 'notsign', 'hyphen', 'registered', 'macron', 'degree', 'plusminus', 'twosuperior', 'threesuperior', 'acute', 'mu', 'paragraph', 'periodcentered', 'cedilla', 'onesuperior', 'masculine', 'guillemotright', 'onequarter', 'onehalf', 'threequarters', 'questiondown', 'Agrave', 'Aacute', 'Acircumflex', 'Atilde', 'Adiaeresis', 'Aring', 'AE', 'Ccedilla', 'Egrave', 'Eacute', 'Ecircumflex', 'Ediaeresis', 'Igrave', 'Iacute', 'Icircumflex', 'Idiaeresis', 'Eth', 'Ntilde', 'Ograve', 'Oacute', 'Ocircumflex', 'Otilde', 'Odiaeresis', 'multiply', 'Ooblique', 'Ugrave', 'Uacute', 'Ucircumflex', 'Udiaeresis', 'Yacute', 'Thorn', 'ssharp', 'agrave', 'aacute', 'acircumflex', 'atilde', 'adiaeresis', 'aring', 'ae', 'ccedilla', 'egrave', 'eacute', 'ecircumflex', 'ediaeresis', 'igrave', 'iacute', 'icircumflex', 'idiaeresis', 'eth', 'ntilde', 'ograve', 'oacute', 'ocircumflex', 'otilde', 'odiaeresis', 'division', 'oslash', 'ugrave', 'uacute', 'ucircumflex', 'udiaeresis', 'yacute', 'thorn', 'ydiaeresis', 'Aogonek', 'breve', 'Lstroke', 'Lcaron', 'Sacute', 'Scaron', 'Scedilla', 'Tcaron', 'Zacute', 'Zcaron', 'Zabovedot', 'aogonek', 'ogonek', 'lstroke', 'lcaron', 'sacute', 'caron', 'scaron', 'scedilla', 'tcaron', 'zacute', 'doubleacute', 'zcaron', 'zabovedot', 'Racute', 'Abreve', 'Cacute', 'Ccaron', 'Eogonek', 'Ecaron', 'Dcaron', 'Nacute', 'Ncaron', 'Odoubleacute', 'Rcaron', 'Uring', 'Udoubleacute', 'Tcedilla', 'racute', 'abreve', 'cacute', 'ccaron', 'eogonek', 'ecaron', 'dcaron', 'nacute', 'ncaron', 'odoubleacute', 'rcaron', 'uring', 'udoubleacute', 'tcedilla', 'abovedot', 'Hstroke', 'Hcircumflex', 'Iabovedot', 'Gbreve', 'Jcircumflex', 'hstroke', 'hcircumflex', 'idotless', 'gbreve', 'jcircumflex', 'Cabovedot', 'Ccircumflex', 'Gabovedot', 'Gcircumflex', 'Ubreve', 'Scircumflex', 'cabovedot', 'ccircumflex', 'gabovedot', 'gcircumflex', 'ubreve', 'scircumflex', 'kappa', 'Rcedilla', 'Itilde', 'Lcedilla', 'Emacron', 'Gcedilla', 'Tslash', 'rcedilla', 'itilde', 'lcedilla', 'emacron', 'gacute', 'tslash', 'ENG', 'eng', 'Amacron', 'Iogonek', 'Eabovedot', 'Imacron', 'Ncedilla', 'Omacron', 'Kcedilla', 'Uogonek', 'Utilde', 'Umacron', 'amacron', 'iogonek', 'eabovedot', 'imacron', 'ncedilla', 'omacron', 'kcedilla', 'uogonek', 'utilde', 'umacron', 'overline', 'kana_fullstop', 'kana_openingbracket', 'kana_closingbracket', 'kana_comma', 'kana_middledot', 'kana_WO', 'kana_a', 'kana_i', 'kana_u', 'kana_e', 'kana_o', 'kana_ya', 'kana_yu', 'kana_yo', 'kana_tu', 'prolongedsound', 'kana_A', 'kana_I', 'kana_U', 'kana_E', 'kana_O', 'kana_KA', 'kana_KI', 'kana_KU', 'kana_KE', 'kana_KO', 'kana_SA', 'kana_SHI', 'kana_SU', 'kana_SE', 'kana_SO', 'kana_TA', 'kana_TI', 'kana_TU', 'kana_TE', 'kana_TO', 'kana_NA', 'kana_NI', 'kana_NU', 'kana_NE', 'kana_NO', 'kana_HA', 'kana_HI', 'kana_HU', 'kana_HE', 'kana_HO', 'kana_MA', 'kana_MI', 'kana_MU', 'kana_ME', 'kana_MO', 'kana_YA', 'kana_YU', 'kana_YO', 'kana_RA', 'kana_RI', 'kana_RU', 'kana_RE', 'kana_RO', 'kana_WA', 'kana_N', 'voicedsound', 'semivoicedsound', 'Arabic_comma', 'Arabic_semicolon', 'Arabic_question_mark', 'Arabic_hamza', 'Arabic_maddaonalef', 'Arabic_hamzaonalef', 'Arabic_hamzaonwaw', 'Arabic_hamzaunderalef', 'Arabic_hamzaonyeh', 'Arabic_alef', 'Arabic_beh', 'Arabic_tehmarbuta', 'Arabic_teh', 'Arabic_theh', 'Arabic_jeem', 'Arabic_hah', 'Arabic_khah', 'Arabic_dal', 'Arabic_thal', 'Arabic_ra', 'Arabic_zain', 'Arabic_seen', 'Arabic_sheen', 'Arabic_sad', 'Arabic_dad', 'Arabic_tah', 'Arabic_zah', 'Arabic_ain', 'Arabic_ghain', 'Arabic_tatweel', 'Arabic_feh', 'Arabic_qaf', 'Arabic_kaf', 'Arabic_lam', 'Arabic_meem', 'Arabic_noon', 'Arabic_heh', 'Arabic_waw', 'Arabic_alefmaksura', 'Arabic_yeh', 'Arabic_fathatan', 'Arabic_dammatan', 'Arabic_kasratan', 'Arabic_fatha', 'Arabic_damma', 'Arabic_kasra', 'Arabic_shadda', 'Arabic_sukun', 'Serbian_dje', 'Macedonia_gje', 'Cyrillic_io', 'Ukranian_je', 'Macedonia_dse', 'Ukranian_i', 'Ukranian_yi', 'Serbian_je', 'Serbian_lje', 'Serbian_nje', 'Serbian_tshe', 'Macedonia_kje', 'Byelorussian_shortu', 'Serbian_dze', 'numerosign', 'Serbian_DJE', 'Macedonia_GJE', 'Cyrillic_IO', 'Ukranian_JE', 'Macedonia_DSE', 'Ukranian_I', 'Ukranian_YI', 'Serbian_JE', 'Serbian_LJE', 'Serbian_NJE', 'Serbian_TSHE', 'Macedonia_KJE', 'Byelorussian_SHORTU', 'Serbian_DZE', 'Cyrillic_yu', 'Cyrillic_a', 'Cyrillic_be', 'Cyrillic_tse', 'Cyrillic_de', 'Cyrillic_ie', 'Cyrillic_ef', 'Cyrillic_ghe', 'Cyrillic_ha', 'Cyrillic_i', 'Cyrillic_shorti', 'Cyrillic_ka', 'Cyrillic_el', 'Cyrillic_em', 'Cyrillic_en', 'Cyrillic_o', 'Cyrillic_pe', 'Cyrillic_ya', 'Cyrillic_er', 'Cyrillic_es', 'Cyrillic_te', 'Cyrillic_u', 'Cyrillic_zhe', 'Cyrillic_ve', 'Cyrillic_softsign', 'Cyrillic_yeru', 'Cyrillic_ze', 'Cyrillic_sha', 'Cyrillic_e', 'Cyrillic_shcha', 'Cyrillic_che', 'Cyrillic_hardsign', 'Cyrillic_YU', 'Cyrillic_A', 'Cyrillic_BE', 'Cyrillic_TSE', 'Cyrillic_DE', 'Cyrillic_IE', 'Cyrillic_EF', 'Cyrillic_GHE', 'Cyrillic_HA', 'Cyrillic_I', 'Cyrillic_SHORTI', 'Cyrillic_KA', 'Cyrillic_EL', 'Cyrillic_EM', 'Cyrillic_EN', 'Cyrillic_O', 'Cyrillic_PE', 'Cyrillic_YA', 'Cyrillic_ER', 'Cyrillic_ES', 'Cyrillic_TE', 'Cyrillic_U', 'Cyrillic_ZHE', 'Cyrillic_VE', 'Cyrillic_SOFTSIGN', 'Cyrillic_YERU', 'Cyrillic_ZE', 'Cyrillic_SHA', 'Cyrillic_E', 'Cyrillic_SHCHA', 'Cyrillic_CHE', 'Cyrillic_HARDSIGN', 'Greek_ALPHAaccent', 'Greek_EPSILONaccent', 'Greek_ETAaccent', 'Greek_IOTAaccent', 'Greek_IOTAdiaeresis', 'Greek_IOTAaccentdiaeresis', 'Greek_OMICRONaccent', 'Greek_UPSILONaccent', 'Greek_UPSILONdieresis', 'Greek_UPSILONaccentdieresis', 'Greek_OMEGAaccent', 'Greek_alphaaccent', 'Greek_epsilonaccent', 'Greek_etaaccent', 'Greek_iotaaccent', 'Greek_iotadieresis', 'Greek_iotaaccentdieresis', 'Greek_omicronaccent', 'Greek_upsilonaccent', 'Greek_upsilondieresis', 'Greek_upsilonaccentdieresis', 'Greek_omegaaccent', 'Greek_ALPHA', 'Greek_BETA', 'Greek_GAMMA', 'Greek_DELTA', 'Greek_EPSILON', 'Greek_ZETA', 'Greek_ETA', 'Greek_THETA', 'Greek_IOTA', 'Greek_KAPPA', 'Greek_LAMBDA', 'Greek_MU', 'Greek_NU', 'Greek_XI', 'Greek_OMICRON', 'Greek_PI', 'Greek_RHO', 'Greek_SIGMA', 'Greek_TAU', 'Greek_UPSILON', 'Greek_PHI', 'Greek_CHI', 'Greek_PSI', 'Greek_OMEGA', 'Greek_alpha', 'Greek_beta', 'Greek_gamma', 'Greek_delta', 'Greek_epsilon', 'Greek_zeta', 'Greek_eta', 'Greek_theta', 'Greek_iota', 'Greek_kappa', 'Greek_lambda', 'Greek_mu', 'Greek_nu', 'Greek_xi', 'Greek_omicron', 'Greek_pi', 'Greek_rho', 'Greek_sigma', 'Greek_finalsmallsigma', 'Greek_tau', 'Greek_upsilon', 'Greek_phi', 'Greek_chi', 'Greek_psi', 'Greek_omega', 'leftradical', 'topleftradical', 'horizconnector', 'topintegral', 'botintegral', 'vertconnector', 'topleftsqbracket', 'botleftsqbracket', 'toprightsqbracket', 'botrightsqbracket', 'topleftparens', 'botleftparens', 'toprightparens', 'botrightparens', 'leftmiddlecurlybrace', 'rightmiddlecurlybrace', 'topleftsummation', 'botleftsummation', 'topvertsummationconnector', 'botvertsummationconnector', 'toprightsummation', 'botrightsummation', 'rightmiddlesummation', 'lessthanequal', 'notequal', 'greaterthanequal', 'integral', 'therefore', 'variation', 'infinity', 'nabla', 'approximate', 'similarequal', 'ifonlyif', 'implies', 'identical', 'radical', 'includedin', 'includes', 'intersection', 'union', 'logicaland', 'logicalor', 'partialderivative', 'function', 'leftarrow', 'uparrow', 'rightarrow', 'downarrow', 'blank', 'soliddiamond', 'checkerboard', 'ht', 'ff', 'cr', 'lf', 'nl', 'vt', 'lowrightcorner', 'uprightcorner', 'upleftcorner', 'lowleftcorner', 'crossinglines', 'horizlinescan1', 'horizlinescan3', 'horizlinescan5', 'horizlinescan7', 'horizlinescan9', 'leftt', 'rightt', 'bott', 'topt', 'vertbar', 'emspace', 'enspace', 'em3space', 'em4space', 'digitspace', 'punctspace', 'thinspace', 'hairspace', 'emdash', 'endash', 'signifblank', 'ellipsis', 'doubbaselinedot', 'onethird', 'twothirds', 'onefifth', 'twofifths', 'threefifths', 'fourfifths', 'onesixth', 'fivesixths', 'careof', 'figdash', 'leftanglebracket', 'decimalpoint', 'rightanglebracket', 'marker', 'oneeighth', 'threeeighths', 'fiveeighths', 'seveneighths', 'trademark', 'signaturemark', 'trademarkincircle', 'leftopentriangle', 'rightopentriangle', 'emopencircle', 'emopenrectangle', 'leftsinglequotemark', 'rightsinglequotemark', 'leftdoublequotemark', 'rightdoublequotemark', 'prescription', 'minutes', 'seconds', 'latincross', 'hexagram', 'filledrectbullet', 'filledlefttribullet', 'filledrighttribullet', 'emfilledcircle', 'emfilledrect', 'enopencircbullet', 'enopensquarebullet', 'openrectbullet', 'opentribulletup', 'opentribulletdown', 'openstar', 'enfilledcircbullet', 'enfilledsqbullet', 'filledtribulletup', 'filledtribulletdown', 'leftpointer', 'rightpointer', 'club', 'diamond', 'heart', 'maltesecross', 'dagger', 'doubledagger', 'checkmark', 'ballotcross', 'musicalsharp', 'musicalflat', 'malesymbol', 'femalesymbol', 'telephone', 'telephonerecorder', 'phonographcopyright', 'caret', 'singlelowquotemark', 'doublelowquotemark', 'cursor', 'leftcaret', 'rightcaret', 'downcaret', 'upcaret', 'overbar', 'downtack', 'upshoe', 'downstile', 'underbar', 'jot', 'quad', 'uptack', 'circle', 'upstile', 'downshoe', 'rightshoe', 'leftshoe', 'lefttack', 'righttack', 'hebrew_aleph', 'hebrew_beth', 'hebrew_gimmel', 'hebrew_daleth', 'hebrew_he', 'hebrew_waw', 'hebrew_zayin', 'hebrew_het', 'hebrew_teth', 'hebrew_yod', 'hebrew_finalkaph', 'hebrew_kaph', 'hebrew_lamed', 'hebrew_finalmem', 'hebrew_mem', 'hebrew_finalnun', 'hebrew_nun', 'hebrew_samekh', 'hebrew_ayin', 'hebrew_finalpe', 'hebrew_pe', 'hebrew_finalzadi', 'hebrew_zadi', 'hebrew_kuf', 'hebrew_resh', 'hebrew_shin', 'hebrew_taf', 'BackSpace', 'Tab', 'Linefeed', 'Clear', 'Return', 'Pause', 'Scroll_Lock', 'Sys_Req', 'Escape', 'Multi_key', 'Kanji', 'Home', 'Left', 'Up', 'Right', 'Down', 'Prior', 'Next', 'End', 'Begin', 'Win_L', 'Win_R', 'App', 'Select', 'Print', 'Execute', 'Insert', 'Undo', 'Redo', 'Menu', 'Find', 'Cancel', 'Help', 'Break', 'Hebrew_switch', 'Num_Lock', 'KP_Space', 'KP_Tab', 'KP_Enter', 'KP_F1', 'KP_F2', 'KP_F3', 'KP_F4', 'KP_Multiply', 'KP_Add', 'KP_Separator', 'KP_Subtract', 'KP_Decimal', 'KP_Divide', 'KP_0', 'KP_1', 'KP_2', 'KP_3', 'KP_4', 'KP_5', 'KP_6', 'KP_7', 'KP_8', 'KP_9', 'KP_Equal', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12', 'L1', 'L2', 'L3', 'L4', 'L5', 'L6', 'L7', 'L8', 'L9', 'L10', 'R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7', 'R8', 'R9', 'R10', 'R11', 'R12', 'F33', 'R14', 'R15', 'Shift_L', 'Shift_R', 'Control_L', 'Control_R', 'Caps_Lock', 'Shift_Lock', 'Meta_L', 'Meta_R', 'Alt_L', 'Alt_R', 'Super_L', 'Super_R', 'Hyper_L', 'Hyper_R', 'Delete',)
+# fmt: on
 
 # ------------------------------------------------------------------------- #
 #                       ToolTip used by the Elements                        #
@@ -2062,12 +986,8 @@ class Element:
         self.Tearoff = False  # needed because of right click menu code
         self.ParentRowFrame = None  # type tk.Frame
         self.metadata = metadata
-        self.user_bind_dict = (
-            {}
-        )  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
-        self.user_bind_event = (
-            None  # Used when user defines a tkinter binding using bind method - event data from tkinter
-        )
+        self.user_bind_dict = {}  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
+        self.user_bind_event = None  # Used when user defines a tkinter binding using bind method - event data from tkinter
         # self.pad_used = (0, 0)  # the amount of pad used when was inserted into the layout
         self._popup_menu_location = (None, None)
         self.pack_settings = None
@@ -2221,13 +1141,11 @@ class Element:
         """
         if self.Type == ELEM_TYPE_TAB_GROUP:
             try:
-                index = self.Widget.index('@{},{}'.format(event.x, event.y))
+                index = self.Widget.index(f'@{event.x},{event.y}')
                 tab = self.Widget.tab(index, 'text')
                 key = self.find_key_from_tab_name(tab)
                 tab_element = self.ParentForm.key_dict[key]
-                if (
-                    tab_element.RightClickMenu is None
-                ):  # if this tab didn't explicitly have a menu, then don't show anything
+                if tab_element.RightClickMenu is None:  # if this tab didn't explicitly have a menu, then don't show anything
                     return
                 tab_element.TKRightClickMenu.tk_popup(event.x_root, event.y_root, 0)
                 self.TKRightClickMenu.grab_release()
@@ -2256,7 +1174,7 @@ class Element:
         else:
             winx, winy = self._popup_menu_location
         # self.ParentForm.TKroot.update()
-        self.ParentForm.TKroot.tk.call('wm', 'geometry', menu, '+{}+{}'.format(winx, winy))
+        self.ParentForm.TKroot.tk.call('wm', 'geometry', menu, f'+{winx}+{winy}')
 
     def _MenuItemChosenCallback(self, item_chosen):  # TEXT Menu item callback
         """
@@ -2738,14 +1656,12 @@ class Element:
                 return False
 
             warnings.warn(
-                'You cannot Update element with key = {} until the window.read() is called or set finalize=True when creating window'.format(
-                    self.Key
-                ),
+                'You cannot Update element with key = {} until the window.read() is called or set finalize=True when creating window'.format(self.Key),
                 UserWarning,
             )
             if not SUPPRESS_ERROR_POPUPS:
                 _error_popup_with_traceback(
-                    'Unable to complete operation on element with key {}'.format(self.Key),
+                    f'Unable to complete operation on element with key {self.Key}',
                     'You cannot perform operations (such as calling update) on an Element until:',
                     ' window.read() is called or finalize=True when Window created.',
                     'Adding a "finalize=True" parameter to your Window creation will likely fix this.',
@@ -2835,9 +1751,7 @@ class Element:
                 top_menu.config(activebackground=self.ParentForm.right_click_menu_selected_colors[1])
             AddMenuItem(top_menu, menu[1], self, right_click_menu=True)
             self.TKRightClickMenu = top_menu
-            if (
-                self.ParentForm.RightClickMenu
-            ):  # if the top level has a right click menu, then setup a callback for the Window itself
+            if self.ParentForm.RightClickMenu:  # if the top level has a right click menu, then setup a callback for the Window itself
                 if self.ParentForm.TKRightClickMenu is None:
                     self.ParentForm.TKRightClickMenu = top_menu
                     if running_mac():
@@ -2885,9 +1799,7 @@ class Element:
             # Save the grabbed image to disk
         except Exception as e:
             # print(e)
-            popup_error_with_traceback(
-                'Screen capture failure', 'Error happened while trying to save screencapture of an element', e
-            )
+            popup_error_with_traceback('Screen capture failure', 'Error happened while trying to save screencapture of an element', e)
             return None
 
         # return grab
@@ -2901,9 +1813,7 @@ class Element:
             try:
                 grab.save(full_filename)
             except Exception as e:
-                popup_error_with_traceback(
-                    'Screen capture failure', 'Error happened while trying to save screencapture', e
-                )
+                popup_error_with_traceback('Screen capture failure', 'Error happened while trying to save screencapture', e)
         else:
             popup_error_with_traceback(
                 'Screen capture failure',
@@ -3951,9 +2861,7 @@ class Listbox(Element):
             sbar_relief=sbar_relief,
         )
 
-    def update(
-        self, values=None, disabled=None, set_to_index=None, scroll_to_index=None, select_mode=None, visible=None
-    ):
+    def update(self, values=None, disabled=None, set_to_index=None, scroll_to_index=None, select_mode=None, visible=None):
         """
         Changes some of the settings for the Listbox Element. Must call `Window.Read` or `Window.Finalize` prior
         Changes will not be visible in your window until you call window.read or window.refresh.
@@ -4002,12 +2910,12 @@ class Listbox(Element):
                     try:
                         self.TKListbox.selection_set(i, i)
                     except:
-                        warnings.warn('* Listbox Update selection_set failed with index {}*'.format(set_to_index))
+                        warnings.warn(f'* Listbox Update selection_set failed with index {set_to_index}*')
             else:
                 try:
                     self.TKListbox.selection_set(set_to_index, set_to_index)
                 except:
-                    warnings.warn('* Listbox Update selection_set failed with index {}*'.format(set_to_index))
+                    warnings.warn(f'* Listbox Update selection_set failed with index {set_to_index}*')
         if visible is False:
             self._pack_forget_save_settings(self.element_frame)
         elif visible is True:
@@ -4094,11 +3002,7 @@ class Listbox(Element):
             return
 
         if index >= len(self.Values):
-            _error_popup_with_traceback(
-                'Index {} is out of range for Listbox.select_index. Max allowed index is {}.'.format(
-                    index, len(self.Values) - 1
-                )
-            )
+            _error_popup_with_traceback('Index {} is out of range for Listbox.select_index. Max allowed index is {}.'.format(index, len(self.Values) - 1))
             return
 
         self.TKListbox.selection_set(index, index)
@@ -4108,9 +3012,7 @@ class Listbox(Element):
         if highlight_background_color is not None:
             self.widget.itemconfig(index, selectbackground=highlight_background_color)
 
-    def set_index_color(
-        self, index, text_color=None, background_color=None, highlight_text_color=None, highlight_background_color=None
-    ):
+    def set_index_color(self, index, text_color=None, background_color=None, highlight_text_color=None, highlight_background_color=None):
         """
         Sets the color of a specific item without selecting it
 
@@ -4134,11 +3036,7 @@ class Listbox(Element):
             return
 
         if index >= len(self.Values):
-            _error_popup_with_traceback(
-                'Index {} is out of range for Listbox.set_index_color. Max allowed index is {}.'.format(
-                    index, len(self.Values) - 1
-                )
-            )
+            _error_popup_with_traceback('Index {} is out of range for Listbox.set_index_color. Max allowed index is {}.'.format(index, len(self.Values) - 1))
             return
 
         if text_color is not None:
@@ -4259,9 +3157,7 @@ class Radio(Element):
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(background_color if background_color else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if (
-                    text_hsl[2] > background_hsl[2]
-                ):  # if the text is "lighter" than the background then make background darker
+                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -4358,19 +3254,12 @@ class Radio(Element):
             self.CircleBackgroundColor = circle_color
             self.TKRadio.configure(selectcolor=self.CircleBackgroundColor)  # The background of the radio button
         elif text_color or background_color:
-            if (
-                self.TextColor not in (None, COLOR_SYSTEM_DEFAULT)
-                and self.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT)
-                and self.TextColor.startswith('#')
-                and self.BackgroundColor.startswith('#')
-            ):
+            if self.TextColor not in (None, COLOR_SYSTEM_DEFAULT) and self.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT) and self.TextColor.startswith('#') and self.BackgroundColor.startswith('#'):
                 # ---- compute color of circle background ---
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(self.BackgroundColor if self.BackgroundColor else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if (
-                    text_hsl[2] > background_hsl[2]
-                ):  # if the text is "lighter" than the background then make background darker
+                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -4513,9 +3402,7 @@ class Checkbox(Element):
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(background_color if background_color else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if (
-                    text_hsl[2] > background_hsl[2]
-                ):  # if the text is "lighter" than the background then make background darker
+                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -4623,20 +3510,12 @@ class Checkbox(Element):
             self.CheckboxBackgroundColor = checkbox_color
             self.TKCheckbutton.configure(selectcolor=self.CheckboxBackgroundColor)  # The background of the checkbox
         elif text_color or background_color:
-            if (
-                self.CheckboxBackgroundColor is not None
-                and self.TextColor is not None
-                and self.BackgroundColor is not None
-                and self.TextColor.startswith('#')
-                and self.BackgroundColor.startswith('#')
-            ):
+            if self.CheckboxBackgroundColor is not None and self.TextColor is not None and self.BackgroundColor is not None and self.TextColor.startswith('#') and self.BackgroundColor.startswith('#'):
                 # ---- compute color of checkbox background ---
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(self.BackgroundColor if self.BackgroundColor else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if (
-                    text_hsl[2] > background_hsl[2]
-                ):  # if the text is "lighter" than the background then make background darker
+                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -5201,15 +4080,7 @@ class Multiline(Element):
             value = str(value)
             if background_color_for_value is not None or text_color_for_value is not None or font_for_value is not None:
                 try:
-                    tag = (
-                        'Multiline('
-                        + str(text_color_for_value)
-                        + ','
-                        + str(background_color_for_value)
-                        + ','
-                        + str(font_for_value)
-                        + ')'
-                    )
+                    tag = 'Multiline(' + str(text_color_for_value) + ',' + str(background_color_for_value) + ',' + str(font_for_value) + ')'
                     if tag not in self.tags:
                         self.tags.add(tag)
                     if background_color_for_value is not None:
@@ -5236,9 +4107,7 @@ class Multiline(Element):
             self.DefaultText = value
 
         if self.Autoscroll:
-            if not self.auto_scroll_only_at_bottom or (
-                self.auto_scroll_only_at_bottom and current_scroll_position == 1.0
-            ):
+            if not self.auto_scroll_only_at_bottom or (self.auto_scroll_only_at_bottom and current_scroll_position == 1.0):
                 self.TKText.see(tk.END)
         if disabled is True:
             self.TKText.configure(state='disabled')
@@ -6112,9 +4981,7 @@ class TKProgressBar:
             else:
                 s.configure(self.style_name, troughrelief=relief, borderwidth=border_width, thickness=width)
 
-            self.TKProgressBarForReal = ttk.Progressbar(
-                root, maximum=self.Max, style=self.style_name, length=length, orient=tk.HORIZONTAL, mode='determinate'
-            )
+            self.TKProgressBarForReal = ttk.Progressbar(root, maximum=self.Max, style=self.style_name, length=length, orient=tk.HORIZONTAL, mode='determinate')
         else:
             s = ttk.Style()
             _change_ttk_theme(s, ttk_theme)
@@ -6131,9 +4998,7 @@ class TKProgressBar:
             else:
                 s.configure(self.style_name, troughrelief=relief, borderwidth=border_width, thickness=width)
 
-            self.TKProgressBarForReal = ttk.Progressbar(
-                root, maximum=self.Max, style=self.style_name, length=length, orient=tk.VERTICAL, mode='determinate'
-            )
+            self.TKProgressBarForReal = ttk.Progressbar(root, maximum=self.Max, style=self.style_name, length=length, orient=tk.VERTICAL, mode='determinate')
 
     def Update(self, count=None, max=None):
         """
@@ -6425,16 +5290,9 @@ class Button(Element):
 
         self.AutoSizeButton = auto_size_button
         self.BType = button_type
-        if (
-            file_types is not None
-            and len(file_types) == 2
-            and isinstance(file_types[0], str)
-            and isinstance(file_types[1], str)
-        ):
+        if file_types is not None and len(file_types) == 2 and isinstance(file_types[0], str) and isinstance(file_types[1], str):
             warnings.warn(
-                'file_types parameter not correctly specified. This parameter is a LIST of TUPLES. You have passed (str,str) rather than ((str, str),). Fixing it for you this time.\nchanging {} to {}\nPlease correct your code'.format(
-                    file_types, ((file_types[0], file_types[1]),)
-                ),
+                'file_types parameter not correctly specified. This parameter is a LIST of TUPLES. You have passed (str,str) rather than ((str, str),). Fixing it for you this time.\nchanging {} to {}\nPlease correct your code'.format(file_types, ((file_types[0], file_types[1]),)),
                 UserWarning,
             )
             file_types = ((file_types[0], file_types[1]),)
@@ -6446,9 +5304,7 @@ class Button(Element):
         # Button colors can be a tuple (text, background) or a string with format "text on background"
         self.ButtonColor = button_color_to_tuple(button_color)
 
-        self.DisabledButtonColor = (
-            button_color_to_tuple(disabled_button_color) if disabled_button_color is not None else (None, None)
-        )
+        self.DisabledButtonColor = button_color_to_tuple(disabled_button_color) if disabled_button_color is not None else (None, None)
         if image_source is not None:
             if isinstance(image_source, bytes):
                 image_data = image_source
@@ -6481,9 +5337,7 @@ class Button(Element):
         self.Disabled = disabled
         self.ChangeSubmits = change_submits or enable_events
         self.UseTtkButtons = use_ttk_buttons
-        self._files_delimiter = (
-            BROWSE_FILES_DELIMITER  # used by the file browse button. used when multiple files are selected by user
-        )
+        self._files_delimiter = BROWSE_FILES_DELIMITER  # used by the file browse button. used when multiple files are selected by user
         if use_ttk_buttons is None and running_mac():
             self.UseTtkButtons = True
 
@@ -6514,9 +5368,7 @@ class Button(Element):
         self.expand_y = expand_y
 
         sz = size if size != (None, None) else s
-        super().__init__(
-            ELEM_TYPE_BUTTON, size=sz, font=font, pad=pad, key=_key, tooltip=tooltip, visible=visible, metadata=metadata
-        )
+        super().__init__(ELEM_TYPE_BUTTON, size=sz, font=font, pad=pad, key=_key, tooltip=tooltip, visible=visible, metadata=metadata)
         return
 
     def _compute_highlight_colors(self):
@@ -6616,13 +5468,9 @@ class Button(Element):
 
         if self.BType == BUTTON_TYPE_BROWSE_FOLDER:
             if running_mac():  # macs don't like seeing the parent window (go firgure)
-                folder_name = tk.filedialog.askdirectory(
-                    initialdir=self.InitialFolder
-                )  # show the 'get folder' dialog box
+                folder_name = tk.filedialog.askdirectory(initialdir=self.InitialFolder)  # show the 'get folder' dialog box
             else:
-                folder_name = tk.filedialog.askdirectory(
-                    initialdir=self.InitialFolder, parent=self.ParentForm.TKroot
-                )  # show the 'get folder' dialog box
+                folder_name = tk.filedialog.askdirectory(initialdir=self.InitialFolder, parent=self.ParentForm.TKroot)  # show the 'get folder' dialog box
             if folder_name:
                 try:
                     strvar.set(folder_name)
@@ -6638,13 +5486,9 @@ class Button(Element):
                 if not len(set(filetypes)) > 1 and (len(is_all) != 0 or filetypes == FILE_TYPES_ALL_FILES):
                     file_name = tk.filedialog.askopenfilename(initialdir=self.InitialFolder)
                 else:
-                    file_name = tk.filedialog.askopenfilename(
-                        initialdir=self.InitialFolder, filetypes=filetypes
-                    )  # show the 'get file' dialog box
+                    file_name = tk.filedialog.askopenfilename(initialdir=self.InitialFolder, filetypes=filetypes)  # show the 'get file' dialog box
             else:
-                file_name = tk.filedialog.askopenfilename(
-                    filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot
-                )  # show the 'get file' dialog box
+                file_name = tk.filedialog.askopenfilename(filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot)  # show the 'get file' dialog box
 
             if file_name:
                 strvar.set(file_name)
@@ -6652,9 +5496,7 @@ class Button(Element):
             else:  # if "cancel" button clicked, don't generate an event
                 should_submit_window = False
         elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:
-            color = tk.colorchooser.askcolor(
-                parent=self.ParentForm.TKroot, color=self.default_color
-            )  # show the 'get file' dialog box
+            color = tk.colorchooser.askcolor(parent=self.ParentForm.TKroot, color=self.default_color)  # show the 'get file' dialog box
             color = color[1]  # save only the #RRGGBB portion
             if color is not None:
                 strvar.set(color)
@@ -6668,9 +5510,7 @@ class Button(Element):
                 else:
                     file_name = tk.filedialog.askopenfilenames(filetypes=filetypes, initialdir=self.InitialFolder)
             else:
-                file_name = tk.filedialog.askopenfilenames(
-                    filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot
-                )
+                file_name = tk.filedialog.askopenfilenames(filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot)
 
             if file_name:
                 file_name = self._files_delimiter.join(file_name)  # normally a ';'
@@ -6684,13 +5524,9 @@ class Button(Element):
                 # Workaround for the "*.*" issue on Mac
                 is_all = [(x, y) for (x, y) in filetypes if all(ch in '* .' for ch in y)]
                 if not len(set(filetypes)) > 1 and (len(is_all) != 0 or filetypes == FILE_TYPES_ALL_FILES):
-                    file_name = tk.filedialog.asksaveasfilename(
-                        defaultextension=self.DefaultExtension, initialdir=self.InitialFolder
-                    )
+                    file_name = tk.filedialog.asksaveasfilename(defaultextension=self.DefaultExtension, initialdir=self.InitialFolder)
                 else:
-                    file_name = tk.filedialog.asksaveasfilename(
-                        filetypes=filetypes, defaultextension=self.DefaultExtension, initialdir=self.InitialFolder
-                    )
+                    file_name = tk.filedialog.asksaveasfilename(filetypes=filetypes, defaultextension=self.DefaultExtension, initialdir=self.InitialFolder)
             else:
                 file_name = tk.filedialog.asksaveasfilename(
                     filetypes=filetypes,
@@ -6732,9 +5568,7 @@ class Button(Element):
             self.ParentForm._Close(without_event=True)
             self.ParentForm.TKroot.destroy()  # close the window with tkinter
             Window._DecrementOpenCount()
-        elif (
-            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
-        ):  # this is a return type button so GET RESULTS and destroy window
+        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
             # ------------ new chooser code -------------
             self.ParentForm.LastButtonClicked = self.Key  # key should have been generated already if not set by user
             self.ParentForm.FormRemainedOpen = True
@@ -7047,9 +5881,7 @@ class ButtonMenu(Element):
             elif isinstance(image_source, bytes):
                 image_data = image_source
             else:
-                warnings.warn(
-                    'ButtonMenu element - image_source is not a valid type: {}'.format(type(image_source)), UserWarning
-                )
+                warnings.warn(f'ButtonMenu element - image_source is not a valid type: {type(image_source)}', UserWarning)
 
         self.ImageFilename = image_filename
         self.ImageData = image_data
@@ -7144,9 +5976,7 @@ class ButtonMenu(Element):
 
         if menu_definition is not None:
             self.MenuDefinition = copy.deepcopy(menu_definition)
-            top_menu = self.TKMenu = tk.Menu(
-                self.TKButtonMenu, tearoff=self.Tearoff, font=self.ItemFont, tearoffcommand=self._tearoff_menu_callback
-            )
+            top_menu = self.TKMenu = tk.Menu(self.TKButtonMenu, tearoff=self.Tearoff, font=self.ItemFont, tearoffcommand=self._tearoff_menu_callback)
 
             if self.BackgroundColor not in (COLOR_SYSTEM_DEFAULT, None):
                 top_menu.config(bg=self.BackgroundColor)
@@ -7167,7 +5997,7 @@ class ButtonMenu(Element):
                     filename = image_source
                 else:
                     warnings.warn(
-                        'ButtonMenu element - image_source is not a valid type: {}'.format(type(image_source)),
+                        f'ButtonMenu element - image_source is not a valid type: {type(image_source)}',
                         UserWarning,
                     )
             image = None
@@ -7501,7 +6331,7 @@ class Image(Element):
             elif isinstance(source, str):
                 filename = source
             else:
-                warnings.warn('Image element - source is not a valid type: {}'.format(type(source)), UserWarning)
+                warnings.warn(f'Image element - source is not a valid type: {type(source)}', UserWarning)
 
         self.Filename = filename
         self.Data = data
@@ -7578,7 +6408,7 @@ class Image(Element):
             elif isinstance(source, str):
                 filename = source
             else:
-                warnings.warn('Image element - source is not a valid type: {}'.format(type(source)), UserWarning)
+                warnings.warn(f'Image element - source is not a valid type: {type(source)}', UserWarning)
 
         image = None
         if filename is not None:
@@ -8092,9 +6922,7 @@ class Graph(Element):
         try:  # needed in case window was closed with an X
             point1 = converted_point[0] - size // 2, converted_point[1] - size // 2
             point2 = converted_point[0] + size // 2, converted_point[1] + size // 2
-            id = self._TKCanvas2.create_oval(
-                point1[0], point1[1], point2[0], point2[1], width=0, fill=color, outline=color
-            )
+            id = self._TKCanvas2.create_oval(point1[0], point1[1], point2[0], point2[1], width=0, fill=color, outline=color)
         except:
             id = None
         return id
@@ -8176,9 +7004,7 @@ class Graph(Element):
 
         return id
 
-    def draw_arc(
-        self, top_left, bottom_right, extent, start_angle, style=None, arc_color='black', line_width=1, fill_color=None
-    ):
+    def draw_arc(self, top_left, bottom_right, extent, start_angle, style=None, arc_color='black', line_width=1, fill_color=None):
         """
         Draws different types of arcs.  Uses a "bounding box" to define location
         :param top_left:     the top left point of bounding rectangle
@@ -8390,7 +7216,7 @@ class Graph(Element):
         try:
             self._TKCanvas2.delete(id)
         except:
-            print('DeleteFigure - bad ID {}'.format(id))
+            print(f'DeleteFigure - bad ID {id}')
         try:
             del self.Images[id]  # in case was an image. If wasn't an image, then will get exception
         except:
@@ -8874,7 +7700,7 @@ class Frame(Element):
                 PopupError(
                     'Error creating Frame layout',
                     'Your row is not an iterable (e.g. a list)',
-                    'Instead of a list, the type found was {}'.format(type(row)),
+                    f'Instead of a list, the type found was {type(row)}',
                     'The offensive row = ',
                     row,
                     'This item will be stripped from your layout',
@@ -9133,7 +7959,7 @@ class Tab(Element):
             elif isinstance(image_source, str):
                 filename = image_source
             else:
-                warnings.warn('Image element - source is not a valid type: {}'.format(type(image_source)), UserWarning)
+                warnings.warn(f'Image element - source is not a valid type: {type(image_source)}', UserWarning)
 
         self.Filename = filename
         self.Data = data
@@ -9251,7 +8077,7 @@ class Tab(Element):
                 PopupError(
                     'Error creating Tab layout',
                     'Your row is not an iterable (e.g. a list)',
-                    'Instead of a list, the type found was {}'.format(type(row)),
+                    f'Instead of a list, the type found was {type(row)}',
                     'The offensive row = ',
                     row,
                     'This item will be stripped from your layout',
@@ -9327,7 +8153,7 @@ class Tab(Element):
         try:
             self.ParentNotebook.select(self.TabID)
         except Exception as e:
-            print('Exception Selecting Tab {}'.format(e))
+            print(f'Exception Selecting Tab {e}')
 
     AddRow = add_row
     Layout = layout
@@ -9433,24 +8259,10 @@ class TabGroup(Element):
         self.ReturnValuesDictionary = {}
         self.DictionaryKeyCounter = 0
         self.ParentWindow = None
-        self.SelectedTitleColor = (
-            selected_title_color
-            if selected_title_color is not None
-            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT']
-        )
-        self.SelectedBackgroundColor = (
-            selected_background_color
-            if selected_background_color is not None
-            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['BACKGROUND']
-        )
-        title_color = (
-            title_color if title_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
-        )
-        self.TabBackgroundColor = (
-            tab_background_color
-            if tab_background_color is not None
-            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
-        )
+        self.SelectedTitleColor = selected_title_color if selected_title_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT']
+        self.SelectedBackgroundColor = selected_background_color if selected_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['BACKGROUND']
+        title_color = title_color if title_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
+        self.TabBackgroundColor = tab_background_color if tab_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
         self.Rows = []
         self.TKNotebook = None  # type: ttk.Notebook
         self.Widget = None  # type: ttk.Notebook
@@ -9567,7 +8379,7 @@ class TabGroup(Element):
                 PopupError(
                     'Error creating Tab layout',
                     'Your row is not an iterable (e.g. a list)',
-                    'Instead of a list, the type found was {}'.format(type(row)),
+                    f'Instead of a list, the type found was {type(row)}',
                     'The offensive row = ',
                     row,
                     'This item will be stripped from your layout',
@@ -9678,7 +8490,7 @@ class TabGroup(Element):
             _error_popup_with_traceback(
                 'Your Window has an Tab Element with an IMAGE problem',
                 'The traceback will show you the Window with the problem layout',
-                'Look in this Window\'s layout for an Image tab_element that has a key of {}'.format(tab_element.Key),
+                f'Look in this Window\'s layout for an Image tab_element that has a key of {tab_element.Key}',
                 'The error occuring is:',
                 e,
             )
@@ -9687,9 +8499,7 @@ class TabGroup(Element):
         # add the label
         if photo is not None:
             width, height = photo.width(), photo.height()
-            tab_element.tktext_label = tk.Label(
-                tab_element.ParentRowFrame, image=photo, width=width, height=height, bd=0
-            )
+            tab_element.tktext_label = tk.Label(tab_element.ParentRowFrame, image=photo, width=width, height=height, bd=0)
         else:
             tab_element.tktext_label = tk.Label(tab_element.ParentRowFrame, bd=0)
         # ------------------- end of imagey-stuff -------------------
@@ -9716,9 +8526,7 @@ class TabGroup(Element):
         if tab_element.BorderWidth is not None:
             tab_element.TKFrame.configure(borderwidth=tab_element.BorderWidth)
         if tab_element.Tooltip is not None:
-            tab_element.TooltipObject = ToolTip(
-                tab_element.TKFrame, text=tab_element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-            )
+            tab_element.TooltipObject = ToolTip(tab_element.TKFrame, text=tab_element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
         _add_right_click_menu(tab_element, form)
 
     def update(self, visible=None):
@@ -10308,7 +9116,7 @@ class Column(Element):
                 PopupError(
                     'Error creating Column layout',
                     'Your row is not an iterable (e.g. a list)',
-                    'Instead of a list, the type found was {}'.format(type(row)),
+                    f'Instead of a list, the type found was {type(row)}',
                     'The offensive row = ',
                     row,
                     'This item will be stripped from your layout',
@@ -10472,9 +9280,7 @@ class Pane(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(
-            ELEM_TYPE_PANE, background_color=bg, size=sz, pad=pad, key=key, visible=visible, metadata=metadata
-        )
+        super().__init__(ELEM_TYPE_PANE, background_color=bg, size=sz, pad=pad, key=key, visible=visible, metadata=metadata)
         return
 
     def update(self, visible=None):
@@ -10689,11 +9495,7 @@ class TKCalendar(ttk.Frame):
         year, month = self._date.year, self._date.month
         now = self.datetime.now()
         try:
-            self._TargetElement.Update(
-                self.datetime(year, month, int(self._selection[0]), now.hour, now.minute, now.second).strftime(
-                    self.format
-                )
-            )
+            self._TargetElement.Update(self.datetime(year, month, int(self._selection[0]), now.hour, now.minute, now.second).strftime(self.format))
             if self._TargetElement.ChangeSubmits:
                 self._TargetElement.ParentForm.LastButtonClicked = self._TargetElement.Key
                 self._TargetElement.ParentForm.FormRemainedOpen = True
@@ -10868,9 +9670,7 @@ class Menu(Element):
         if menu_definition is not None:
             self.MenuDefinition = copy.deepcopy(menu_definition)
             if self.TKMenu is None:  # if no menu exists, make one
-                self.TKMenu = tk.Menu(
-                    self.ParentForm.TKroot, tearoff=self.Tearoff, tearoffcommand=self._tearoff_menu_callback
-                )  # create the menubar
+                self.TKMenu = tk.Menu(self.ParentForm.TKroot, tearoff=self.Tearoff, tearoffcommand=self._tearoff_menu_callback)  # create the menubar
             menubar = self.TKMenu
             # Delete all the menu items (assuming 10000 should be a high enough number to cover them all)
             menubar.delete(0, 10000)
@@ -10895,9 +9695,7 @@ class Menu(Element):
                     if pos == 0 or menu_entry[0][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
                         menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + len(MENU_SHORTCUT_CHARACTER) :]
                 if menu_entry[0][0] == MENU_DISABLED_CHARACTER:
-                    menubar.add_cascade(
-                        label=menu_entry[0][len(MENU_DISABLED_CHARACTER) :], menu=baritem, underline=pos
-                    )
+                    menubar.add_cascade(label=menu_entry[0][len(MENU_DISABLED_CHARACTER) :], menu=baritem, underline=pos)
                     menubar.entryconfig(menu_entry[0][len(MENU_DISABLED_CHARACTER) :], state='disabled')
                 else:
                     menubar.add_cascade(label=menu_entry[0], menu=baritem, underline=pos)
@@ -11093,16 +9891,8 @@ class Table(Element):
         self.AutoSizeColumns = auto_size_columns
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
-        self.HeaderTextColor = (
-            header_text_color
-            if header_text_color is not None
-            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
-        )
-        self.HeaderBackgroundColor = (
-            header_background_color
-            if header_background_color is not None
-            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
-        )
+        self.HeaderTextColor = header_text_color if header_text_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
+        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
         self.HeaderFont = header_font
         self.Justification = justification
         self.InitialState = None
@@ -11167,9 +9957,7 @@ class Table(Element):
         )
         return
 
-    def update(
-        self, values=None, num_rows=None, visible=None, select_rows=None, alternating_row_color=None, row_colors=None
-    ):
+    def update(self, values=None, num_rows=None, visible=None, select_rows=None, alternating_row_color=None, row_colors=None):
         """
         Changes some of the settings for the Table Element. Must call `Window.Read` or `Window.Finalize` prior
 
@@ -11320,12 +10108,10 @@ class Table(Element):
             else:
                 column = None
         except Exception as e:
-            warnings.warn(
-                'Error getting table click data for table with key= {}\nError: {}'.format(self.Key, e), UserWarning
-            )
+            warnings.warn(f'Error getting table click data for table with key= {self.Key}\nError: {e}', UserWarning)
             if not SUPPRESS_ERROR_POPUPS:
                 _error_popup_with_traceback(
-                    'Unable to complete operation getting the clicked event for table with key {}'.format(self.Key),
+                    f'Unable to complete operation getting the clicked event for table with key {self.Key}',
                     _create_error_message(),
                     e,
                     'Event data:',
@@ -11544,16 +10330,8 @@ class Tree(Element):
         self.AutoSizeColumns = auto_size_columns
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
-        self.HeaderTextColor = (
-            header_text_color
-            if header_text_color is not None
-            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
-        )
-        self.HeaderBackgroundColor = (
-            header_background_color
-            if header_background_color is not None
-            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
-        )
+        self.HeaderTextColor = header_text_color if header_text_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
+        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
         self.HeaderBorderWidth = header_border_width
         self.BorderWidth = border_width
         self.HeaderRelief = header_relief
@@ -11767,14 +10545,14 @@ class Tree(Element):
     Update = update
 
 
-class TreeData(object):
+class TreeData:
     """
     Class that user fills in to represent their tree data. It's a very simple tree representation with a root "Node"
     with possibly one or more children "Nodes".  Each Node contains a key, text to display, list of values to display
     and an icon.  The entire tree is built using a single method, Insert.  Nothing else is required to make the tree.
     """
 
-    class Node(object):
+    class Node:
         """
         Contains information about the individual node in the tree
         """
@@ -11864,10 +10642,7 @@ class TreeData(object):
         :param level: The indentation level for string formatting
         :type level:  (int)
         """
-        return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text) + ' [ ' + ', '.join([str(v) for v in node.values]) + ' ]']
-            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
-        )
+        return '\n'.join([str(node.key) + ' : ' + str(node.text) + ' [ ' + ', '.join([str(v) for v in node.values]) + ' ]'] + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
 
     Insert = insert
 
@@ -12286,9 +11061,7 @@ class Window:
         self.Title = str(title)
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = default_element_size if default_element_size is not None else DEFAULT_ELEMENT_SIZE
-        self.DefaultButtonElementSize = (
-            default_button_element_size if default_button_element_size != (None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
-        )
+        self.DefaultButtonElementSize = default_button_element_size if default_button_element_size != (None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
         if DEFAULT_WINDOW_LOCATION != (None, None) and location == (None, None):
             self.Location = DEFAULT_WINDOW_LOCATION
         else:
@@ -12371,12 +11144,8 @@ class Window:
         self.metadata = metadata
         self.TtkTheme = ttk_theme or DEFAULT_TTK_THEME
         self.UseTtkButtons = use_ttk_buttons if use_ttk_buttons is not None else USE_TTK_BUTTONS
-        self.user_bind_dict = (
-            {}
-        )  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
-        self.user_bind_event = (
-            None  # Used when user defines a tkinter binding using bind method - event data from tkinter
-        )
+        self.user_bind_dict = {}  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
+        self.user_bind_event = None  # Used when user defines a tkinter binding using bind method - event data from tkinter
         self.modal = modal
         self.thread_queue = None  # type: queue.Queue
         self.thread_lock = None  # type: threading.Lock
@@ -12390,26 +11159,14 @@ class Window:
         self.config_count = 0
         self.saw_00 = False
         self.maximized = False
-        self.right_click_menu_background_color = (
-            right_click_menu_background_color
-            if right_click_menu_background_color is not None
-            else theme_input_background_color()
-        )
-        self.right_click_menu_text_color = (
-            right_click_menu_text_color if right_click_menu_text_color is not None else theme_input_text_color()
-        )
-        self.right_click_menu_disabled_text_color = (
-            right_click_menu_disabled_text_color
-            if right_click_menu_disabled_text_color is not None
-            else COLOR_SYSTEM_DEFAULT
-        )
+        self.right_click_menu_background_color = right_click_menu_background_color if right_click_menu_background_color is not None else theme_input_background_color()
+        self.right_click_menu_text_color = right_click_menu_text_color if right_click_menu_text_color is not None else theme_input_text_color()
+        self.right_click_menu_disabled_text_color = right_click_menu_disabled_text_color if right_click_menu_disabled_text_color is not None else COLOR_SYSTEM_DEFAULT
         self.right_click_menu_font = right_click_menu_font if right_click_menu_font is not None else self.Font
         self.right_click_menu_tearoff = right_click_menu_tearoff
         self.auto_close_timer_needs_starting = False
         self.finalize_in_progress = False
-        self.close_destroys_window = (
-            not enable_close_attempted_event if enable_close_attempted_event is not None else None
-        )
+        self.close_destroys_window = not enable_close_attempted_event if enable_close_attempted_event is not None else None
         self.enable_window_config_events = enable_window_config_events
         self.override_custom_titlebar = False
         self.use_custom_titlebar = use_custom_titlebar or theme_use_custom_titlebar()
@@ -12417,9 +11174,7 @@ class Window:
         self.titlebar_text_color = titlebar_text_color
         self.titlebar_font = titlebar_font
         self.titlebar_icon = titlebar_icon
-        self.right_click_menu_selected_colors = _simplified_dual_color_to_tuple(
-            right_click_menu_selected_colors, (self.right_click_menu_background_color, self.right_click_menu_text_color)
-        )
+        self.right_click_menu_selected_colors = _simplified_dual_color_to_tuple(right_click_menu_selected_colors, (self.right_click_menu_background_color, self.right_click_menu_text_color))
         self.TKRightClickMenu = None
         self._grab_anywhere_ignore_these_list = []
         self._grab_anywhere_include_these_list = []
@@ -12463,8 +11218,7 @@ class Window:
         if CURRENT_LOOK_AND_FEEL == 'Default':
             print(
                 'Window will be a boring gray. Try removing the theme call entirely\n',
-                'You will get the default theme or the one set in global settings\n'
-                "If you seriously want this gray window and no more nagging, add  theme('DefaultNoMoreNagging')  or theme('Gray Gray Gray') for completely gray/System Defaults",
+                'You will get the default theme or the one set in global settings\n' "If you seriously want this gray window and no more nagging, add  theme('DefaultNoMoreNagging')  or theme('Gray Gray Gray') for completely gray/System Defaults",
             )
 
     @classmethod
@@ -12610,7 +11364,7 @@ class Window:
                     'Error Creating Window Layout',
                     'Error creating Window layout',
                     'Your row is not an iterable (e.g. a list)',
-                    'Instead of a list, the type found was {}'.format(type(row)),
+                    f'Instead of a list, the type found was {type(row)}',
                     'The offensive row = ',
                     row,
                     'This item will be stripped from your layout',
@@ -12706,9 +11460,7 @@ class Window:
             'The Window.LayoutAndRead call is no longer supported',
         )
 
-        raise DeprecationWarning(
-            'LayoutAndRead is no longer supported... change your call window.Layout(layout).Read()\nor window(title, layout).Read()'
-        )
+        raise DeprecationWarning('LayoutAndRead is no longer supported... change your call window.Layout(layout).Read()\nor window(title, layout).Read()')
 
     def LayoutAndShow(self, rows):
         """
@@ -12895,9 +11647,7 @@ class Window:
             now = datetime.datetime.now()
             hour, minute, second = now.hour, now.minute, now.second
             try:
-                date_string = calendar.datetime.datetime(year, month, day, hour, minute, second).strftime(
-                    elem.calendar_format
-                )
+                date_string = calendar.datetime.datetime(year, month, day, hour, minute, second).strftime(elem.calendar_format)
             except Exception as e:
                 print('Bad format string in calendar chooser button', e)
                 date_string = 'Bad format string'
@@ -13050,9 +11800,7 @@ class Window:
                 # clear the realtime flag if the element is not a button element (for example a graph element that is dragging)
                 if self.AllKeysDict.get(self.LastButtonClicked, None):
                     if self.AllKeysDict.get(self.LastButtonClicked).Type != ELEM_TYPE_BUTTON:
-                        self.LastButtonClickedWasRealtime = (
-                            False  # stops from generating events until something changes
-                        )
+                        self.LastButtonClickedWasRealtime = False  # stops from generating events until something changes
                 else:  # it is possible for the key to not be in the dicitonary because it has a modifier. If so, then clear the realtime button flag
                     self.LastButtonClickedWasRealtime = False  # stops from generating events until something changes
 
@@ -13119,13 +11867,9 @@ class Window:
             if self._queued_thread_event_available():
                 self.ReturnValues = results = _BuildResults(self, False, self)
                 return results
-            if (
-                not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None
-            ):  # Special Qt case because returning for no reason so fake timeout
+            if not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None:  # Special Qt case because returning for no reason so fake timeout
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
-            elif (
-                not self.XFound and self.ReturnValues[0] is None
-            ):  # Return a timeout event... can happen when autoclose used on another window
+            elif not self.XFound and self.ReturnValues[0] is None:  # Return a timeout event... can happen when autoclose used on another window
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
             return self.ReturnValues
 
@@ -13258,9 +12002,7 @@ class Window:
             'Use of FindElement is not recommended.\nEither switch to the recommended window[key] format\nor the PEP8 compliant find_element',
             UserWarning,
         )
-        print(
-            '** Warning - FindElement should not be used to look up elements. window[key] or window.find_element are recommended. **'
-        )
+        print('** Warning - FindElement should not be used to look up elements. window[key] or window.find_element are recommended. **')
 
         return self.find_element(key, silent_on_error=silent_on_error)
 
@@ -13312,9 +12054,7 @@ class Window:
             key_error = True
             closest_key = self._find_closest_key(key)
             if not silent_on_error:
-                print(
-                    '** Error looking up your element using the key: ', key, 'The closest matching key: ', closest_key
-                )
+                print('** Error looking up your element using the key: ', key, 'The closest matching key: ', closest_key)
                 _error_popup_with_traceback(
                     'Key Error',
                     'Problem finding your key ' + str(key),
@@ -13425,22 +12165,16 @@ class Window:
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        if (
-                            element.Type == ELEM_TYPE_BUTTON and WARN_DUPLICATE_BUTTON_KEY_ERRORS
-                        ):  # for Buttons see if should complain
-                            warnings.warn(
-                                '*** Duplicate key found in your layout {} ***'.format(element.Key), UserWarning
-                            )
-                            warnings.warn(
-                                '*** Replaced new key with {} ***'.format(str(element.Key) + str(self.UniqueKeyCounter))
-                            )
+                        if element.Type == ELEM_TYPE_BUTTON and WARN_DUPLICATE_BUTTON_KEY_ERRORS:  # for Buttons see if should complain
+                            warnings.warn(f'*** Duplicate key found in your layout {element.Key} ***', UserWarning)
+                            warnings.warn(f'*** Replaced new key with {str(element.Key) + str(self.UniqueKeyCounter)} ***')
                             if not SUPPRESS_ERROR_POPUPS:
                                 _error_popup_with_traceback(
                                     'Duplicate key found in your layout',
-                                    'Dupliate key: {}'.format(element.Key),
-                                    'Is being replaced with: {}'.format(str(element.Key) + str(self.UniqueKeyCounter)),
+                                    f'Dupliate key: {element.Key}',
+                                    f'Is being replaced with: {str(element.Key) + str(self.UniqueKeyCounter)}',
                                     'The line of code above shows you which layout, but does not tell you exactly where the element was defined',
-                                    'The element type is {}'.format(element.Type),
+                                    f'The element type is {element.Type}',
                                 )
                         element.Key = str(element.Key) + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
@@ -13549,7 +12283,7 @@ class Window:
         :type y:  (int)
         """
         try:
-            self.TKroot.geometry('+%s+%s' % (x, y))
+            self.TKroot.geometry('+{}+{}'.format(x, y))
             self.config_last_location = (int(x), (int(y)))
 
         except:
@@ -13628,10 +12362,7 @@ class Window:
         :param event: event information passed in by tkinter. Contains x,y position of mouse
         :type event:  (event)
         """
-        if (
-            isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS)
-            or event.widget in self._grab_anywhere_ignore_these_list
-        ) and event.widget not in self._grab_anywhere_include_these_list:
+        if (isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS) or event.widget in self._grab_anywhere_ignore_these_list) and event.widget not in self._grab_anywhere_include_these_list:
             # print('Found widget to ignore in grab anywhere...')
             return
         self._start_move_save_offset(event)
@@ -13680,10 +12411,7 @@ class Window:
         :param event: event information passed in by tkinter. Contains x,y position of mouse
         :type event:  (event)
         """
-        if (
-            isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS)
-            or event.widget in self._grab_anywhere_ignore_these_list
-        ) and event.widget not in self._grab_anywhere_include_these_list:
+        if (isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS) or event.widget in self._grab_anywhere_ignore_these_list) and event.widget not in self._grab_anywhere_include_these_list:
             # print('Found widget to ignore in grab anywhere...')
             return
 
@@ -13703,7 +12431,7 @@ class Window:
             print('on motion error', e)
 
     def _focus_callback(self, event):
-        print('Focus event = {} window = {}'.format(event, self.Title))
+        print(f'Focus event = {event} window = {self.Title}')
 
     def _config_callback(self, event):
         """
@@ -14078,9 +12806,7 @@ class Window:
         try:
             self.TKroot.wm_attributes('-topmost', 0)
         except Exception as e:
-            warnings.warn(
-                'Problem in Window.keep_on_top_clear trying to clear wm_attributes topmost' + str(e), UserWarning
-            )
+            warnings.warn('Problem in Window.keep_on_top_clear trying to clear wm_attributes topmost' + str(e), UserWarning)
 
     def current_location(self, more_accurate=False, without_titlebar=False):
         """
@@ -14133,10 +12859,7 @@ class Window:
             x, y = int(window_size[0]), int(window_size[1])
         except Exception as e:
             warnings.warn(
-                'Error in Window.current_size_accurate. Trouble getting x,y size\n{} {}'.format(
-                    geometry, geometry_tuple
-                )
-                + str(e),
+                'Error in Window.current_size_accurate. Trouble getting x,y size\n{} {}'.format(geometry, geometry_tuple) + str(e),
                 UserWarning,
             )
             x, y = (None, None)
@@ -14165,7 +12888,7 @@ class Window:
         :type size:  (int, int)
         """
         try:
-            self.TKroot.geometry('%sx%s' % (size[0], size[1]))
+            self.TKroot.geometry('{}x{}'.format(size[0], size[1]))
             self.TKroot.update_idletasks()
         except:
             pass
@@ -14181,7 +12904,7 @@ class Window:
         if not self._is_window_created('Tried to change the size of the window prior to creation.'):
             return
         try:
-            self.TKroot.geometry('%sx%s' % (size[0], size[1]))
+            self.TKroot.geometry('{}x{}'.format(size[0], size[1]))
             self.TKroot.update_idletasks()
         except:
             pass
@@ -14615,9 +13338,7 @@ class Window:
             try:
                 grab.save(full_filename)
             except Exception as e:
-                popup_error_with_traceback(
-                    'Screen capture failure', 'Error happened while trying to save screencapture', e
-                )
+                popup_error_with_traceback('Screen capture failure', 'Error happened while trying to save screencapture', e)
         else:
             popup_error_with_traceback(
                 'Screen capture failure',
@@ -14842,8 +13563,7 @@ class Window:
         msg = str(additional_message)
         if self.TKroot is None:
             warnings.warn(
-                'You cannot perform operations on a Window until it is read or finalized. Adding a "finalize=True" parameter to your Window creation will fix this. '
-                + msg,
+                'You cannot perform operations on a Window until it is read or finalized. Adding a "finalize=True" parameter to your Window creation will fix this. ' + msg,
                 UserWarning,
             )
             if not SUPPRESS_ERROR_POPUPS:
@@ -15129,13 +13849,9 @@ class SystemTray:
         screen_size = Window.get_screen_size()
 
         if filename:
-            image_elem = Image(
-                filename=filename, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-'
-            )
+            image_elem = Image(filename=filename, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-')
         elif data_base64:
-            image_elem = Image(
-                data=data_base64, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-'
-            )
+            image_elem = Image(data=data_base64, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-')
         elif data:
             image_elem = Image(data=data, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-')
         else:
@@ -15245,9 +13961,7 @@ class SystemTray:
 
         user_icon = data_base64 or filename or data or messageicon
 
-        event = self.notify(
-            title, message, icon=user_icon, fade_in_duration=fade_duration, display_duration_in_ms=display_duration
-        )
+        event = self.notify(title, message, icon=user_icon, fade_in_duration=fade_duration, display_duration_in_ms=display_duration)
         self.last_message_event = event
         return event
 
@@ -15352,11 +14066,7 @@ class SystemTray:
             ]
         ]
 
-        win_location = (
-            location
-            if location is not None
-            else (screen_res_x - win_width - win_margin[0], screen_res_y - win_height - win_margin[1])
-        )
+        win_location = location if location is not None else (screen_res_x - win_width - win_margin[0], screen_res_y - win_height - win_margin[1])
         window = Window(
             title,
             layout,
@@ -18197,9 +16907,7 @@ def _simplified_dual_color_to_tuple(color_tuple_or_string, default=(None, None))
                 text_color, background_color = default
         else:
             if not SUPPRESS_ERROR_POPUPS:
-                _error_popup_with_traceback(
-                    '** Badly formatted dual-color... not a tuple nor string **', color_tuple_or_string
-                )
+                _error_popup_with_traceback('** Badly formatted dual-color... not a tuple nor string **', color_tuple_or_string)
             else:
                 print('** Badly formatted dual-color... not a tuple nor string **', color_tuple_or_string)
             text_color, background_color = default
@@ -18341,11 +17049,7 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                         value = element.TKStringVar.get()
                     except:
                         value = ''
-                    if (
-                        not top_level_form.NonBlocking
-                        and not element.do_not_clear
-                        and not top_level_form.ReturnKeyboardEvents
-                    ):
+                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
                         element.TKStringVar.set('')
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
                     value = element.TKIntVar.get()
@@ -18374,9 +17078,7 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                         if element.TKCombo.current() == -1:  # if the current value was not in the original list
                             value = element.TKCombo.get()
                         else:
-                            value = element.Values[
-                                element.TKCombo.current()
-                            ]  # get value from original list given index
+                            value = element.Values[element.TKCombo.current()]  # get value from original list given index
                     except:
                         value = '*Exception occurred*'
                 elif element.Type == ELEM_TYPE_INPUT_OPTION_MENU:
@@ -18402,19 +17104,13 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                     except:
                         value = 0
                 elif element.Type == ELEM_TYPE_INPUT_MULTILINE:
-                    if (
-                        element.WriteOnly
-                    ):  # if marked as "write only" when created, then don't include with the values being returned
+                    if element.WriteOnly:  # if marked as "write only" when created, then don't include with the values being returned
                         continue
                     try:
                         value = element.TKText.get(1.0, tk.END)
                         if element.rstrip:
                             value = value.rstrip()
-                        if (
-                            not top_level_form.NonBlocking
-                            and not element.do_not_clear
-                            and not top_level_form.ReturnKeyboardEvents
-                        ):
+                        if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
                             element.TKText.delete('1.0', tk.END)
                     except:
                         value = None
@@ -18471,11 +17167,7 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                 if not (element.Type == ELEM_TYPE_BUTTONMENU and element.part_of_custom_menubar):
                     AddToReturnList(form, value)
                     AddToReturnDictionary(top_level_form, element, value)
-            elif (
-                element.Type == ELEM_TYPE_BUTTON
-                and element.BType == BUTTON_TYPE_COLOR_CHOOSER
-                and element.Target == (None, None)
-            ) or (
+            elif (element.Type == ELEM_TYPE_BUTTON and element.BType == BUTTON_TYPE_COLOR_CHOOSER and element.Target == (None, None)) or (
                 element.Type == ELEM_TYPE_BUTTON
                 and element.Key is not None
                 and (
@@ -18537,7 +17229,7 @@ def fill_form_with_values(window, values_dict):
         try:
             window.AllKeysDict[element_key].Update(values_dict[element_key])
         except Exception:
-            print('Problem filling form. Perhaps bad key?  This is a suspected bad key: {}'.format(element_key))
+            print(f'Problem filling form. Perhaps bad key?  This is a suspected bad key: {element_key}')
 
 
 def _FindElementWithFocusInSubForm(form):
@@ -18673,13 +17365,8 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False,
                     return_val = new_menu
                     pos = sub_menu_info[i].find(MENU_SHORTCUT_CHARACTER)
                     if pos != -1:
-                        if (
-                            pos < len(MENU_SHORTCUT_CHARACTER)
-                            or sub_menu_info[i][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\'
-                        ):
-                            sub_menu_info[i] = (
-                                sub_menu_info[i][:pos] + sub_menu_info[i][pos + len(MENU_SHORTCUT_CHARACTER) :]
-                            )
+                        if pos < len(MENU_SHORTCUT_CHARACTER) or sub_menu_info[i][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
+                            sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + len(MENU_SHORTCUT_CHARACTER) :]
                     if sub_menu_info[i][0] == MENU_DISABLED_CHARACTER:
                         top_menu.add_cascade(
                             label=sub_menu_info[i][len(MENU_DISABLED_CHARACTER) :],
@@ -18689,9 +17376,7 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False,
                         )
                     else:
                         top_menu.add_cascade(label=sub_menu_info[i], menu=new_menu, underline=pos)
-                    AddMenuItem(
-                        new_menu, sub_menu_info[i + 1], element, is_sub_menu=True, right_click_menu=right_click_menu
-                    )
+                    AddMenuItem(new_menu, sub_menu_info[i + 1], element, is_sub_menu=True, right_click_menu=right_click_menu)
                     i += 1  # skip the next one
                 else:
                     AddMenuItem(top_menu, item, element, right_click_menu=right_click_menu)
@@ -18724,7 +17409,7 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False,
 
 
 # Chr0nic || This is probably *very* bad practice. But it works. Simple, but it works...
-class VarHolder(object):
+class VarHolder:
     canvas_holder = None
 
     def __init__(self):
@@ -18741,32 +17426,20 @@ def _fixed_map(style, style_name, option, highlight_colors=(None, None)):
 
     # default_map = [elm for elm in style.map("Treeview", query_opt=option) if '!' not in elm[0]]
     # custom_map = [elm for elm in style.map(style_name, query_opt=option) if '!' not in elm[0]]
-    default_map = [
-        elm for elm in style.map('Treeview', query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]
-    ]
-    custom_map = [
-        elm for elm in style.map(style_name, query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]
-    ]
+    default_map = [elm for elm in style.map('Treeview', query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]]
+    custom_map = [elm for elm in style.map(style_name, query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]]
     if option == 'background':
         custom_map.append(
             (
                 'selected',
-                (
-                    highlight_colors[1]
-                    if highlight_colors[1] is not None
-                    else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[1]
-                ),
+                (highlight_colors[1] if highlight_colors[1] is not None else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[1]),
             )
         )
     elif option == 'foreground':
         custom_map.append(
             (
                 'selected',
-                (
-                    highlight_colors[0]
-                    if highlight_colors[0] is not None
-                    else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[0]
-                ),
+                (highlight_colors[0] if highlight_colors[0] is not None else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[0]),
             )
         )
 
@@ -18810,7 +17483,7 @@ def _change_ttk_theme(style, theme_name):
     global ttk_theme_in_use
     if theme_name not in style.theme_names():
         _error_popup_with_traceback(
-            'You are trying to use TTK theme "{}"'.format(theme_name),
+            f'You are trying to use TTK theme "{theme_name}"',
             'This is not legal for your system',
             'The valid themes to choose from are: {}'.format(', '.join(style.theme_names())),
         )
@@ -18890,17 +17563,13 @@ def _make_ttk_scrollbar(element, orientation, window):
         style_name = _make_ttk_style_name('.Vertical.TScrollbar', element)
         # style_name_thumb = _make_ttk_style_name('.Vertical.TScrollbar.thumb', element)
         element.vsb_style = style
-        element.vsb = ttk.Scrollbar(
-            element.element_frame, orient=orient, command=element.Widget.yview, style=style_name
-        )
+        element.vsb = ttk.Scrollbar(element.element_frame, orient=orient, command=element.Widget.yview, style=style_name)
         element.vsb_style_name = style_name
     else:
         orient = 'horizontal'
         style_name = _make_ttk_style_name('.Horizontal.TScrollbar', element)
         element.hsb_style = style
-        element.hsb = ttk.Scrollbar(
-            element.element_frame, orient=orient, command=element.Widget.xview, style=style_name
-        )
+        element.hsb = ttk.Scrollbar(element.element_frame, orient=orient, command=element.Widget.xview, style=style_name)
         element.hsb_style_name = style_name
 
     # ------------------ Get the colors using heirarchy of element, window, options, settings ------------------
@@ -19117,9 +17786,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
     def _add_right_click_menu_and_grab(element):
         if element.RightClickMenu == MENU_RIGHT_CLICK_DISABLED:
             return
-        if (
-            element.Type == ELEM_TYPE_TAB_GROUP
-        ):  # unless everything disabled, then need to always set a right click menu for tabgroups
+        if element.Type == ELEM_TYPE_TAB_GROUP:  # unless everything disabled, then need to always set a right click menu for tabgroups
             if toplevel_form.RightClickMenu == MENU_RIGHT_CLICK_DISABLED:
                 return
             menu = _MENU_RIGHT_CLICK_TABGROUP_DEFAULT
@@ -19148,9 +17815,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 top_menu.config(activebackground=toplevel_form.right_click_menu_selected_colors[1])
             AddMenuItem(top_menu, menu[1], element, right_click_menu=True)
             element.TKRightClickMenu = top_menu
-            if (
-                toplevel_form.RightClickMenu
-            ):  # if the top level has a right click menu, then setup a callback for the Window itself
+            if toplevel_form.RightClickMenu:  # if the top level has a right click menu, then setup a callback for the Window itself
                 if toplevel_form.TKRightClickMenu is None:
                     toplevel_form.TKRightClickMenu = top_menu
                     if running_mac():
@@ -19176,14 +17841,10 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             row_should_expand = True
         elif element.expand_x:
             fill = tk.X
-            row_fill_direction = (
-                tk.X if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.Y else tk.X
-            )
+            row_fill_direction = tk.X if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.Y else tk.X
         elif element.expand_y:
             fill = tk.Y
-            row_fill_direction = (
-                tk.Y if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.X else tk.Y
-            )
+            row_fill_direction = tk.Y if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.X else tk.Y
             row_should_expand = True
         else:
             fill = tk.NONE
@@ -19259,9 +17920,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element = element  # type: Column
                 # ----------------------- SCROLLABLE Column ----------------------
                 if element.Scrollable:
-                    element.Widget = element.TKColFrame = TkScrollableFrame(
-                        tk_row_frame, element.VerticalScrollOnly, element, toplevel_form
-                    )  # do not use yet!  not working
+                    element.Widget = element.TKColFrame = TkScrollableFrame(tk_row_frame, element.VerticalScrollOnly, element, toplevel_form)  # do not use yet!  not working
                     PackFormIntoFrame(element, element.TKColFrame.TKFrame, toplevel_form)
                     element.TKColFrame.TKFrame.update()
                     if element.Size == (None, None):  # if no size specified, use column width x column height/2
@@ -19282,12 +17941,8 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             element.TKColFrame.canvas.config(width=element.Size[0])
                     if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                         element.TKColFrame.canvas.config(background=element.BackgroundColor)
-                        element.TKColFrame.TKFrame.config(
-                            background=element.BackgroundColor, borderwidth=0, highlightthickness=0
-                        )
-                        element.TKColFrame.config(
-                            background=element.BackgroundColor, borderwidth=0, highlightthickness=0
-                        )
+                        element.TKColFrame.TKFrame.config(background=element.BackgroundColor, borderwidth=0, highlightthickness=0)
+                        element.TKColFrame.config(background=element.BackgroundColor, borderwidth=0, highlightthickness=0)
                 # ----------------------- PLAIN Column ----------------------
                 else:
                     if element.Size != (None, None):
@@ -19302,16 +17957,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             element.TKColFrame.canvas.config(width=element.Size[0])
                         if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                             element.TKColFrame.canvas.config(background=element.BackgroundColor)
-                            element.TKColFrame.TKFrame.config(
-                                background=element.BackgroundColor, borderwidth=0, highlightthickness=0
-                            )
+                            element.TKColFrame.TKFrame.config(background=element.BackgroundColor, borderwidth=0, highlightthickness=0)
                     else:
                         element.Widget = element.TKColFrame = tk.Frame(tk_row_frame)
                         PackFormIntoFrame(element, element.TKColFrame, toplevel_form)
                         if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
-                            element.TKColFrame.config(
-                                background=element.BackgroundColor, borderwidth=0, highlightthickness=0
-                            )
+                            element.TKColFrame.config(background=element.BackgroundColor, borderwidth=0, highlightthickness=0)
 
                 if element.Justification is None:
                     pass
@@ -19353,13 +18004,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         anchor = tk.CENTER
                     if element.VerticalAlignment.lower().startswith('b'):
                         anchor = tk.S
-                    element.TKColFrame.pack(
-                        side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
-                    )
+                    element.TKColFrame.pack(side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 else:
-                    element.TKColFrame.pack(
-                        side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
-                    )
+                    element.TKColFrame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
 
                 # element.TKColFrame.pack(side=side, padx=elementpad[0], pady=elementpad[1], expand=True, fill='both')
                 if element.visible is False:
@@ -19400,9 +18047,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             highlightbackground=pane.BackgroundColor,
                             highlightcolor=pane.BackgroundColor,
                         )
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element.PanedWindow.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 # element.PanedWindow.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=True, fill='both')
                 if element.visible is False:
@@ -19431,20 +18076,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = (
-                    tk.LEFT
-                    if justification.startswith('l')
-                    else tk.CENTER if justification.startswith('c') else tk.RIGHT
-                )
+                justify = tk.LEFT if justification.startswith('l') else tk.CENTER if justification.startswith('c') else tk.RIGHT
                 anchor = tk.NW if justification.startswith('l') else tk.N if justification.startswith('c') else tk.NE
-                tktext_label = element.Widget = tk.Label(
-                    tk_row_frame, textvariable=stringvar, width=width, height=height, justify=justify, bd=bd, font=font
-                )
+                tktext_label = element.Widget = tk.Label(tk_row_frame, textvariable=stringvar, width=width, height=height, justify=justify, bd=bd, font=font)
                 # Set wrap-length for text (in PIXELS) == PAIN IN THE ASS
                 wraplen = tktext_label.winfo_reqwidth()  # width of widget in Pixels
-                if auto_size_text or (
-                    not auto_size_text and height == 1
-                ):  # if just 1 line high, ensure no wrap happens
+                if auto_size_text or (not auto_size_text and height == 1):  # if just 1 line high, ensure no wrap happens
                     wraplen = 0
                 tktext_label.configure(anchor=anchor, wraplen=wraplen)  # set wrap to width of widget
                 if element.Relief is not None:
@@ -19453,9 +18090,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tktext_label.configure(background=element.BackgroundColor)
                 if element.TextColor != COLOR_SYSTEM_DEFAULT and element.TextColor is not None:
                     tktext_label.configure(fg=element.TextColor)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 tktext_label.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -19469,11 +18104,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Grab:
                     element._grab_anywhere_on()
             # -------------------------  BUTTON placement element non-ttk version  ------------------------- #
-            elif (element_type == ELEM_TYPE_BUTTON and element.UseTtkButtons is False) or (
-                element_type == ELEM_TYPE_BUTTON
-                and element.UseTtkButtons is not True
-                and toplevel_form.UseTtkButtons is not True
-            ):
+            elif (element_type == ELEM_TYPE_BUTTON and element.UseTtkButtons is False) or (element_type == ELEM_TYPE_BUTTON and element.UseTtkButtons is not True and toplevel_form.UseTtkButtons is not True):
                 element = element  # type: Button
                 element.UseTtkButtons = False  # indicate that ttk button was not used
                 stringvar = tk.StringVar()
@@ -19507,9 +18138,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         else:
                             btext = btext.replace('\\' + MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
                             pos = -1
-                tkbutton = element.Widget = tk.Button(
-                    tk_row_frame, text=btext, width=width, height=height, justify=tk.CENTER, bd=bd, font=font
-                )
+                tkbutton = element.Widget = tk.Button(tk_row_frame, text=btext, width=width, height=height, justify=tk.CENTER, bd=bd, font=font)
                 if pos != -1:
                     tkbutton.config(underline=pos)
                 try:
@@ -19530,11 +18159,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     _error_popup_with_traceback(
                         'Button has a problem....',
                         'The traceback information will not show the line in your layout with the problem, but it does tell you which window.',
-                        'Error {}'.format(e),
+                        f'Error {e}',
                         # 'Button Text: {}'.format(btext),
                         # 'Button key: {}'.format(element.Key),
                         # 'Color string: {}'.format(bc),
-                        "Parent Window's Title: {}".format(toplevel_form.Title),
+                        f"Parent Window's Title: {toplevel_form.Title}",
                     )
 
                 if bd == 0 and not running_mac():
@@ -19559,11 +18188,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             width, height = photo.width(), photo.height()
                     except Exception as e:
                         _error_popup_with_traceback(
-                            'Button Element error {}'.format(e),
-                            'Image filename: {}'.format(element.ImageFilename),
+                            f'Button Element error {e}',
+                            f'Image filename: {element.ImageFilename}',
                             'NOTE - file format must be PNG or GIF!',
-                            'Button element key: {}'.format(element.Key),
-                            "Parent Window's Title: {}".format(toplevel_form.Title),
+                            f'Button element key: {element.Key}',
+                            f"Parent Window's Title: {toplevel_form.Title}",
                         )
                     tkbutton.config(image=photo, compound=tk.CENTER, width=width, height=height)
                     tkbutton.image = photo
@@ -19583,18 +18212,16 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         tkbutton.image = photo
                     except Exception as e:
                         _error_popup_with_traceback(
-                            'Button Element error {}'.format(e),
+                            f'Button Element error {e}',
                             'Problem using BASE64 Image data Image Susample',
-                            'Buton element key: {}'.format(element.Key),
-                            "Parent Window's Title: {}".format(toplevel_form.Title),
+                            f'Buton element key: {element.Key}',
+                            f"Parent Window's Title: {toplevel_form.Title}",
                         )
 
                 if width != 0:
                     wraplen = width * _char_width_in_pixels(font)
                     tkbutton.configure(wraplength=wraplen)  # set wrap to width of widget
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
 
                 tkbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
@@ -19621,9 +18248,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkbutton.config(activeforeground=element.MouseOverColors[0])
 
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 try:
                     if element.HighlightColors[1] != COLOR_SYSTEM_DEFAULT:
                         tkbutton.config(highlightbackground=element.HighlightColors[1])
@@ -19631,11 +18256,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         tkbutton.config(highlightcolor=element.HighlightColors[0])
                 except Exception as e:
                     _error_popup_with_traceback(
-                        'Button Element error {}'.format(e),
-                        'Button element key: {}'.format(element.Key),
-                        'Button text: {}'.format(btext),
-                        'Has a bad highlight color {}'.format(element.HighlightColors),
-                        "Parent Window's Title: {}".format(toplevel_form.Title),
+                        f'Button Element error {e}',
+                        f'Button element key: {element.Key}',
+                        f'Button text: {btext}',
+                        f'Has a bad highlight color {element.HighlightColors}',
+                        f"Parent Window's Title: {toplevel_form.Title}",
                     )
                     # print('Button with text: ', btext, 'has a bad highlight color', element.HighlightColors)
                 _add_right_click_menu_and_grab(element)
@@ -19713,9 +18338,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     button_style.map(style_name, background=[('disabled', element.DisabledButtonColor[1])])
 
                 if height > 1:
-                    button_style.configure(
-                        style_name, padding=height * _char_height_in_pixels(font)
-                    )  # should this be height instead?
+                    button_style.configure(style_name, padding=height * _char_height_in_pixels(font))  # should this be height instead?
                 if width != 0:
                     wraplen = width * _char_width_in_pixels(font)  # width of widget in Pixels
                     button_style.configure(style_name, wraplength=wraplen)  # set wrap to width of widget
@@ -19753,9 +18376,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkbutton.image = photo
 
                 element.TKButton = tkbutton  # not used yet but save the TK button in case
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 tkbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -19774,9 +18395,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 _add_right_click_menu_and_grab(element)
 
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
             # -------------------------  BUTTONMENU placement element  ------------------------- #
             elif element_type == ELEM_TYPE_BUTTONMENU:
                 element = element  # type: ButtonMenu
@@ -19800,9 +18419,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 bd = element.BorderWidth
                 if element.ItemFont is None:
                     element.ItemFont = font
-                tkbutton = element.Widget = tk.Menubutton(
-                    tk_row_frame, text=btext, width=width, height=height, justify=tk.LEFT, bd=bd, font=font
-                )
+                tkbutton = element.Widget = tk.Menubutton(tk_row_frame, text=btext, width=width, height=height, justify=tk.LEFT, bd=bd, font=font)
                 element.TKButtonMenu = tkbutton
                 if bc != (None, None) and bc != COLOR_SYSTEM_DEFAULT and bc[1] != COLOR_SYSTEM_DEFAULT:
                     tkbutton.config(foreground=bc[0], background=bc[1])
@@ -19844,9 +18461,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkbutton.image = photo
                 if width != 0:
                     tkbutton.configure(wraplength=wraplen + 10)  # set wrap to width of widget
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 tkbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
 
                 menu_def = element.MenuDefinition
@@ -19880,9 +18495,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Disabled:
                     element.TKButton['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
 
             # -------------------------  INPUT placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_TEXT:
@@ -19896,11 +18509,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     justification = element.Justification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = (
-                    tk.LEFT
-                    if justification.startswith('l')
-                    else tk.CENTER if justification.startswith('c') else tk.RIGHT
-                )
+                justify = tk.LEFT if justification.startswith('l') else tk.CENTER if justification.startswith('c') else tk.RIGHT
                 # anchor = tk.NW if justification == 'left' else tk.N if justification == 'center' else tk.NE
                 element.TKEntry = element.Widget = tk.Entry(
                     tk_row_frame,
@@ -19916,9 +18525,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.TKEntry.bind('<Return>', element._ReturnKeyHandler)
 
                 if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
-                    element.TKEntry.configure(
-                        background=element.BackgroundColor, selectforeground=element.BackgroundColor
-                    )
+                    element.TKEntry.configure(background=element.BackgroundColor, selectforeground=element.BackgroundColor)
 
                 if text_color not in (None, COLOR_SYSTEM_DEFAULT):
                     element.TKEntry.configure(fg=text_color, selectbackground=text_color)
@@ -19935,9 +18542,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.Widget.config(highlightthickness=0)
                 # element.pack_keywords = {'side':tk.LEFT, 'padx':elementpad[0], 'pady':elementpad[1], 'expand':False, 'fill':tk.NONE }
                 # element.TKEntry.pack(**element.pack_keywords)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element.TKEntry.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -19997,19 +18602,17 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 except Exception as e:
                     _error_popup_with_traceback(
-                        'Combo Element error {}'.format(e),
-                        'Combo element key: {}'.format(element.Key),
+                        f'Combo Element error {e}',
+                        f'Combo element key: {element.Key}',
                         'One of your colors is bad. Check the text, background, button background and button arrow colors',
-                        "Parent Window's Title: {}".format(toplevel_form.Title),
+                        f"Parent Window's Title: {toplevel_form.Title}",
                     )
 
                 # Strange code that is needed to set the font for the drop-down list
                 element._dropdown_newfont = tkinter.font.Font(font=font)
                 tk_row_frame.option_add('*TCombobox*Listbox*Font', element._dropdown_newfont)
 
-                element.TKCombo = element.Widget = ttk.Combobox(
-                    tk_row_frame, width=width, textvariable=element.TKStringVar, font=font, style=style_name
-                )
+                element.TKCombo = element.Widget = ttk.Combobox(tk_row_frame, width=width, textvariable=element.TKStringVar, font=font, style=style_name)
 
                 # make tcl call to deal with colors for the drop-down formatting
                 try:
@@ -20040,9 +18643,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Size[1] != 1 and element.Size[1] is not None:
                     element.TKCombo.configure(height=element.Size[1])
                 element.TKCombo['values'] = element.Values
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element.TKCombo.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -20073,9 +18674,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.TKStringVar = tk.StringVar()
                 if element.DefaultValue:
                     element.TKStringVar.set(element.DefaultValue)
-                element.TKOptionMenu = element.Widget = tk.OptionMenu(
-                    tk_row_frame, element.TKStringVar, *element.Values
-                )
+                element.TKOptionMenu = element.Widget = tk.OptionMenu(tk_row_frame, element.TKStringVar, *element.Values)
                 element.TKOptionMenu.config(highlightthickness=0, font=font, width=width)
                 element.TKOptionMenu['menu'].config(font=font)
                 element.TKOptionMenu.config(borderwidth=border_depth)
@@ -20085,21 +18684,15 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.TextColor != COLOR_SYSTEM_DEFAULT and element.TextColor is not None:
                     element.TKOptionMenu.configure(fg=element.TextColor)
                     element.TKOptionMenu['menu'].config(fg=element.TextColor)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
-                element.TKOptionMenu.pack(
-                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                element.TKOptionMenu.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element.TKOptionMenu.pack_forget()
                 if element.Disabled is True:
                     element.TKOptionMenu['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKOptionMenu, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKOptionMenu, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
             # -------------------------  LISTBOX placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_LISTBOX:
                 element = element  # type: Listbox
@@ -20142,10 +18735,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         element.TKListbox.selection_set(index)
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element.TKListbox.configure(background=element.BackgroundColor)
-                if (
-                    element.HighlightBackgroundColor is not None
-                    and element.HighlightBackgroundColor != COLOR_SYSTEM_DEFAULT
-                ):
+                if element.HighlightBackgroundColor is not None and element.HighlightBackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element.TKListbox.config(selectbackground=element.HighlightBackgroundColor)
                 if text_color is not None and text_color != COLOR_SYSTEM_DEFAULT:
                     element.TKListbox.configure(fg=text_color)
@@ -20170,9 +18760,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.Widget.bind('<Enter>', lambda event, em=element: testMouseHook(em))
                     element.Widget.bind('<Leave>', lambda event, em=element: testMouseUnhook(em))
 
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand)
                 element.TKListbox.pack(side=tk.LEFT, fill=fill, expand=expand)
                 if element.visible is False:
@@ -20184,9 +18772,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Disabled is True:
                     element.TKListbox['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKListbox, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKListbox, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 _add_right_click_menu_and_grab(element)
             # -------------------------  MULTILINE placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_MULTILINE:
@@ -20196,9 +18782,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.element_frame = element_frame = tk.Frame(tk_row_frame)
 
                 # if element.no_scrollbar:
-                element.TKText = element.Widget = tk.Text(
-                    element_frame, width=width, height=height, bd=bd, font=font, relief=RELIEF_SUNKEN
-                )
+                element.TKText = element.Widget = tk.Text(element_frame, width=width, height=height, bd=bd, font=font, relief=RELIEF_SUNKEN)
                 # else:
                 #     element.TKText = element.Widget = tk.scrolledtext.ScrolledText(element_frame, width=width, height=height, bd=bd, font=font, relief=RELIEF_SUNKEN)
 
@@ -20234,9 +18818,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.TKText.configure(fg=text_color, selectbackground=text_color)
                     element.TKText.config(insertbackground=text_color)
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
-                    element.TKText.configure(
-                        background=element.BackgroundColor, selectforeground=element.BackgroundColor
-                    )
+                    element.TKText.configure(background=element.BackgroundColor, selectforeground=element.BackgroundColor)
                 if element.selected_background_color not in (None, COLOR_SYSTEM_DEFAULT):
                     element.TKText.configure(selectbackground=element.selected_background_color)
                 if element.selected_text_color not in (None, COLOR_SYSTEM_DEFAULT):
@@ -20256,13 +18838,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.justification_tag = 'center'
                 # if DEFAULT_SCROLLBAR_COLOR not in (None, COLOR_SYSTEM_DEFAULT):               # only works on Linux so not including it
                 #     element.TKText.vbar.config(troughcolor=DEFAULT_SCROLLBAR_COLOR)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
 
-                element.element_frame.pack(
-                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand
-                )
+                element.element_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand)
                 element.Widget.pack(side=tk.LEFT, fill=fill, expand=expand)
 
                 if element.visible is False:
@@ -20319,9 +18897,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.TKCheckbutton.configure(state='disable')
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element.TKCheckbutton.configure(background=element.BackgroundColor)
-                    element.TKCheckbutton.configure(
-                        selectcolor=element.CheckboxBackgroundColor
-                    )  # The background of the checkbox
+                    element.TKCheckbutton.configure(selectcolor=element.CheckboxBackgroundColor)  # The background of the checkbox
                     element.TKCheckbutton.configure(activebackground=element.BackgroundColor)
                 if text_color is not None and text_color != COLOR_SYSTEM_DEFAULT:
                     element.TKCheckbutton.configure(fg=text_color)
@@ -20332,19 +18908,13 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.TKCheckbutton.config(highlightbackground=element.BackgroundColor)
                 if element.TextColor != COLOR_SYSTEM_DEFAULT:
                     element.TKCheckbutton.config(highlightcolor=element.TextColor)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
-                element.TKCheckbutton.pack(
-                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                element.TKCheckbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element.TKCheckbutton.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKCheckbutton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKCheckbutton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 _add_right_click_menu_and_grab(element)
 
             # -------------------------  PROGRESS placement element  ------------------------- #
@@ -20382,12 +18952,8 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     style_name=style_name,
                 )
                 element.Widget = element.TKProgressBar.TKProgressBarForReal
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
-                element.TKProgressBar.TKProgressBarForReal.pack(
-                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                element.TKProgressBar.TKProgressBarForReal.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings(alternate_widget=element.TKProgressBar.TKProgressBarForReal)
                     # element.TKProgressBar.TKProgressBarForReal.pack_forget()
@@ -20400,9 +18966,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 default_value = element.InitialState
                 ID = element.GroupID
                 # see if ID has already been placed
-                value = EncodeRadioRowCol(
-                    form.ContainerElemementNumber, row_num, col_num
-                )  # value to set intvar to if this radio is selected
+                value = EncodeRadioRowCol(form.ContainerElemementNumber, row_num, col_num)  # value to set intvar to if this radio is selected
                 element.EncodedRadioValue = value
                 if ID in toplevel_form.RadioDict:
                     RadVar = toplevel_form.RadioDict[ID]
@@ -20440,9 +19004,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 if element.Disabled:
                     element.TKRadio['state'] = 'disabled'
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element.TKRadio.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -20457,9 +19019,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 width, height = element_size
                 width = 0 if auto_size_text else element_size[0]
                 element.TKStringVar = tk.StringVar()
-                element.TKSpinBox = element.Widget = tk.Spinbox(
-                    tk_row_frame, values=element.Values, textvariable=element.TKStringVar, width=width, bd=border_depth
-                )
+                element.TKSpinBox = element.Widget = tk.Spinbox(tk_row_frame, values=element.Values, textvariable=element.TKStringVar, width=width, bd=border_depth)
                 if element.DefaultValue is not None:
                     element.TKStringVar.set(element.DefaultValue)
                 element.TKSpinBox.configure(font=font)  # set wrap to width of widget
@@ -20472,9 +19032,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.Widget.config(highlightthickness=0)
                 if element.wrap is True:
                     element.Widget.configure(wrap=True)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element.TKSpinBox.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -20489,9 +19047,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Disabled is True:  # note overrides readonly if disabled
                     element.TKSpinBox['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKSpinBox, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKSpinBox, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 if element.BindReturnKey:
                     element.TKSpinBox.bind('<Return>', element._SpinboxSelectHandler)
                 _add_right_click_menu_and_grab(element)
@@ -20517,7 +19073,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     _error_popup_with_traceback(
                         'Your Window has an Image Element with a problem',
                         'The traceback will show you the Window with the problem layout',
-                        'Look in this Window\'s layout for an Image element that has a key of {}'.format(element.Key),
+                        f'Look in this Window\'s layout for an Image element that has a key of {element.Key}',
                         'The error occuring is:',
                         e,
                     )
@@ -20525,11 +19081,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.tktext_label = element.Widget = tk.Label(tk_row_frame, bd=0)
 
                 if photo is not None:
-                    if (
-                        element_size == (None, None)
-                        or element_size is None
-                        or element_size == toplevel_form.DefaultElementSize
-                    ):
+                    if element_size == (None, None) or element_size is None or element_size == toplevel_form.DefaultElementSize:
                         width, height = photo.width(), photo.height()
                     else:
                         width, height = element_size
@@ -20540,20 +19092,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 element.tktext_label.image = photo
                 # tktext_label.configure(anchor=tk.NW, image=photo)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
-                element.tktext_label.pack(
-                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                element.tktext_label.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
 
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element.tktext_label.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.tktext_label, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.tktext_label, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 if element.EnableEvents and element.tktext_label is not None:
                     element.tktext_label.bind('<ButtonPress-1>', element._ClickHandler)
 
@@ -20571,17 +19117,13 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element._TKCanvas.configure(background=element.BackgroundColor, highlightthickness=0)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element._TKCanvas.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element._TKCanvas.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element._TKCanvas, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element._TKCanvas, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 _add_right_click_menu_and_grab(element)
 
                 # -------------------------  Graph placement element  ------------------------- #
@@ -20593,12 +19135,8 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 #     element._TKCanvas = tk.Canvas(tk_row_frame, width=width, height=height, bd=border_depth)
                 # else:
                 #     element._TKCanvas.master = tk_row_frame
-                element._TKCanvas2 = element.Widget = tk.Canvas(
-                    tk_row_frame, width=width, height=height, bd=border_depth
-                )
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                element._TKCanvas2 = element.Widget = tk.Canvas(tk_row_frame, width=width, height=height, bd=border_depth)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element._TKCanvas2.pack(side=tk.LEFT, expand=expand, fill=fill)
                 element._TKCanvas2.addtag_all('mytag')
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
@@ -20609,9 +19147,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element._pack_forget_save_settings()
                     # element._TKCanvas2.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element._TKCanvas2, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element._TKCanvas2, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 if element.ChangeSubmits:
                     element._TKCanvas2.bind('<ButtonRelease-1>', element.ButtonReleaseCallBack)
                     element._TKCanvas2.bind('<ButtonPress-1>', element.ButtonPressCallBack)
@@ -20622,9 +19158,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             elif element_type == ELEM_TYPE_MENUBAR:
                 element = element  # type: MenuBar
                 menu_def = element.MenuDefinition
-                element.TKMenu = element.Widget = tk.Menu(
-                    toplevel_form.TKroot, tearoff=element.Tearoff, tearoffcommand=element._tearoff_menu_callback
-                )  # create the menubar
+                element.TKMenu = element.Widget = tk.Menu(toplevel_form.TKroot, tearoff=element.Tearoff, tearoffcommand=element._tearoff_menu_callback)  # create the menubar
                 menubar = element.TKMenu
                 if font is not None:  # if a font is used, make sure it's saved in the element
                     element.Font = font
@@ -20646,9 +19180,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         if pos == 0 or menu_entry[0][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
                             menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + 1 :]
                     if menu_entry[0][0] == MENU_DISABLED_CHARACTER:
-                        menubar.add_cascade(
-                            label=menu_entry[0][len(MENU_DISABLED_CHARACTER) :], menu=baritem, underline=pos - 1
-                        )
+                        menubar.add_cascade(label=menu_entry[0][len(MENU_DISABLED_CHARACTER) :], menu=baritem, underline=pos - 1)
                         menubar.entryconfig(menu_entry[0][len(MENU_DISABLED_CHARACTER) :], state='disabled')
                     else:
                         menubar.add_cascade(label=menu_entry[0], menu=baritem, underline=pos)
@@ -20662,9 +19194,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 labeled_frame = element.Widget = tk.LabelFrame(tk_row_frame, text=element.Title, relief=element.Relief)
                 element.TKFrame = labeled_frame
                 PackFormIntoFrame(element, labeled_frame, toplevel_form)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 if element.VerticalAlignment is not None:
                     anchor = tk.CENTER  # Default to center if a bad choice is made
                     if element.VerticalAlignment.lower().startswith('t'):
@@ -20673,9 +19203,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         anchor = tk.CENTER
                     if element.VerticalAlignment.lower().startswith('b'):
                         anchor = tk.S
-                    labeled_frame.pack(
-                        side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
-                    )
+                    labeled_frame.pack(side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 else:
                     labeled_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
 
@@ -20733,18 +19261,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     _error_popup_with_traceback(
                         'Your Window has an Tab Element with an IMAGE problem',
                         'The traceback will show you the Window with the problem layout',
-                        'Look in this Window\'s layout for an Image element that has a key of {}'.format(element.Key),
+                        f'Look in this Window\'s layout for an Image element that has a key of {element.Key}',
                         'The error occuring is:',
                         e,
                     )
 
                 element.photo = photo
                 if photo is not None:
-                    if (
-                        element_size == (None, None)
-                        or element_size is None
-                        or element_size == toplevel_form.DefaultElementSize
-                    ):
+                    if element_size == (None, None) or element_size is None or element_size == toplevel_form.DefaultElementSize:
                         width, height = photo.width(), photo.height()
                     else:
                         width, height = element_size
@@ -20764,9 +19288,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 element.ParentNotebook = form.TKNotebook
                 element.TabID = form.TabCount
-                form.tab_index_to_key[element.TabID] = (
-                    element.key
-                )  # has a list of the tabs in the notebook and their associated key
+                form.tab_index_to_key[element.TabID] = element.key  # has a list of the tabs in the notebook and their associated key
                 form.TabCount += 1
                 if element.BackgroundColor not in (COLOR_SYSTEM_DEFAULT, None):
                     element.TKFrame.configure(
@@ -20816,10 +19338,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 # FINALLY the proper styling to get tab colors!
                 if element.SelectedTitleColor is not None and element.SelectedTitleColor != COLOR_SYSTEM_DEFAULT:
                     style.map(custom_style + '.Tab', foreground=[('selected', element.SelectedTitleColor)])
-                if (
-                    element.SelectedBackgroundColor is not None
-                    and element.SelectedBackgroundColor != COLOR_SYSTEM_DEFAULT
-                ):
+                if element.SelectedBackgroundColor is not None and element.SelectedBackgroundColor != COLOR_SYSTEM_DEFAULT:
                     style.map(custom_style + '.Tab', background=[('selected', element.SelectedBackgroundColor)])
                 if element.TabBackgroundColor is not None and element.TabBackgroundColor != COLOR_SYSTEM_DEFAULT:
                     style.configure(custom_style + '.Tab', background=element.TabBackgroundColor)
@@ -20828,9 +19347,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.BorderWidth is not None:
                     style.configure(custom_style, borderwidth=element.BorderWidth)
                 if element.TabBorderWidth is not None:
-                    style.configure(
-                        custom_style + '.Tab', borderwidth=element.TabBorderWidth
-                    )  # if ever want to get rid of border around the TABS themselves
+                    style.configure(custom_style + '.Tab', borderwidth=element.TabBorderWidth)  # if ever want to get rid of border around the TABS themselves
                 if element.FocusColor not in (None, COLOR_SYSTEM_DEFAULT):
                     style.configure(custom_style + '.Tab', focuscolor=element.FocusColor)
 
@@ -20841,19 +19358,13 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 PackFormIntoFrame(element, toplevel_form.TKroot, toplevel_form)
 
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
-                element.TKNotebook.pack(
-                    anchor=tk.SW, side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                element.TKNotebook.pack(anchor=tk.SW, side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand)
 
                 if element.ChangeSubmits:
                     element.TKNotebook.bind('<<NotebookTabChanged>>', element._TabGroupSelectHandler)
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKNotebook, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKNotebook, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 if element.Size != (None, None):
                     element.TKNotebook.configure(width=element.Size[0], height=element.Size[1])
                 _add_right_click_menu_and_grab(element)
@@ -20899,9 +19410,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkscale.config(showvalue=0)
                 if text_color not in (None, COLOR_SYSTEM_DEFAULT):
                     tkscale.configure(fg=text_color)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 tkscale.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -20974,18 +19483,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     row_number_header_width = _string_width_in_pixels(element.HeaderFont, element.RowHeaderText) + 10
                     row_number_width = _string_width_in_pixels(font, str(len(element.Values))) + 10
                     row_number_width = max(row_number_header_width, row_number_width)
-                    treeview.column(
-                        element.RowHeaderText, width=row_number_width, minwidth=10, anchor=anchor, stretch=0
-                    )
+                    treeview.column(element.RowHeaderText, width=row_number_width, minwidth=10, anchor=anchor, stretch=0)
 
                 headings = element.ColumnHeadings if element.ColumnHeadings is not None else element.Values[0]
                 for i, heading in enumerate(headings):
                     # heading = str(heading)
                     treeview.heading(heading, text=heading)
                     if element.AutoSizeColumns:
-                        col_width = column_widths.get(
-                            i, len(heading)
-                        )  # in case more headings than there are columns of data
+                        col_width = column_widths.get(i, len(heading))  # in case more headings than there are columns of data
                         width = max(
                             col_width * _char_width_in_pixels(font),
                             len(heading) * _char_width_in_pixels(element.HeaderFont),
@@ -21124,20 +19629,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.Widget.bind('<Enter>', lambda event, em=element: testMouseHook(em))
                     element.Widget.bind('<Leave>', lambda event, em=element: testMouseUnhook(em))
 
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element.TKTreeview.pack(side=tk.LEFT, padx=0, pady=0, expand=expand, fill=fill)
                 frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
-                    element._pack_forget_save_settings(
-                        alternate_widget=element.element_frame
-                    )  # seems like it should be the frame if following other elements conventions
+                    element._pack_forget_save_settings(alternate_widget=element.element_frame)  # seems like it should be the frame if following other elements conventions
                     # element.TKTreeview.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(
-                        element.TKTreeview, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKTreeview, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 _add_right_click_menu_and_grab(element)
 
                 if tclversion_detailed == '8.6.9' and ENABLE_TREEVIEW_869_PATCH:
@@ -21258,9 +19757,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 _change_ttk_theme(tree_style, toplevel_form.TtkTheme)
 
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
-                    tree_style.configure(
-                        style_name, background=element.BackgroundColor, fieldbackground=element.BackgroundColor
-                    )
+                    tree_style.configure(style_name, background=element.BackgroundColor, fieldbackground=element.BackgroundColor)
                     if element.SelectedRowColors[1] is not None:
                         tree_style.map(
                             style_name,
@@ -21312,21 +19809,15 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.Widget.bind('<Enter>', lambda event, em=element: testMouseHook(em))
                     element.Widget.bind('<Leave>', lambda event, em=element: testMouseUnhook(em))
 
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
                 element.TKTreeview.pack(side=tk.LEFT, padx=0, pady=0, expand=expand, fill=fill)
                 element_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
-                    element._pack_forget_save_settings(
-                        alternate_widget=element.element_frame
-                    )  # seems like it should be the frame if following other elements conventions
+                    element._pack_forget_save_settings(alternate_widget=element.element_frame)  # seems like it should be the frame if following other elements conventions
                     # element.TKTreeview.pack_forget()
                 treeview.bind('<<TreeviewSelect>>', element._treeview_selected)
                 if element.Tooltip is not None:  # tooltip
-                    element.TooltipObject = ToolTip(
-                        element.TKTreeview, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
-                    )
+                    element.TooltipObject = ToolTip(element.TKTreeview, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
                 _add_right_click_menu_and_grab(element)
 
                 if tclversion_detailed == '8.6.9' and ENABLE_TREEVIEW_869_PATCH:
@@ -21353,9 +19844,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     orient=element.Orientation,
                 )
 
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
-                    element, row_should_expand, row_fill_direction
-                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
 
                 if element.Orientation.startswith('h'):
                     separator.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=tk.X, expand=True)
@@ -21379,9 +19868,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     style.configure(style_name, background=toplevel_form.TKroot['bg'])
                 size_grip.configure(style=style_name)
 
-                size_grip.pack(
-                    side=tk.BOTTOM, anchor='se', padx=elementpad[0], pady=elementpad[1], fill=tk.X, expand=True
-                )
+                size_grip.pack(side=tk.BOTTOM, anchor='se', padx=elementpad[0], pady=elementpad[1], fill=tk.X, expand=True)
                 # tricky part of sizegrip... it shouldn't cause the row to expand, but should expand and should add X axis if
                 # not already filling in that direction.  Otherwise, leaves things alone!
                 # row_should_expand = True
@@ -21413,11 +19900,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = (
-                    tk.LEFT
-                    if justification.startswith('l')
-                    else tk.CENTER if justification.startswith('c') else tk.RIGHT
-                )
+                justify = tk.LEFT if justification.startswith('l') else tk.CENTER if justification.startswith('c') else tk.RIGHT
                 anchor = tk.NW if justification.startswith('l') else tk.N if justification.startswith('c') else tk.NE
                 tktext_label = element.Widget = tk.Label(
                     tk_row_frame,
@@ -21515,7 +19998,7 @@ def _no_titlebar_setup(window):
                     print('* Applying Mac no_titlebar patch *')
                     window.TKroot.wm_overrideredirect(False)
     except Exception as e:
-        warnings.warn('** Problem setting no titlebar {} **'.format(e), UserWarning)
+        warnings.warn(f'** Problem setting no titlebar {e} **', UserWarning)
 
 
 def _convert_window_to_tk(window):
@@ -21534,7 +20017,7 @@ def _convert_window_to_tk(window):
 
     # ....................................... DONE creating and laying out window ..........................#
     if window._Size != (None, None):
-        master.geometry('%sx%s' % (window._Size[0], window._Size[1]))
+        master.geometry('{}x{}'.format(window._Size[0], window._Size[1]))
     screen_width = master.winfo_screenwidth()  # get window info to move to middle of screen
     screen_height = master.winfo_screenheight()
     if window.Location is not None:
@@ -21610,11 +20093,7 @@ def StartupTK(window):
     # If location is None, then there's no need to hide the window.  Let it build where it is going to end up being.
     if DEFAULT_HIDE_WINDOW_WHEN_CREATING is True and window.Location is not None:
         try:
-            if (
-                not running_mac()
-                or (running_mac() and not window.NoTitleBar)
-                or (running_mac() and window.NoTitleBar and not _mac_should_apply_notitlebar_patch())
-            ):
+            if not running_mac() or (running_mac() and not window.NoTitleBar) or (running_mac() and window.NoTitleBar and not _mac_should_apply_notitlebar_patch()):
 
                 root.attributes('-alpha', 0)  # hide window while building it. makes for smoother 'paint'
         except Exception as e:
@@ -21660,9 +20139,7 @@ def StartupTK(window):
             root.bind('<ButtonPress-1>', window._StartMoveGrabAnywhere)
             root.bind('<ButtonRelease-1>', window._StopMove)
             root.bind('<B1-Motion>', window._OnMotionGrabAnywhere)
-    if window.GrabAnywhereUsingControlKey is not False and not (
-        window.NonBlocking and window.GrabAnywhereUsingControlKey is not True
-    ):
+    if window.GrabAnywhereUsingControlKey is not False and not (window.NonBlocking and window.GrabAnywhereUsingControlKey is not True):
         root.bind('<Control-Button-1>', window._StartMoveUsingControlKey)
         root.bind('<Control-ButtonRelease-1>', window._StopMove)
         root.bind('<Control-B1-Motion>', window._OnMotionUsingControlKey)
@@ -21677,7 +20154,7 @@ def StartupTK(window):
         alpha_channel = 1 if window.AlphaChannel is None else window.AlphaChannel
         root.attributes('-alpha', alpha_channel)  # Make window visible again
     except Exception as e:
-        print('**** Error setting Alpha Channel to {} after window was created ****'.format(alpha_channel), e)
+        print(f'**** Error setting Alpha Channel to {alpha_channel} after window was created ****', e)
         # pass
 
     if window.ReturnKeyboardEvents and not window.NonBlocking:
@@ -21851,7 +20328,7 @@ METER_OK = True
 METER_STOPPED = False
 
 
-class _QuickMeter(object):
+class _QuickMeter:
     active_meters = {}
     exit_reasons = {}
 
@@ -21924,9 +20401,7 @@ class _QuickMeter(object):
         layout = []
         if self.orientation.lower().startswith('h'):
             col = []
-            col += [
-                [T(''.join(map(lambda x: str(x) + '\n', args)), key='-OPTMSG-')]
-            ]  # convert all *args into one string that can be updated
+            col += [[T(''.join(map(lambda x: str(x) + '\n', args)), key='-OPTMSG-')]]  # convert all *args into one string that can be updated
 
             col += [
                 [T('', size=(30, 10), key='-STATS-')],
@@ -21957,9 +20432,7 @@ class _QuickMeter(object):
             ]
             col2 = []
 
-            col2 += [
-                [T(''.join(map(lambda x: str(x) + '\n', args)), key='-OPTMSG-')]
-            ]  # convert all *args into one string that can be updated
+            col2 += [[T(''.join(map(lambda x: str(x) + '\n', args)), key='-OPTMSG-')]]  # convert all *args into one string that can be updated
 
             col2 += [[T('', size=(30, 10), key='-STATS-')]]
 
@@ -21985,16 +20458,10 @@ class _QuickMeter(object):
         self.max_value = max_value
         self.window.Element('-PROG-').UpdateBar(self.current_value, self.max_value)
         self.window.Element('-STATS-').Update('\n'.join(self.ComputeProgressStats()))
-        self.window.Element('-OPTMSG-').Update(
-            value=''.join(map(lambda x: str(x) + '\n', args))
-        )  # update the string with the args
+        self.window.Element('-OPTMSG-').Update(value=''.join(map(lambda x: str(x) + '\n', args)))  # update the string with the args
         event, values = self.window.read(timeout=0)
         if event in ('Cancel', None) or current_value >= max_value:
-            exit_reason = (
-                METER_REASON_CANCELLED
-                if event in ('Cancel', None)
-                else METER_REASON_REACHED_MAX if current_value >= max_value else METER_STOPPED
-            )
+            exit_reason = METER_REASON_CANCELLED if event in ('Cancel', None) else METER_REASON_REACHED_MAX if current_value >= max_value else METER_STOPPED
             self.window.close()
             del _QuickMeter.active_meters[self.key]
             _QuickMeter.exit_reasons[self.key] = exit_reason
@@ -22018,15 +20485,15 @@ class _QuickMeter(object):
         total_time = time_delta + datetime.timedelta(seconds=seconds_remaining)
         total_time_short = str(total_time).split('.')[0]
         self.stat_messages = [
-            '{} of {}'.format(self.current_value, self.max_value),
-            '{} %'.format(100 * self.current_value // self.max_value),
+            f'{self.current_value} of {self.max_value}',
+            f'{100 * self.current_value // self.max_value} %',
             '',
-            ' {:6.2f} Iterations per Second'.format(self.current_value / total_seconds),
-            ' {:6.2f} Seconds per Iteration'.format(total_seconds / (self.current_value if self.current_value else 1)),
+            f' {self.current_value / total_seconds:6.2f} Iterations per Second',
+            f' {total_seconds / (self.current_value if self.current_value else 1):6.2f} Seconds per Iteration',
             '',
-            '{} Elapsed Time'.format(time_delta_short),
-            '{} Time Remaining'.format(time_remaining_short),
-            '{} Estimated Total Time'.format(total_time_short),
+            f'{time_delta_short} Elapsed Time',
+            f'{time_remaining_short} Time Remaining',
+            f'{total_time_short} Estimated Total Time',
         ]
         return self.stat_messages
 
@@ -22352,9 +20819,7 @@ class _DebugWin:
             elif not paused and event == TIMEOUT_EVENT and not blocking:
                 break
             elif event == '-PAUSE-':
-                if (
-                    blocking or self.no_button
-                ):  # if blocking or shouldn't have been a button event, ignore the pause button entirely
+                if blocking or self.no_button:  # if blocking or shouldn't have been a button event, ignore the pause button entirely
                     continue
                 if paused:
                     self.window['-PAUSE-'].update(text='Pause')
@@ -23094,9 +21559,7 @@ def set_options(
         DEFAULT_PROGRESS_BAR_BORDER_WIDTH = progress_meter_border_depth
 
     if progress_meter_style is not None:
-        warnings.warn(
-            'You can no longer set a progress bar style. All ttk styles must be the same for the window', UserWarning
-        )
+        warnings.warn('You can no longer set a progress bar style. All ttk styles must be the same for the window', UserWarning)
         # DEFAULT_PROGRESS_BAR_STYLE = progress_meter_style
 
     if progress_meter_relief is not None:
@@ -23208,9 +21671,7 @@ def set_options(
         DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME = pysimplegui_settings_filename
 
     if pysimplegui_settings_filename is not None or pysimplegui_settings_filename is not None:
-        _pysimplegui_user_settings = UserSettings(
-            filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH
-        )
+        _pysimplegui_user_settings = UserSettings(filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH)
 
     if keep_on_top is not None:
         DEFAULT_KEEP_ON_TOP = keep_on_top
@@ -23289,2073 +21750,170 @@ def set_options(
 # Predefined settings that will change the colors and styles #
 # of the elements.                                           #
 ##############################################################
+# fmt: off
 LOOK_AND_FEEL_TABLE = {
-    'SystemDefault': {
-        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-        'TEXT': COLOR_SYSTEM_DEFAULT,
-        'INPUT': COLOR_SYSTEM_DEFAULT,
-        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-        'SCROLL': COLOR_SYSTEM_DEFAULT,
-        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-        'PROGRESS': COLOR_SYSTEM_DEFAULT,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'SystemDefaultForReal': {
-        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-        'TEXT': COLOR_SYSTEM_DEFAULT,
-        'INPUT': COLOR_SYSTEM_DEFAULT,
-        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-        'SCROLL': COLOR_SYSTEM_DEFAULT,
-        'BUTTON': COLOR_SYSTEM_DEFAULT,
-        'PROGRESS': COLOR_SYSTEM_DEFAULT,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'SystemDefault1': {
-        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-        'TEXT': COLOR_SYSTEM_DEFAULT,
-        'INPUT': COLOR_SYSTEM_DEFAULT,
-        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-        'SCROLL': COLOR_SYSTEM_DEFAULT,
-        'BUTTON': COLOR_SYSTEM_DEFAULT,
-        'PROGRESS': COLOR_SYSTEM_DEFAULT,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Material1': {
-        'BACKGROUND': '#E3F2FD',
-        'TEXT': '#000000',
-        'INPUT': '#86A8FF',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#86A8FF',
-        'BUTTON': ('#FFFFFF', '#5079D3'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 0,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#FF0266',
-        'ACCENT2': '#FF5C93',
-        'ACCENT3': '#C5003C',
-    },
-    'Material2': {
-        'BACKGROUND': '#FAFAFA',
-        'TEXT': '#000000',
-        'INPUT': '#004EA1',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#5EA7FF',
-        'BUTTON': ('#FFFFFF', '#0079D3'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 0,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#FF0266',
-        'ACCENT2': '#FF5C93',
-        'ACCENT3': '#C5003C',
-    },
-    'Reddit': {
-        'BACKGROUND': '#ffffff',
-        'TEXT': '#1a1a1b',
-        'INPUT': '#dae0e6',
-        'TEXT_INPUT': '#222222',
-        'SCROLL': '#a5a4a4',
-        'BUTTON': ('#FFFFFF', '#0079d3'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#ff5414',
-        'ACCENT2': '#33a8ff',
-        'ACCENT3': '#dbf0ff',
-    },
-    'Topanga': {
-        'BACKGROUND': '#282923',
-        'TEXT': '#E7DB74',
-        'INPUT': '#393a32',
-        'TEXT_INPUT': '#E7C855',
-        'SCROLL': '#E7C855',
-        'BUTTON': ('#E7C855', '#284B5A'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#c15226',
-        'ACCENT2': '#7a4d5f',
-        'ACCENT3': '#889743',
-    },
-    'GreenTan': {
-        'BACKGROUND': '#9FB8AD',
-        'TEXT': '#000000',
-        'INPUT': '#F7F3EC',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#F7F3EC',
-        'BUTTON': ('#FFFFFF', '#475841'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Dark': {
-        'BACKGROUND': '#404040',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#4D4D4D',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#707070',
-        'BUTTON': ('#FFFFFF', '#004F00'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightGreen': {
-        'BACKGROUND': '#B7CECE',
-        'TEXT': '#000000',
-        'INPUT': '#FDFFF7',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#FDFFF7',
-        'BUTTON': ('#FFFFFF', '#658268'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'ACCENT1': '#76506d',
-        'ACCENT2': '#5148f1',
-        'ACCENT3': '#0a1c84',
-        'PROGRESS_DEPTH': 0,
-    },
-    'Dark2': {
-        'BACKGROUND': '#404040',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#FFFFFF',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#707070',
-        'BUTTON': ('#FFFFFF', '#004F00'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Black': {
-        'BACKGROUND': '#000000',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#4D4D4D',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#707070',
-        'BUTTON': ('#000000', '#FFFFFF'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Black2': {
-        'BACKGROUND': '#000000',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#000000',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#FFFFFF',
-        'BUTTON': ('#000000', '#FFFFFF'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Tan': {
-        'BACKGROUND': '#fdf6e3',
-        'TEXT': '#268bd1',
-        'INPUT': '#eee8d5',
-        'TEXT_INPUT': '#6c71c3',
-        'SCROLL': '#eee8d5',
-        'BUTTON': ('#FFFFFF', '#063542'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'TanBlue': {
-        'BACKGROUND': '#e5dece',
-        'TEXT': '#063289',
-        'INPUT': '#f9f8f4',
-        'TEXT_INPUT': '#242834',
-        'SCROLL': '#eee8d5',
-        'BUTTON': ('#FFFFFF', '#063289'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkTanBlue': {
-        'BACKGROUND': '#242834',
-        'TEXT': '#dfe6f8',
-        'INPUT': '#97755c',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#a9afbb',
-        'BUTTON': ('#FFFFFF', '#063289'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkAmber': {
-        'BACKGROUND': '#2c2825',
-        'TEXT': '#fdcb52',
-        'INPUT': '#705e52',
-        'TEXT_INPUT': '#fdcb52',
-        'SCROLL': '#705e52',
-        'BUTTON': ('#000000', '#fdcb52'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBlue': {
-        'BACKGROUND': '#1a2835',
-        'TEXT': '#d1ecff',
-        'INPUT': '#335267',
-        'TEXT_INPUT': '#acc2d0',
-        'SCROLL': '#1b6497',
-        'BUTTON': ('#000000', '#fafaf8'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Reds': {
-        'BACKGROUND': '#280001',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#d8d584',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#763e00',
-        'BUTTON': ('#000000', '#daad28'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Green': {
-        'BACKGROUND': '#82a459',
-        'TEXT': '#000000',
-        'INPUT': '#d8d584',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e3ecf3',
-        'BUTTON': ('#FFFFFF', '#517239'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'BluePurple': {
-        'BACKGROUND': '#A5CADD',
-        'TEXT': '#6E266E',
-        'INPUT': '#E0F5FF',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#E0F5FF',
-        'BUTTON': ('#FFFFFF', '#303952'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Purple': {
-        'BACKGROUND': '#B0AAC2',
-        'TEXT': '#000000',
-        'INPUT': '#F2EFE8',
-        'SCROLL': '#F2EFE8',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#000000', '#C2D4D8'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'BlueMono': {
-        'BACKGROUND': '#AAB6D3',
-        'TEXT': '#000000',
-        'INPUT': '#F1F4FC',
-        'SCROLL': '#F1F4FC',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#7186C7'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'GreenMono': {
-        'BACKGROUND': '#A8C1B4',
-        'TEXT': '#000000',
-        'INPUT': '#DDE0DE',
-        'SCROLL': '#E3E3E3',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#6D9F85'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'BrownBlue': {
-        'BACKGROUND': '#64778d',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#f0f3f7',
-        'SCROLL': '#A6B2BE',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#283b5b'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'BrightColors': {
-        'BACKGROUND': '#b4ffb4',
-        'TEXT': '#000000',
-        'INPUT': '#ffff64',
-        'SCROLL': '#ffb482',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#000000', '#ffa0dc'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'NeutralBlue': {
-        'BACKGROUND': '#92aa9d',
-        'TEXT': '#000000',
-        'INPUT': '#fcfff6',
-        'SCROLL': '#fcfff6',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#000000', '#d0dbbd'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Kayak': {
-        'BACKGROUND': '#a7ad7f',
-        'TEXT': '#000000',
-        'INPUT': '#e6d3a8',
-        'SCROLL': '#e6d3a8',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#5d907d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'SandyBeach': {
-        'BACKGROUND': '#efeccb',
-        'TEXT': '#012f2f',
-        'INPUT': '#e6d3a8',
-        'SCROLL': '#e6d3a8',
-        'TEXT_INPUT': '#012f2f',
-        'BUTTON': ('#FFFFFF', '#046380'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'TealMono': {
-        'BACKGROUND': '#a8cfdd',
-        'TEXT': '#000000',
-        'INPUT': '#dfedf2',
-        'SCROLL': '#dfedf2',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#183440'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Default': {
-        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-        'TEXT': COLOR_SYSTEM_DEFAULT,
-        'INPUT': COLOR_SYSTEM_DEFAULT,
-        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-        'SCROLL': COLOR_SYSTEM_DEFAULT,
-        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-        'PROGRESS': COLOR_SYSTEM_DEFAULT,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Default1': {
-        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-        'TEXT': COLOR_SYSTEM_DEFAULT,
-        'INPUT': COLOR_SYSTEM_DEFAULT,
-        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-        'SCROLL': COLOR_SYSTEM_DEFAULT,
-        'BUTTON': COLOR_SYSTEM_DEFAULT,
-        'PROGRESS': COLOR_SYSTEM_DEFAULT,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DefaultNoMoreNagging': {
-        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-        'TEXT': COLOR_SYSTEM_DEFAULT,
-        'INPUT': COLOR_SYSTEM_DEFAULT,
-        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-        'SCROLL': COLOR_SYSTEM_DEFAULT,
-        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-        'PROGRESS': COLOR_SYSTEM_DEFAULT,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'GrayGrayGray': {
-        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-        'TEXT': COLOR_SYSTEM_DEFAULT,
-        'INPUT': COLOR_SYSTEM_DEFAULT,
-        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-        'SCROLL': COLOR_SYSTEM_DEFAULT,
-        'BUTTON': COLOR_SYSTEM_DEFAULT,
-        'PROGRESS': COLOR_SYSTEM_DEFAULT,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBlue': {
-        'BACKGROUND': '#E3F2FD',
-        'TEXT': '#000000',
-        'INPUT': '#86A8FF',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#86A8FF',
-        'BUTTON': ('#FFFFFF', '#5079D3'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 0,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#FF0266',
-        'ACCENT2': '#FF5C93',
-        'ACCENT3': '#C5003C',
-    },
-    'LightGrey': {
-        'BACKGROUND': '#FAFAFA',
-        'TEXT': '#000000',
-        'INPUT': '#004EA1',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#5EA7FF',
-        'BUTTON': ('#FFFFFF', '#0079D3'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 0,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#FF0266',
-        'ACCENT2': '#FF5C93',
-        'ACCENT3': '#C5003C',
-    },
-    'LightGrey1': {
-        'BACKGROUND': '#ffffff',
-        'TEXT': '#1a1a1b',
-        'INPUT': '#dae0e6',
-        'TEXT_INPUT': '#222222',
-        'SCROLL': '#a5a4a4',
-        'BUTTON': ('#FFFFFF', '#0079d3'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#ff5414',
-        'ACCENT2': '#33a8ff',
-        'ACCENT3': '#dbf0ff',
-    },
-    'DarkBrown': {
-        'BACKGROUND': '#282923',
-        'TEXT': '#E7DB74',
-        'INPUT': '#393a32',
-        'TEXT_INPUT': '#E7C855',
-        'SCROLL': '#E7C855',
-        'BUTTON': ('#E7C855', '#284B5A'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'ACCENT1': '#c15226',
-        'ACCENT2': '#7a4d5f',
-        'ACCENT3': '#889743',
-    },
-    'LightGreen1': {
-        'BACKGROUND': '#9FB8AD',
-        'TEXT': '#000000',
-        'INPUT': '#F7F3EC',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#F7F3EC',
-        'BUTTON': ('#FFFFFF', '#475841'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey': {
-        'BACKGROUND': '#404040',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#4D4D4D',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#707070',
-        'BUTTON': ('#FFFFFF', '#004F00'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightGreen2': {
-        'BACKGROUND': '#B7CECE',
-        'TEXT': '#000000',
-        'INPUT': '#FDFFF7',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#FDFFF7',
-        'BUTTON': ('#FFFFFF', '#658268'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'ACCENT1': '#76506d',
-        'ACCENT2': '#5148f1',
-        'ACCENT3': '#0a1c84',
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey1': {
-        'BACKGROUND': '#404040',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#FFFFFF',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#707070',
-        'BUTTON': ('#FFFFFF', '#004F00'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBlack': {
-        'BACKGROUND': '#000000',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#4D4D4D',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#707070',
-        'BUTTON': ('#000000', '#FFFFFF'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBrown': {
-        'BACKGROUND': '#fdf6e3',
-        'TEXT': '#268bd1',
-        'INPUT': '#eee8d5',
-        'TEXT_INPUT': '#6c71c3',
-        'SCROLL': '#eee8d5',
-        'BUTTON': ('#FFFFFF', '#063542'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBrown1': {
-        'BACKGROUND': '#e5dece',
-        'TEXT': '#063289',
-        'INPUT': '#f9f8f4',
-        'TEXT_INPUT': '#242834',
-        'SCROLL': '#eee8d5',
-        'BUTTON': ('#FFFFFF', '#063289'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBlue1': {
-        'BACKGROUND': '#242834',
-        'TEXT': '#dfe6f8',
-        'INPUT': '#97755c',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#a9afbb',
-        'BUTTON': ('#FFFFFF', '#063289'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBrown1': {
-        'BACKGROUND': '#2c2825',
-        'TEXT': '#fdcb52',
-        'INPUT': '#705e52',
-        'TEXT_INPUT': '#fdcb52',
-        'SCROLL': '#705e52',
-        'BUTTON': ('#000000', '#fdcb52'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBlue2': {
-        'BACKGROUND': '#1a2835',
-        'TEXT': '#d1ecff',
-        'INPUT': '#335267',
-        'TEXT_INPUT': '#acc2d0',
-        'SCROLL': '#1b6497',
-        'BUTTON': ('#000000', '#fafaf8'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBrown2': {
-        'BACKGROUND': '#280001',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#d8d584',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#763e00',
-        'BUTTON': ('#000000', '#daad28'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGreen': {
-        'BACKGROUND': '#82a459',
-        'TEXT': '#000000',
-        'INPUT': '#d8d584',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e3ecf3',
-        'BUTTON': ('#FFFFFF', '#517239'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBlue1': {
-        'BACKGROUND': '#A5CADD',
-        'TEXT': '#6E266E',
-        'INPUT': '#E0F5FF',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#E0F5FF',
-        'BUTTON': ('#FFFFFF', '#303952'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightPurple': {
-        'BACKGROUND': '#B0AAC2',
-        'TEXT': '#000000',
-        'INPUT': '#F2EFE8',
-        'SCROLL': '#F2EFE8',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#000000', '#C2D4D8'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBlue2': {
-        'BACKGROUND': '#AAB6D3',
-        'TEXT': '#000000',
-        'INPUT': '#F1F4FC',
-        'SCROLL': '#F1F4FC',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#7186C7'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightGreen3': {
-        'BACKGROUND': '#A8C1B4',
-        'TEXT': '#000000',
-        'INPUT': '#DDE0DE',
-        'SCROLL': '#E3E3E3',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#6D9F85'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBlue3': {
-        'BACKGROUND': '#64778d',
-        'TEXT': '#FFFFFF',
-        'INPUT': '#f0f3f7',
-        'SCROLL': '#A6B2BE',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#283b5b'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightGreen4': {
-        'BACKGROUND': '#b4ffb4',
-        'TEXT': '#000000',
-        'INPUT': '#ffff64',
-        'SCROLL': '#ffb482',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#000000', '#ffa0dc'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightGreen5': {
-        'BACKGROUND': '#92aa9d',
-        'TEXT': '#000000',
-        'INPUT': '#fcfff6',
-        'SCROLL': '#fcfff6',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#000000', '#d0dbbd'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBrown2': {
-        'BACKGROUND': '#a7ad7f',
-        'TEXT': '#000000',
-        'INPUT': '#e6d3a8',
-        'SCROLL': '#e6d3a8',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#5d907d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBrown3': {
-        'BACKGROUND': '#efeccb',
-        'TEXT': '#012f2f',
-        'INPUT': '#e6d3a8',
-        'SCROLL': '#e6d3a8',
-        'TEXT_INPUT': '#012f2f',
-        'BUTTON': ('#FFFFFF', '#046380'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBlue3': {
-        'BACKGROUND': '#a8cfdd',
-        'TEXT': '#000000',
-        'INPUT': '#dfedf2',
-        'SCROLL': '#dfedf2',
-        'TEXT_INPUT': '#000000',
-        'BUTTON': ('#FFFFFF', '#183440'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'LightBrown4': {
-        'BACKGROUND': '#d7c79e',
-        'TEXT': '#a35638',
-        'INPUT': '#9dab86',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#a35638',
-        'BUTTON': ('#FFFFFF', '#a35638'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'],
-    },
-    'DarkTeal': {
-        'BACKGROUND': '#003f5c',
-        'TEXT': '#fb5b5a',
-        'INPUT': '#bc4873',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#bc4873',
-        'BUTTON': ('#FFFFFF', '#fb5b5a'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
-    },
-    'DarkPurple': {
-        'BACKGROUND': '#472b62',
-        'TEXT': '#fb5b5a',
-        'INPUT': '#bc4873',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#bc4873',
-        'BUTTON': ('#FFFFFF', '#472b62'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
-    },
-    'LightGreen6': {
-        'BACKGROUND': '#eafbea',
-        'TEXT': '#1f6650',
-        'INPUT': '#6f9a8d',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#1f6650',
-        'BUTTON': ('#FFFFFF', '#1f6650'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'],
-    },
-    'DarkGrey2': {
-        'BACKGROUND': '#2b2b28',
-        'TEXT': '#f8f8f8',
-        'INPUT': '#f1d6ab',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#f1d6ab',
-        'BUTTON': ('#2b2b28', '#e3b04b'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'],
-    },
-    'LightBrown6': {
-        'BACKGROUND': '#f9b282',
-        'TEXT': '#8f4426',
-        'INPUT': '#de6b35',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#8f4426',
-        'BUTTON': ('#FFFFFF', '#8f4426'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'],
-    },
-    'DarkTeal1': {
-        'BACKGROUND': '#396362',
-        'TEXT': '#ffe7d1',
-        'INPUT': '#f6c89f',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#f6c89f',
-        'BUTTON': ('#ffe7d1', '#4b8e8d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
-    },
-    'LightBrown7': {
-        'BACKGROUND': '#f6c89f',
-        'TEXT': '#396362',
-        'INPUT': '#4b8e8d',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#396362',
-        'BUTTON': ('#FFFFFF', '#396362'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
-    },
-    'DarkPurple1': {
-        'BACKGROUND': '#0c093c',
-        'TEXT': '#fad6d6',
-        'INPUT': '#eea5f6',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#eea5f6',
-        'BUTTON': ('#FFFFFF', '#df42d1'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'],
-    },
-    'DarkGrey3': {
-        'BACKGROUND': '#211717',
-        'TEXT': '#dfddc7',
-        'INPUT': '#f58b54',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#f58b54',
-        'BUTTON': ('#dfddc7', '#a34a28'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
-    },
-    'LightBrown8': {
-        'BACKGROUND': '#dfddc7',
-        'TEXT': '#211717',
-        'INPUT': '#a34a28',
-        'TEXT_INPUT': '#dfddc7',
-        'SCROLL': '#211717',
-        'BUTTON': ('#dfddc7', '#a34a28'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
-    },
-    'DarkBlue4': {
-        'BACKGROUND': '#494ca2',
-        'TEXT': '#e3e7f1',
-        'INPUT': '#c6cbef',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#c6cbef',
-        'BUTTON': ('#FFFFFF', '#8186d5'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'],
-    },
-    'LightBlue4': {
-        'BACKGROUND': '#5c94bd',
-        'TEXT': '#470938',
-        'INPUT': '#1a3e59',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#470938',
-        'BUTTON': ('#FFFFFF', '#470938'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'],
-    },
-    'DarkTeal2': {
-        'BACKGROUND': '#394a6d',
-        'TEXT': '#c0ffb3',
-        'INPUT': '#52de97',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#52de97',
-        'BUTTON': ('#c0ffb3', '#394a6d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
-    },
-    'DarkTeal3': {
-        'BACKGROUND': '#3c9d9b',
-        'TEXT': '#c0ffb3',
-        'INPUT': '#52de97',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#52de97',
-        'BUTTON': ('#c0ffb3', '#394a6d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
-    },
-    'DarkPurple5': {
-        'BACKGROUND': '#730068',
-        'TEXT': '#f6f078',
-        'INPUT': '#01d28e',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#01d28e',
-        'BUTTON': ('#f6f078', '#730068'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'],
-    },
-    'DarkPurple2': {
-        'BACKGROUND': '#202060',
-        'TEXT': '#b030b0',
-        'INPUT': '#602080',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#602080',
-        'BUTTON': ('#FFFFFF', '#202040'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'],
-    },
-    'DarkBlue5': {
-        'BACKGROUND': '#000272',
-        'TEXT': '#ff6363',
-        'INPUT': '#a32f80',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#a32f80',
-        'BUTTON': ('#FFFFFF', '#341677'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'],
-    },
-    'LightGrey2': {
-        'BACKGROUND': '#f6f6f6',
-        'TEXT': '#420000',
-        'INPUT': '#d4d7dd',
-        'TEXT_INPUT': '#420000',
-        'SCROLL': '#420000',
-        'BUTTON': ('#420000', '#d4d7dd'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
-    },
-    'LightGrey3': {
-        'BACKGROUND': '#eae9e9',
-        'TEXT': '#420000',
-        'INPUT': '#d4d7dd',
-        'TEXT_INPUT': '#420000',
-        'SCROLL': '#420000',
-        'BUTTON': ('#420000', '#d4d7dd'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
-    },
-    'DarkBlue6': {
-        'BACKGROUND': '#01024e',
-        'TEXT': '#ff6464',
-        'INPUT': '#8b4367',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#8b4367',
-        'BUTTON': ('#FFFFFF', '#543864'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'],
-    },
-    'DarkBlue7': {
-        'BACKGROUND': '#241663',
-        'TEXT': '#eae7af',
-        'INPUT': '#a72693',
-        'TEXT_INPUT': '#eae7af',
-        'SCROLL': '#a72693',
-        'BUTTON': ('#eae7af', '#160f30'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'],
-    },
-    'LightBrown9': {
-        'BACKGROUND': '#f6d365',
-        'TEXT': '#3a1f5d',
-        'INPUT': '#c83660',
-        'TEXT_INPUT': '#f6d365',
-        'SCROLL': '#3a1f5d',
-        'BUTTON': ('#f6d365', '#c83660'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'],
-    },
-    'DarkPurple3': {
-        'BACKGROUND': '#6e2142',
-        'TEXT': '#ffd692',
-        'INPUT': '#e16363',
-        'TEXT_INPUT': '#ffd692',
-        'SCROLL': '#e16363',
-        'BUTTON': ('#ffd692', '#943855'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
-    },
-    'LightBrown10': {
-        'BACKGROUND': '#ffd692',
-        'TEXT': '#6e2142',
-        'INPUT': '#943855',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#6e2142',
-        'BUTTON': ('#FFFFFF', '#6e2142'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
-    },
-    'DarkPurple4': {
-        'BACKGROUND': '#200f21',
-        'TEXT': '#f638dc',
-        'INPUT': '#5a3d5c',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#5a3d5c',
-        'BUTTON': ('#FFFFFF', '#382039'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'],
-    },
-    'LightBlue5': {
-        'BACKGROUND': '#b2fcff',
-        'TEXT': '#3e64ff',
-        'INPUT': '#5edfff',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#3e64ff',
-        'BUTTON': ('#FFFFFF', '#3e64ff'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'],
-    },
-    'DarkTeal4': {
-        'BACKGROUND': '#464159',
-        'TEXT': '#c7f0db',
-        'INPUT': '#8bbabb',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#8bbabb',
-        'BUTTON': ('#FFFFFF', '#6c7b95'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
-    },
-    'LightTeal': {
-        'BACKGROUND': '#c7f0db',
-        'TEXT': '#464159',
-        'INPUT': '#6c7b95',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#464159',
-        'BUTTON': ('#FFFFFF', '#464159'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
-    },
-    'DarkTeal5': {
-        'BACKGROUND': '#8bbabb',
-        'TEXT': '#464159',
-        'INPUT': '#6c7b95',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#464159',
-        'BUTTON': ('#c7f0db', '#6c7b95'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
-    },
-    'LightGrey4': {
-        'BACKGROUND': '#faf5ef',
-        'TEXT': '#672f2f',
-        'INPUT': '#99b19c',
-        'TEXT_INPUT': '#672f2f',
-        'SCROLL': '#672f2f',
-        'BUTTON': ('#672f2f', '#99b19c'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
-    },
-    'LightGreen7': {
-        'BACKGROUND': '#99b19c',
-        'TEXT': '#faf5ef',
-        'INPUT': '#d7d1c9',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#d7d1c9',
-        'BUTTON': ('#FFFFFF', '#99b19c'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
-    },
-    'LightGrey5': {
-        'BACKGROUND': '#d7d1c9',
-        'TEXT': '#672f2f',
-        'INPUT': '#99b19c',
-        'TEXT_INPUT': '#672f2f',
-        'SCROLL': '#672f2f',
-        'BUTTON': ('#FFFFFF', '#672f2f'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
-    },
-    'DarkBrown3': {
-        'BACKGROUND': '#a0855b',
-        'TEXT': '#f9f6f2',
-        'INPUT': '#f1d6ab',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#f1d6ab',
-        'BUTTON': ('#FFFFFF', '#38470b'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
-    },
-    'LightBrown11': {
-        'BACKGROUND': '#f1d6ab',
-        'TEXT': '#38470b',
-        'INPUT': '#a0855b',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#38470b',
-        'BUTTON': ('#f9f6f2', '#a0855b'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
-    },
-    'DarkRed': {
-        'BACKGROUND': '#83142c',
-        'TEXT': '#f9d276',
-        'INPUT': '#ad1d45',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#ad1d45',
-        'BUTTON': ('#f9d276', '#ad1d45'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'],
-    },
-    'DarkTeal6': {
-        'BACKGROUND': '#204969',
-        'TEXT': '#fff7f7',
-        'INPUT': '#dadada',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#dadada',
-        'BUTTON': ('#000000', '#fff7f7'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'],
-    },
-    'DarkBrown4': {
-        'BACKGROUND': '#252525',
-        'TEXT': '#ff0000',
-        'INPUT': '#af0404',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#af0404',
-        'BUTTON': ('#FFFFFF', '#252525'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'],
-    },
-    'LightYellow': {
-        'BACKGROUND': '#f4ff61',
-        'TEXT': '#27aa80',
-        'INPUT': '#32ff6a',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#27aa80',
-        'BUTTON': ('#f4ff61', '#27aa80'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'],
-    },
-    'DarkGreen1': {
-        'BACKGROUND': '#2b580c',
-        'TEXT': '#fdef96',
-        'INPUT': '#f7b71d',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#f7b71d',
-        'BUTTON': ('#fdef96', '#2b580c'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'],
-    },
-    'LightGreen8': {
-        'BACKGROUND': '#c8dad3',
-        'TEXT': '#63707e',
-        'INPUT': '#93b5b3',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#63707e',
-        'BUTTON': ('#FFFFFF', '#63707e'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'],
-    },
-    'DarkTeal7': {
-        'BACKGROUND': '#248ea9',
-        'TEXT': '#fafdcb',
-        'INPUT': '#aee7e8',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#aee7e8',
-        'BUTTON': ('#000000', '#fafdcb'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'],
-    },
-    'DarkBlue8': {
-        'BACKGROUND': '#454d66',
-        'TEXT': '#d9d872',
-        'INPUT': '#58b368',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#58b368',
-        'BUTTON': ('#000000', '#009975'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'],
-    },
-    'DarkBlue9': {
-        'BACKGROUND': '#263859',
-        'TEXT': '#ff6768',
-        'INPUT': '#6b778d',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#6b778d',
-        'BUTTON': ('#ff6768', '#263859'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'],
-    },
-    'DarkBlue10': {
-        'BACKGROUND': '#0028ff',
-        'TEXT': '#f1f4df',
-        'INPUT': '#10eaf0',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#10eaf0',
-        'BUTTON': ('#f1f4df', '#24009c'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'],
-    },
-    'DarkBlue11': {
-        'BACKGROUND': '#6384b3',
-        'TEXT': '#e6f0b6',
-        'INPUT': '#b8e9c0',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#b8e9c0',
-        'BUTTON': ('#e6f0b6', '#684949'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'],
-    },
-    'DarkTeal8': {
-        'BACKGROUND': '#71a0a5',
-        'TEXT': '#212121',
-        'INPUT': '#665c84',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#212121',
-        'BUTTON': ('#fab95b', '#665c84'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'],
-    },
-    'DarkRed1': {
-        'BACKGROUND': '#c10000',
-        'TEXT': '#eeeeee',
-        'INPUT': '#dedede',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#dedede',
-        'BUTTON': ('#c10000', '#eeeeee'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'],
-    },
-    'LightBrown5': {
-        'BACKGROUND': '#fff591',
-        'TEXT': '#e41749',
-        'INPUT': '#f5587b',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e41749',
-        'BUTTON': ('#fff591', '#e41749'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'],
-    },
-    'LightGreen9': {
-        'BACKGROUND': '#f1edb3',
-        'TEXT': '#3b503d',
-        'INPUT': '#4a746e',
-        'TEXT_INPUT': '#f1edb3',
-        'SCROLL': '#3b503d',
-        'BUTTON': ('#f1edb3', '#3b503d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
-        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
-    },
-    'DarkGreen2': {
-        'BACKGROUND': '#3b503d',
-        'TEXT': '#f1edb3',
-        'INPUT': '#c8cf94',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#c8cf94',
-        'BUTTON': ('#f1edb3', '#3b503d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
-        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
-    },
-    'LightGray1': {
-        'BACKGROUND': '#f2f2f2',
-        'TEXT': '#222831',
-        'INPUT': '#393e46',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#222831',
-        'BUTTON': ('#f2f2f2', '#222831'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],
-        'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn'],
-    },
-    'DarkGrey4': {
-        'BACKGROUND': '#52524e',
-        'TEXT': '#e9e9e5',
-        'INPUT': '#d4d6c8',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#d4d6c8',
-        'BUTTON': ('#FFFFFF', '#9a9b94'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],
-        'DESCRIPTION': ['Grey', 'Pastel', 'Winter'],
-    },
-    'DarkBlue12': {
-        'BACKGROUND': '#324e7b',
-        'TEXT': '#f8f8f8',
-        'INPUT': '#86a6df',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#86a6df',
-        'BUTTON': ('#FFFFFF', '#5068a9'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],
-        'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'],
-    },
-    'DarkPurple6': {
-        'BACKGROUND': '#070739',
-        'TEXT': '#e1e099',
-        'INPUT': '#c327ab',
-        'TEXT_INPUT': '#e1e099',
-        'SCROLL': '#c327ab',
-        'BUTTON': ('#e1e099', '#521477'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],
-        'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark'],
-    },
-    'DarkPurple7': {
-        'BACKGROUND': '#191930',
-        'TEXT': '#B1B7C5',
-        'INPUT': '#232B5C',
-        'TEXT_INPUT': '#D0E3E7',
-        'SCROLL': '#B1B7C5',
-        'BUTTON': ('#272D38', '#B1B7C5'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBlue13': {
-        'BACKGROUND': '#203562',
-        'TEXT': '#e3e8f8',
-        'INPUT': '#c0c5cd',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#c0c5cd',
-        'BUTTON': ('#FFFFFF', '#3e588f'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],
-        'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'],
-    },
-    'DarkBrown5': {
-        'BACKGROUND': '#3c1b1f',
-        'TEXT': '#f6e1b5',
-        'INPUT': '#e2bf81',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e2bf81',
-        'BUTTON': ('#3c1b1f', '#f6e1b5'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],
-        'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'],
-    },
-    'DarkGreen3': {
-        'BACKGROUND': '#062121',
-        'TEXT': '#eeeeee',
-        'INPUT': '#e4dcad',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e4dcad',
-        'BUTTON': ('#eeeeee', '#181810'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
-        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
-    },
-    'DarkBlack1': {
-        'BACKGROUND': '#181810',
-        'TEXT': '#eeeeee',
-        'INPUT': '#e4dcad',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e4dcad',
-        'BUTTON': ('#FFFFFF', '#062121'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
-        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
-    },
-    'DarkGrey5': {
-        'BACKGROUND': '#343434',
-        'TEXT': '#f3f3f3',
-        'INPUT': '#e9dcbe',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e9dcbe',
-        'BUTTON': ('#FFFFFF', '#8e8b82'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
-        'DESCRIPTION': ['Grey', 'Brown'],
-    },
-    'LightBrown12': {
-        'BACKGROUND': '#8e8b82',
-        'TEXT': '#f3f3f3',
-        'INPUT': '#e9dcbe',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e9dcbe',
-        'BUTTON': ('#f3f3f3', '#8e8b82'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
-        'DESCRIPTION': ['Grey', 'Brown'],
-    },
-    'DarkTeal9': {
-        'BACKGROUND': '#13445a',
-        'TEXT': '#fef4e8',
-        'INPUT': '#446878',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#446878',
-        'BUTTON': ('#fef4e8', '#446878'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],
-        'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'],
-    },
-    'DarkBlue14': {
-        'BACKGROUND': '#21273d',
-        'TEXT': '#f1f6f8',
-        'INPUT': '#b9d4f1',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#b9d4f1',
-        'BUTTON': ('#FFFFFF', '#6a759b'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
-        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
-    },
-    'LightBlue6': {
-        'BACKGROUND': '#f1f6f8',
-        'TEXT': '#21273d',
-        'INPUT': '#6a759b',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#21273d',
-        'BUTTON': ('#f1f6f8', '#6a759b'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
-        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
-    },
-    'DarkGreen4': {
-        'BACKGROUND': '#044343',
-        'TEXT': '#e4e4e4',
-        'INPUT': '#045757',
-        'TEXT_INPUT': '#e4e4e4',
-        'SCROLL': '#045757',
-        'BUTTON': ('#e4e4e4', '#045757'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],
-        'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark'],
-    },
-    'DarkGreen5': {
-        'BACKGROUND': '#1b4b36',
-        'TEXT': '#e0e7f1',
-        'INPUT': '#aebd77',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#aebd77',
-        'BUTTON': ('#FFFFFF', '#538f6a'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'],
-        'DESCRIPTION': ['Green', 'Grey'],
-    },
-    'DarkTeal10': {
-        'BACKGROUND': '#0d3446',
-        'TEXT': '#d8dfe2',
-        'INPUT': '#71adb5',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#71adb5',
-        'BUTTON': ('#FFFFFF', '#176d81'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],
-        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'],
-    },
-    'DarkGrey6': {
-        'BACKGROUND': '#3e3e3e',
-        'TEXT': '#ededed',
-        'INPUT': '#68868c',
-        'TEXT_INPUT': '#ededed',
-        'SCROLL': '#68868c',
-        'BUTTON': ('#FFFFFF', '#405559'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
-        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
-    },
-    'DarkTeal11': {
-        'BACKGROUND': '#405559',
-        'TEXT': '#ededed',
-        'INPUT': '#68868c',
-        'TEXT_INPUT': '#ededed',
-        'SCROLL': '#68868c',
-        'BUTTON': ('#ededed', '#68868c'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
-        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
-    },
-    'LightBlue7': {
-        'BACKGROUND': '#9ed0e0',
-        'TEXT': '#19483f',
-        'INPUT': '#5c868e',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#19483f',
-        'BUTTON': ('#FFFFFF', '#19483f'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],
-        'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'],
-    },
-    'LightGreen10': {
-        'BACKGROUND': '#d8ebb5',
-        'TEXT': '#205d67',
-        'INPUT': '#639a67',
-        'TEXT_INPUT': '#FFFFFF',
-        'SCROLL': '#205d67',
-        'BUTTON': ('#d8ebb5', '#205d67'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],
-        'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'],
-    },
-    'DarkBlue15': {
-        'BACKGROUND': '#151680',
-        'TEXT': '#f1fea4',
-        'INPUT': '#375fc0',
-        'TEXT_INPUT': '#f1fea4',
-        'SCROLL': '#375fc0',
-        'BUTTON': ('#f1fea4', '#1c44ac'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
-        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
-    },
-    'DarkBlue16': {
-        'BACKGROUND': '#1c44ac',
-        'TEXT': '#f1fea4',
-        'INPUT': '#375fc0',
-        'TEXT_INPUT': '#f1fea4',
-        'SCROLL': '#375fc0',
-        'BUTTON': ('#f1fea4', '#151680'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
-        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
-    },
-    'DarkTeal12': {
-        'BACKGROUND': '#004a7c',
-        'TEXT': '#fafafa',
-        'INPUT': '#e8f1f5',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#e8f1f5',
-        'BUTTON': ('#fafafa', '#005691'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],
-        'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'],
-    },
-    'LightBrown13': {
-        'BACKGROUND': '#ebf5ee',
-        'TEXT': '#921224',
-        'INPUT': '#bdc6b8',
-        'TEXT_INPUT': '#921224',
-        'SCROLL': '#921224',
-        'BUTTON': ('#FFFFFF', '#921224'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],
-        'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'],
-    },
-    'DarkBlue17': {
-        'BACKGROUND': '#21294c',
-        'TEXT': '#f9f2d7',
-        'INPUT': '#f2dea8',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#f2dea8',
-        'BUTTON': ('#f9f2d7', '#141829'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
-        'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],
-    },
-    'DarkBlue18': {
-        'BACKGROUND': '#0c1825',
-        'TEXT': '#d1d7dd',
-        'INPUT': '#001c35',
-        'TEXT_INPUT': '#d1d7dd',
-        'SCROLL': '#00438e',
-        'BUTTON': ('#75b7ff', '#001c35'),
-        'PROGRESS': ('#0074ff', '#75b7ff'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
-        'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],
-    },
-    'DarkBrown6': {
-        'BACKGROUND': '#785e4d',
-        'TEXT': '#f2eee3',
-        'INPUT': '#baaf92',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#baaf92',
-        'BUTTON': ('#FFFFFF', '#785e4d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],
-        'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'],
-    },
-    'DarkGreen6': {
-        'BACKGROUND': '#5c715e',
-        'TEXT': '#f2f9f1',
-        'INPUT': '#ddeedf',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#ddeedf',
-        'BUTTON': ('#f2f9f1', '#5c715e'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],
-        'DESCRIPTION': ['Grey', 'Green', 'Vintage'],
-    },
-    'DarkGreen7': {
-        'BACKGROUND': '#0C231E',
-        'TEXT': '#efbe1c',
-        'INPUT': '#153C33',
-        'TEXT_INPUT': '#efbe1c',
-        'SCROLL': '#153C33',
-        'BUTTON': ('#efbe1c', '#153C33'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey7': {
-        'BACKGROUND': '#4b586e',
-        'TEXT': '#dddddd',
-        'INPUT': '#574e6d',
-        'TEXT_INPUT': '#dddddd',
-        'SCROLL': '#574e6d',
-        'BUTTON': ('#dddddd', '#43405d'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],
-        'DESCRIPTION': ['Grey', 'Winter', 'Cold'],
-    },
-    'DarkRed2': {
-        'BACKGROUND': '#ab1212',
-        'TEXT': '#f6e4b5',
-        'INPUT': '#cd3131',
-        'TEXT_INPUT': '#f6e4b5',
-        'SCROLL': '#cd3131',
-        'BUTTON': ('#f6e4b5', '#ab1212'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],
-        'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'],
-    },
-    'LightGrey6': {
-        'BACKGROUND': '#e3e3e3',
-        'TEXT': '#233142',
-        'INPUT': '#455d7a',
-        'TEXT_INPUT': '#e3e3e3',
-        'SCROLL': '#233142',
-        'BUTTON': ('#e3e3e3', '#455d7a'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-        'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],
-        'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey'],
-    },
-    'HotDogStand': {
-        'BACKGROUND': 'red',
-        'TEXT': 'yellow',
-        'INPUT': 'yellow',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': 'yellow',
-        'BUTTON': ('red', 'yellow'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey8': {
-        'BACKGROUND': '#19232D',
-        'TEXT': '#ffffff',
-        'INPUT': '#32414B',
-        'TEXT_INPUT': '#ffffff',
-        'SCROLL': '#505F69',
-        'BUTTON': ('#ffffff', '#32414B'),
-        'PROGRESS': ('#505F69', '#32414B'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey9': {
-        'BACKGROUND': '#36393F',
-        'TEXT': '#DCDDDE',
-        'INPUT': '#40444B',
-        'TEXT_INPUT': '#ffffff',
-        'SCROLL': '#202225',
-        'BUTTON': ('#202225', '#B9BBBE'),
-        'PROGRESS': ('#202225', '#40444B'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey10': {
-        'BACKGROUND': '#1c1e23',
-        'TEXT': '#cccdcf',
-        'INPUT': '#272a31',
-        'TEXT_INPUT': '#8b9fde',
-        'SCROLL': '#313641',
-        'BUTTON': ('#f5f5f6', '#2e3d5a'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey11': {
-        'BACKGROUND': '#1c1e23',
-        'TEXT': '#cccdcf',
-        'INPUT': '#313641',
-        'TEXT_INPUT': '#cccdcf',
-        'SCROLL': '#313641',
-        'BUTTON': ('#f5f5f6', '#313641'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey12': {
-        'BACKGROUND': '#1c1e23',
-        'TEXT': '#8b9fde',
-        'INPUT': '#313641',
-        'TEXT_INPUT': '#8b9fde',
-        'SCROLL': '#313641',
-        'BUTTON': ('#cccdcf', '#2e3d5a'),
-        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey13': {
-        'BACKGROUND': '#1c1e23',
-        'TEXT': '#cccdcf',
-        'INPUT': '#272a31',
-        'TEXT_INPUT': '#cccdcf',
-        'SCROLL': '#313641',
-        'BUTTON': ('#8b9fde', '#313641'),
-        'PROGRESS': ('#cccdcf', '#272a31'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey14': {
-        'BACKGROUND': '#24292e',
-        'TEXT': '#fafbfc',
-        'INPUT': '#1d2125',
-        'TEXT_INPUT': '#fafbfc',
-        'SCROLL': '#1d2125',
-        'BUTTON': ('#fafbfc', '#155398'),
-        'PROGRESS': ('#155398', '#1d2125'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey15': {
-        'BACKGROUND': '#121212',
-        'TEXT': '#dddddd',
-        'INPUT': '#1e1e1e',
-        'TEXT_INPUT': '#69b1ef',
-        'SCROLL': '#272727',
-        'BUTTON': ('#69b1ef', '#2e2e2e'),
-        'PROGRESS': ('#69b1ef', '#2e2e2e'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkGrey16': {
-        'BACKGROUND': '#353535',
-        'TEXT': '#ffffff',
-        'INPUT': '#191919',
-        'TEXT_INPUT': '#ffffff',
-        'SCROLL': '#454545',
-        'BUTTON': ('#ffffff', '#454545'),
-        'PROGRESS': ('#757575', '#454545'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'DarkBrown7': {
-        'BACKGROUND': '#2c2417',
-        'TEXT': '#baa379',
-        'INPUT': '#baa379',
-        'TEXT_INPUT': '#000000',
-        'SCROLL': '#392e1c',
-        'BUTTON': ('#000000', '#baa379'),
-        'PROGRESS': ('#baa379', '#453923'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'Python': {
-        'BACKGROUND': '#3d7aab',
-        'TEXT': '#ffde56',
-        'INPUT': '#295273',
-        'TEXT_INPUT': '#ffde56',
-        'SCROLL': '#295273',
-        'BUTTON': ('#ffde56', '#295273'),
-        'PROGRESS': ('#ffde56', '#295273'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'PythonPlus': {
-        'BACKGROUND': '#001d3c',
-        'TEXT': '#ffffff',
-        'INPUT': '#015bbb',
-        'TEXT_INPUT': '#fed500',
-        'SCROLL': '#015bbb',
-        'BUTTON': ('#fed500', '#015bbb'),
-        'PROGRESS': ('#015bbb', '#fed500'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 1,
-        'PROGRESS_DEPTH': 0,
-    },
-    'NeonBlue1': {
-        'BACKGROUND': '#000000',
-        'TEXT': '#ffffff',
-        'INPUT': '#000000',
-        'TEXT_INPUT': '#33ccff',
-        'SCROLL': '#33ccff',
-        'BUTTON': ('#33ccff', '#000000'),
-        'PROGRESS': ('#33ccff', '#ffffff'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'NeonGreen1': {
-        'BACKGROUND': '#000000',
-        'TEXT': '#ffffff',
-        'INPUT': '#000000',
-        'TEXT_INPUT': '#96ff7b',
-        'SCROLL': '#96ff7b',
-        'BUTTON': ('#96ff7b', '#000000'),
-        'PROGRESS': ('#96ff7b', '#ffffff'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
-    'NeonYellow1': {
-        'BACKGROUND': '#000000',
-        'TEXT': '#ffffff',
-        'INPUT': '#000000',
-        'TEXT_INPUT': '#ffcf40',
-        'SCROLL': '#ffcf40',
-        'BUTTON': ('#ffcf40', '#000000'),
-        'PROGRESS': ('#ffcf40', '#ffffff'),
-        'BORDER': 1,
-        'SLIDER_DEPTH': 0,
-        'PROGRESS_DEPTH': 0,
-    },
+    'SystemDefault': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'SystemDefaultForReal': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': COLOR_SYSTEM_DEFAULT,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'SystemDefault1': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': COLOR_SYSTEM_DEFAULT,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'Material1': {'BACKGROUND': '#E3F2FD','TEXT': '#000000','INPUT': '#86A8FF','TEXT_INPUT': '#000000','SCROLL': '#86A8FF','BUTTON': ('#FFFFFF', '#5079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
+    'Material2': {'BACKGROUND': '#FAFAFA','TEXT': '#000000','INPUT': '#004EA1','TEXT_INPUT': '#FFFFFF','SCROLL': '#5EA7FF','BUTTON': ('#FFFFFF', '#0079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
+    'Reddit': {'BACKGROUND': '#ffffff','TEXT': '#1a1a1b','INPUT': '#dae0e6','TEXT_INPUT': '#222222','SCROLL': '#a5a4a4','BUTTON': ('#FFFFFF', '#0079d3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#ff5414','ACCENT2': '#33a8ff','ACCENT3': '#dbf0ff',},
+    'Topanga': {'BACKGROUND': '#282923','TEXT': '#E7DB74','INPUT': '#393a32','TEXT_INPUT': '#E7C855','SCROLL': '#E7C855','BUTTON': ('#E7C855', '#284B5A'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#c15226','ACCENT2': '#7a4d5f','ACCENT3': '#889743',},
+    'GreenTan': {'BACKGROUND': '#9FB8AD','TEXT': '#000000','INPUT': '#F7F3EC','TEXT_INPUT': '#000000','SCROLL': '#F7F3EC','BUTTON': ('#FFFFFF', '#475841'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Dark': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightGreen': {'BACKGROUND': '#B7CECE','TEXT': '#000000','INPUT': '#FDFFF7','TEXT_INPUT': '#000000','SCROLL': '#FDFFF7','BUTTON': ('#FFFFFF', '#658268'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'ACCENT1': '#76506d','ACCENT2': '#5148f1','ACCENT3': '#0a1c84','PROGRESS_DEPTH': 0,},
+    'Dark2': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#FFFFFF','TEXT_INPUT': '#000000','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Black': {'BACKGROUND': '#000000','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#000000', '#FFFFFF'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Black2': {'BACKGROUND': '#000000','TEXT': '#FFFFFF','INPUT': '#000000','TEXT_INPUT': '#FFFFFF','SCROLL': '#FFFFFF','BUTTON': ('#000000', '#FFFFFF'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Tan': {'BACKGROUND': '#fdf6e3','TEXT': '#268bd1','INPUT': '#eee8d5','TEXT_INPUT': '#6c71c3','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063542'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'TanBlue': {'BACKGROUND': '#e5dece','TEXT': '#063289','INPUT': '#f9f8f4','TEXT_INPUT': '#242834','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkTanBlue': {'BACKGROUND': '#242834','TEXT': '#dfe6f8','INPUT': '#97755c','TEXT_INPUT': '#FFFFFF','SCROLL': '#a9afbb','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkAmber': {'BACKGROUND': '#2c2825','TEXT': '#fdcb52','INPUT': '#705e52','TEXT_INPUT': '#fdcb52','SCROLL': '#705e52','BUTTON': ('#000000', '#fdcb52'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBlue': {'BACKGROUND': '#1a2835','TEXT': '#d1ecff','INPUT': '#335267','TEXT_INPUT': '#acc2d0','SCROLL': '#1b6497','BUTTON': ('#000000', '#fafaf8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Reds': {'BACKGROUND': '#280001','TEXT': '#FFFFFF','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#763e00','BUTTON': ('#000000', '#daad28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Green': {'BACKGROUND': '#82a459','TEXT': '#000000','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#e3ecf3','BUTTON': ('#FFFFFF', '#517239'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'BluePurple': {'BACKGROUND': '#A5CADD','TEXT': '#6E266E','INPUT': '#E0F5FF','TEXT_INPUT': '#000000','SCROLL': '#E0F5FF','BUTTON': ('#FFFFFF', '#303952'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Purple': {'BACKGROUND': '#B0AAC2','TEXT': '#000000','INPUT': '#F2EFE8','SCROLL': '#F2EFE8','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#C2D4D8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'BlueMono': {'BACKGROUND': '#AAB6D3','TEXT': '#000000','INPUT': '#F1F4FC','SCROLL': '#F1F4FC','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#7186C7'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'GreenMono': {'BACKGROUND': '#A8C1B4','TEXT': '#000000','INPUT': '#DDE0DE','SCROLL': '#E3E3E3','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#6D9F85'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'BrownBlue': {'BACKGROUND': '#64778d','TEXT': '#FFFFFF','INPUT': '#f0f3f7','SCROLL': '#A6B2BE','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#283b5b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'BrightColors': {'BACKGROUND': '#b4ffb4','TEXT': '#000000','INPUT': '#ffff64','SCROLL': '#ffb482','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#ffa0dc'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'NeutralBlue': {'BACKGROUND': '#92aa9d','TEXT': '#000000','INPUT': '#fcfff6','SCROLL': '#fcfff6','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#d0dbbd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Kayak': {'BACKGROUND': '#a7ad7f','TEXT': '#000000','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#5d907d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'SandyBeach': {'BACKGROUND': '#efeccb','TEXT': '#012f2f','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#012f2f','BUTTON': ('#FFFFFF', '#046380'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'TealMono': {'BACKGROUND': '#a8cfdd','TEXT': '#000000','INPUT': '#dfedf2','SCROLL': '#dfedf2','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#183440'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'Default': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'Default1': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': COLOR_SYSTEM_DEFAULT,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'DefaultNoMoreNagging': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'GrayGrayGray': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': COLOR_SYSTEM_DEFAULT,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'LightBlue': {'BACKGROUND': '#E3F2FD','TEXT': '#000000','INPUT': '#86A8FF','TEXT_INPUT': '#000000','SCROLL': '#86A8FF','BUTTON': ('#FFFFFF', '#5079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
+    'LightGrey': {'BACKGROUND': '#FAFAFA','TEXT': '#000000','INPUT': '#004EA1','TEXT_INPUT': '#FFFFFF','SCROLL': '#5EA7FF','BUTTON': ('#FFFFFF', '#0079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
+    'LightGrey1': {'BACKGROUND': '#ffffff','TEXT': '#1a1a1b','INPUT': '#dae0e6','TEXT_INPUT': '#222222','SCROLL': '#a5a4a4','BUTTON': ('#FFFFFF', '#0079d3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#ff5414','ACCENT2': '#33a8ff','ACCENT3': '#dbf0ff',},
+    'DarkBrown': {'BACKGROUND': '#282923','TEXT': '#E7DB74','INPUT': '#393a32','TEXT_INPUT': '#E7C855','SCROLL': '#E7C855','BUTTON': ('#E7C855', '#284B5A'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#c15226','ACCENT2': '#7a4d5f','ACCENT3': '#889743',},
+    'LightGreen1': {'BACKGROUND': '#9FB8AD','TEXT': '#000000','INPUT': '#F7F3EC','TEXT_INPUT': '#000000','SCROLL': '#F7F3EC','BUTTON': ('#FFFFFF', '#475841'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightGreen2': {'BACKGROUND': '#B7CECE','TEXT': '#000000','INPUT': '#FDFFF7','TEXT_INPUT': '#000000','SCROLL': '#FDFFF7','BUTTON': ('#FFFFFF', '#658268'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'ACCENT1': '#76506d','ACCENT2': '#5148f1','ACCENT3': '#0a1c84','PROGRESS_DEPTH': 0,},
+    'DarkGrey1': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#FFFFFF','TEXT_INPUT': '#000000','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBlack': {'BACKGROUND': '#000000','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#000000', '#FFFFFF'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBrown': {'BACKGROUND': '#fdf6e3','TEXT': '#268bd1','INPUT': '#eee8d5','TEXT_INPUT': '#6c71c3','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063542'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBrown1': {'BACKGROUND': '#e5dece','TEXT': '#063289','INPUT': '#f9f8f4','TEXT_INPUT': '#242834','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBlue1': {'BACKGROUND': '#242834','TEXT': '#dfe6f8','INPUT': '#97755c','TEXT_INPUT': '#FFFFFF','SCROLL': '#a9afbb','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBrown1': {'BACKGROUND': '#2c2825','TEXT': '#fdcb52','INPUT': '#705e52','TEXT_INPUT': '#fdcb52','SCROLL': '#705e52','BUTTON': ('#000000', '#fdcb52'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBlue2': {'BACKGROUND': '#1a2835','TEXT': '#d1ecff','INPUT': '#335267','TEXT_INPUT': '#acc2d0','SCROLL': '#1b6497','BUTTON': ('#000000', '#fafaf8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBrown2': {'BACKGROUND': '#280001','TEXT': '#FFFFFF','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#763e00','BUTTON': ('#000000', '#daad28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGreen': {'BACKGROUND': '#82a459','TEXT': '#000000','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#e3ecf3','BUTTON': ('#FFFFFF', '#517239'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBlue1': {'BACKGROUND': '#A5CADD','TEXT': '#6E266E','INPUT': '#E0F5FF','TEXT_INPUT': '#000000','SCROLL': '#E0F5FF','BUTTON': ('#FFFFFF', '#303952'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightPurple': {'BACKGROUND': '#B0AAC2','TEXT': '#000000','INPUT': '#F2EFE8','SCROLL': '#F2EFE8','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#C2D4D8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBlue2': {'BACKGROUND': '#AAB6D3','TEXT': '#000000','INPUT': '#F1F4FC','SCROLL': '#F1F4FC','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#7186C7'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightGreen3': {'BACKGROUND': '#A8C1B4','TEXT': '#000000','INPUT': '#DDE0DE','SCROLL': '#E3E3E3','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#6D9F85'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBlue3': {'BACKGROUND': '#64778d','TEXT': '#FFFFFF','INPUT': '#f0f3f7','SCROLL': '#A6B2BE','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#283b5b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightGreen4': {'BACKGROUND': '#b4ffb4','TEXT': '#000000','INPUT': '#ffff64','SCROLL': '#ffb482','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#ffa0dc'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightGreen5': {'BACKGROUND': '#92aa9d','TEXT': '#000000','INPUT': '#fcfff6','SCROLL': '#fcfff6','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#d0dbbd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBrown2': {'BACKGROUND': '#a7ad7f','TEXT': '#000000','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#5d907d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBrown3': {'BACKGROUND': '#efeccb','TEXT': '#012f2f','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#012f2f','BUTTON': ('#FFFFFF', '#046380'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBlue3': {'BACKGROUND': '#a8cfdd','TEXT': '#000000','INPUT': '#dfedf2','SCROLL': '#dfedf2','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#183440'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'LightBrown4': {'BACKGROUND': '#d7c79e','TEXT': '#a35638','INPUT': '#9dab86','TEXT_INPUT': '#000000','SCROLL': '#a35638','BUTTON': ('#FFFFFF', '#a35638'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'],},
+    'DarkTeal': {'BACKGROUND': '#003f5c','TEXT': '#fb5b5a','INPUT': '#bc4873','TEXT_INPUT': '#FFFFFF','SCROLL': '#bc4873','BUTTON': ('#FFFFFF', '#fb5b5a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],},
+    'DarkPurple': {'BACKGROUND': '#472b62','TEXT': '#fb5b5a','INPUT': '#bc4873','TEXT_INPUT': '#FFFFFF','SCROLL': '#bc4873','BUTTON': ('#FFFFFF', '#472b62'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],},
+    'LightGreen6': {'BACKGROUND': '#eafbea','TEXT': '#1f6650','INPUT': '#6f9a8d','TEXT_INPUT': '#FFFFFF','SCROLL': '#1f6650','BUTTON': ('#FFFFFF', '#1f6650'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'],},
+    'DarkGrey2': {'BACKGROUND': '#2b2b28','TEXT': '#f8f8f8','INPUT': '#f1d6ab','TEXT_INPUT': '#000000','SCROLL': '#f1d6ab','BUTTON': ('#2b2b28', '#e3b04b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'],},
+    'LightBrown6': {'BACKGROUND': '#f9b282','TEXT': '#8f4426','INPUT': '#de6b35','TEXT_INPUT': '#FFFFFF','SCROLL': '#8f4426','BUTTON': ('#FFFFFF', '#8f4426'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'],},
+    'DarkTeal1': {'BACKGROUND': '#396362','TEXT': '#ffe7d1','INPUT': '#f6c89f','TEXT_INPUT': '#000000','SCROLL': '#f6c89f','BUTTON': ('#ffe7d1', '#4b8e8d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],},
+    'LightBrown7': {'BACKGROUND': '#f6c89f','TEXT': '#396362','INPUT': '#4b8e8d','TEXT_INPUT': '#FFFFFF','SCROLL': '#396362','BUTTON': ('#FFFFFF', '#396362'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],},
+    'DarkPurple1': {'BACKGROUND': '#0c093c','TEXT': '#fad6d6','INPUT': '#eea5f6','TEXT_INPUT': '#000000','SCROLL': '#eea5f6','BUTTON': ('#FFFFFF', '#df42d1'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'],},
+    'DarkGrey3': {'BACKGROUND': '#211717','TEXT': '#dfddc7','INPUT': '#f58b54','TEXT_INPUT': '#000000','SCROLL': '#f58b54','BUTTON': ('#dfddc7', '#a34a28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],},
+    'LightBrown8': {'BACKGROUND': '#dfddc7','TEXT': '#211717','INPUT': '#a34a28','TEXT_INPUT': '#dfddc7','SCROLL': '#211717','BUTTON': ('#dfddc7', '#a34a28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],},
+    'DarkBlue4': {'BACKGROUND': '#494ca2','TEXT': '#e3e7f1','INPUT': '#c6cbef','TEXT_INPUT': '#000000','SCROLL': '#c6cbef','BUTTON': ('#FFFFFF', '#8186d5'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'],},
+    'LightBlue4': {'BACKGROUND': '#5c94bd','TEXT': '#470938','INPUT': '#1a3e59','TEXT_INPUT': '#FFFFFF','SCROLL': '#470938','BUTTON': ('#FFFFFF', '#470938'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'],},
+    'DarkTeal2': {'BACKGROUND': '#394a6d','TEXT': '#c0ffb3','INPUT': '#52de97','TEXT_INPUT': '#000000','SCROLL': '#52de97','BUTTON': ('#c0ffb3', '#394a6d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],},
+    'DarkTeal3': {'BACKGROUND': '#3c9d9b','TEXT': '#c0ffb3','INPUT': '#52de97','TEXT_INPUT': '#000000','SCROLL': '#52de97','BUTTON': ('#c0ffb3', '#394a6d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],},
+    'DarkPurple5': {'BACKGROUND': '#730068','TEXT': '#f6f078','INPUT': '#01d28e','TEXT_INPUT': '#000000','SCROLL': '#01d28e','BUTTON': ('#f6f078', '#730068'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'],},
+    'DarkPurple2': {'BACKGROUND': '#202060','TEXT': '#b030b0','INPUT': '#602080','TEXT_INPUT': '#FFFFFF','SCROLL': '#602080','BUTTON': ('#FFFFFF', '#202040'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'],},
+    'DarkBlue5': {'BACKGROUND': '#000272','TEXT': '#ff6363','INPUT': '#a32f80','TEXT_INPUT': '#FFFFFF','SCROLL': '#a32f80','BUTTON': ('#FFFFFF', '#341677'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'],},
+    'LightGrey2': {'BACKGROUND': '#f6f6f6','TEXT': '#420000','INPUT': '#d4d7dd','TEXT_INPUT': '#420000','SCROLL': '#420000','BUTTON': ('#420000', '#d4d7dd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],},
+    'LightGrey3': {'BACKGROUND': '#eae9e9','TEXT': '#420000','INPUT': '#d4d7dd','TEXT_INPUT': '#420000','SCROLL': '#420000','BUTTON': ('#420000', '#d4d7dd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],},
+    'DarkBlue6': {'BACKGROUND': '#01024e','TEXT': '#ff6464','INPUT': '#8b4367','TEXT_INPUT': '#FFFFFF','SCROLL': '#8b4367','BUTTON': ('#FFFFFF', '#543864'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'],},
+    'DarkBlue7': {'BACKGROUND': '#241663','TEXT': '#eae7af','INPUT': '#a72693','TEXT_INPUT': '#eae7af','SCROLL': '#a72693','BUTTON': ('#eae7af', '#160f30'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'],},
+    'LightBrown9': {'BACKGROUND': '#f6d365','TEXT': '#3a1f5d','INPUT': '#c83660','TEXT_INPUT': '#f6d365','SCROLL': '#3a1f5d','BUTTON': ('#f6d365', '#c83660'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'],},
+    'DarkPurple3': {'BACKGROUND': '#6e2142','TEXT': '#ffd692','INPUT': '#e16363','TEXT_INPUT': '#ffd692','SCROLL': '#e16363','BUTTON': ('#ffd692', '#943855'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],},
+    'LightBrown10': {'BACKGROUND': '#ffd692','TEXT': '#6e2142','INPUT': '#943855','TEXT_INPUT': '#FFFFFF','SCROLL': '#6e2142','BUTTON': ('#FFFFFF', '#6e2142'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],},
+    'DarkPurple4': {'BACKGROUND': '#200f21','TEXT': '#f638dc','INPUT': '#5a3d5c','TEXT_INPUT': '#FFFFFF','SCROLL': '#5a3d5c','BUTTON': ('#FFFFFF', '#382039'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'],},
+    'LightBlue5': {'BACKGROUND': '#b2fcff','TEXT': '#3e64ff','INPUT': '#5edfff','TEXT_INPUT': '#000000','SCROLL': '#3e64ff','BUTTON': ('#FFFFFF', '#3e64ff'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'],},
+    'DarkTeal4': {'BACKGROUND': '#464159','TEXT': '#c7f0db','INPUT': '#8bbabb','TEXT_INPUT': '#000000','SCROLL': '#8bbabb','BUTTON': ('#FFFFFF', '#6c7b95'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],},
+    'LightTeal': {'BACKGROUND': '#c7f0db','TEXT': '#464159','INPUT': '#6c7b95','TEXT_INPUT': '#FFFFFF','SCROLL': '#464159','BUTTON': ('#FFFFFF', '#464159'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],},
+    'DarkTeal5': {'BACKGROUND': '#8bbabb','TEXT': '#464159','INPUT': '#6c7b95','TEXT_INPUT': '#FFFFFF','SCROLL': '#464159','BUTTON': ('#c7f0db', '#6c7b95'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],},
+    'LightGrey4': {'BACKGROUND': '#faf5ef','TEXT': '#672f2f','INPUT': '#99b19c','TEXT_INPUT': '#672f2f','SCROLL': '#672f2f','BUTTON': ('#672f2f', '#99b19c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],},
+    'LightGreen7': {'BACKGROUND': '#99b19c','TEXT': '#faf5ef','INPUT': '#d7d1c9','TEXT_INPUT': '#000000','SCROLL': '#d7d1c9','BUTTON': ('#FFFFFF', '#99b19c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],},
+    'LightGrey5': {'BACKGROUND': '#d7d1c9','TEXT': '#672f2f','INPUT': '#99b19c','TEXT_INPUT': '#672f2f','SCROLL': '#672f2f','BUTTON': ('#FFFFFF', '#672f2f'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],},
+    'DarkBrown3': {'BACKGROUND': '#a0855b','TEXT': '#f9f6f2','INPUT': '#f1d6ab','TEXT_INPUT': '#000000','SCROLL': '#f1d6ab','BUTTON': ('#FFFFFF', '#38470b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],},
+    'LightBrown11': {'BACKGROUND': '#f1d6ab','TEXT': '#38470b','INPUT': '#a0855b','TEXT_INPUT': '#FFFFFF','SCROLL': '#38470b','BUTTON': ('#f9f6f2', '#a0855b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],},
+    'DarkRed': {'BACKGROUND': '#83142c','TEXT': '#f9d276','INPUT': '#ad1d45','TEXT_INPUT': '#FFFFFF','SCROLL': '#ad1d45','BUTTON': ('#f9d276', '#ad1d45'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'],},
+    'DarkTeal6': {'BACKGROUND': '#204969','TEXT': '#fff7f7','INPUT': '#dadada','TEXT_INPUT': '#000000','SCROLL': '#dadada','BUTTON': ('#000000', '#fff7f7'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'],},
+    'DarkBrown4': {'BACKGROUND': '#252525','TEXT': '#ff0000','INPUT': '#af0404','TEXT_INPUT': '#FFFFFF','SCROLL': '#af0404','BUTTON': ('#FFFFFF', '#252525'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'],},
+    'LightYellow': {'BACKGROUND': '#f4ff61','TEXT': '#27aa80','INPUT': '#32ff6a','TEXT_INPUT': '#000000','SCROLL': '#27aa80','BUTTON': ('#f4ff61', '#27aa80'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'],},
+    'DarkGreen1': {'BACKGROUND': '#2b580c','TEXT': '#fdef96','INPUT': '#f7b71d','TEXT_INPUT': '#000000','SCROLL': '#f7b71d','BUTTON': ('#fdef96', '#2b580c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'],},
+    'LightGreen8': {'BACKGROUND': '#c8dad3','TEXT': '#63707e','INPUT': '#93b5b3','TEXT_INPUT': '#000000','SCROLL': '#63707e','BUTTON': ('#FFFFFF', '#63707e'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'],},
+    'DarkTeal7': {'BACKGROUND': '#248ea9','TEXT': '#fafdcb','INPUT': '#aee7e8','TEXT_INPUT': '#000000','SCROLL': '#aee7e8','BUTTON': ('#000000', '#fafdcb'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'],},
+    'DarkBlue8': {'BACKGROUND': '#454d66','TEXT': '#d9d872','INPUT': '#58b368','TEXT_INPUT': '#000000','SCROLL': '#58b368','BUTTON': ('#000000', '#009975'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'],},
+    'DarkBlue9': {'BACKGROUND': '#263859','TEXT': '#ff6768','INPUT': '#6b778d','TEXT_INPUT': '#FFFFFF','SCROLL': '#6b778d','BUTTON': ('#ff6768', '#263859'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'],},
+    'DarkBlue10': {'BACKGROUND': '#0028ff','TEXT': '#f1f4df','INPUT': '#10eaf0','TEXT_INPUT': '#000000','SCROLL': '#10eaf0','BUTTON': ('#f1f4df', '#24009c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'],},
+    'DarkBlue11': {'BACKGROUND': '#6384b3','TEXT': '#e6f0b6','INPUT': '#b8e9c0','TEXT_INPUT': '#000000','SCROLL': '#b8e9c0','BUTTON': ('#e6f0b6', '#684949'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'],},
+    'DarkTeal8': {'BACKGROUND': '#71a0a5','TEXT': '#212121','INPUT': '#665c84','TEXT_INPUT': '#FFFFFF','SCROLL': '#212121','BUTTON': ('#fab95b', '#665c84'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'],},
+    'DarkRed1': {'BACKGROUND': '#c10000','TEXT': '#eeeeee','INPUT': '#dedede','TEXT_INPUT': '#000000','SCROLL': '#dedede','BUTTON': ('#c10000', '#eeeeee'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'],},
+    'LightBrown5': {'BACKGROUND': '#fff591','TEXT': '#e41749','INPUT': '#f5587b','TEXT_INPUT': '#000000','SCROLL': '#e41749','BUTTON': ('#fff591', '#e41749'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'],},
+    'LightGreen9': {'BACKGROUND': '#f1edb3','TEXT': '#3b503d','INPUT': '#4a746e','TEXT_INPUT': '#f1edb3','SCROLL': '#3b503d','BUTTON': ('#f1edb3', '#3b503d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],},
+    'DarkGreen2': {'BACKGROUND': '#3b503d','TEXT': '#f1edb3','INPUT': '#c8cf94','TEXT_INPUT': '#000000','SCROLL': '#c8cf94','BUTTON': ('#f1edb3', '#3b503d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],},
+    'LightGray1': {'BACKGROUND': '#f2f2f2','TEXT': '#222831','INPUT': '#393e46','TEXT_INPUT': '#FFFFFF','SCROLL': '#222831','BUTTON': ('#f2f2f2', '#222831'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn'],},
+    'DarkGrey4': {'BACKGROUND': '#52524e','TEXT': '#e9e9e5','INPUT': '#d4d6c8','TEXT_INPUT': '#000000','SCROLL': '#d4d6c8','BUTTON': ('#FFFFFF', '#9a9b94'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],'DESCRIPTION': ['Grey', 'Pastel', 'Winter'],},
+    'DarkBlue12': {'BACKGROUND': '#324e7b','TEXT': '#f8f8f8','INPUT': '#86a6df','TEXT_INPUT': '#000000','SCROLL': '#86a6df','BUTTON': ('#FFFFFF', '#5068a9'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'],},
+    'DarkPurple6': {'BACKGROUND': '#070739','TEXT': '#e1e099','INPUT': '#c327ab','TEXT_INPUT': '#e1e099','SCROLL': '#c327ab','BUTTON': ('#e1e099', '#521477'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark'],},
+    'DarkPurple7': {'BACKGROUND': '#191930','TEXT': '#B1B7C5','INPUT': '#232B5C','TEXT_INPUT': '#D0E3E7','SCROLL': '#B1B7C5','BUTTON': ('#272D38', '#B1B7C5'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBlue13': {'BACKGROUND': '#203562','TEXT': '#e3e8f8','INPUT': '#c0c5cd','TEXT_INPUT': '#000000','SCROLL': '#c0c5cd','BUTTON': ('#FFFFFF', '#3e588f'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'],},
+    'DarkBrown5': {'BACKGROUND': '#3c1b1f','TEXT': '#f6e1b5','INPUT': '#e2bf81','TEXT_INPUT': '#000000','SCROLL': '#e2bf81','BUTTON': ('#3c1b1f', '#f6e1b5'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'],},
+    'DarkGreen3': {'BACKGROUND': '#062121','TEXT': '#eeeeee','INPUT': '#e4dcad','TEXT_INPUT': '#000000','SCROLL': '#e4dcad','BUTTON': ('#eeeeee', '#181810'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],},
+    'DarkBlack1': {'BACKGROUND': '#181810','TEXT': '#eeeeee','INPUT': '#e4dcad','TEXT_INPUT': '#000000','SCROLL': '#e4dcad','BUTTON': ('#FFFFFF', '#062121'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],},
+    'DarkGrey5': {'BACKGROUND': '#343434','TEXT': '#f3f3f3','INPUT': '#e9dcbe','TEXT_INPUT': '#000000','SCROLL': '#e9dcbe','BUTTON': ('#FFFFFF', '#8e8b82'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],'DESCRIPTION': ['Grey', 'Brown'],},
+    'LightBrown12': {'BACKGROUND': '#8e8b82','TEXT': '#f3f3f3','INPUT': '#e9dcbe','TEXT_INPUT': '#000000','SCROLL': '#e9dcbe','BUTTON': ('#f3f3f3', '#8e8b82'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],'DESCRIPTION': ['Grey', 'Brown'],},
+    'DarkTeal9': {'BACKGROUND': '#13445a','TEXT': '#fef4e8','INPUT': '#446878','TEXT_INPUT': '#FFFFFF','SCROLL': '#446878','BUTTON': ('#fef4e8', '#446878'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'],},
+    'DarkBlue14': {'BACKGROUND': '#21273d','TEXT': '#f1f6f8','INPUT': '#b9d4f1','TEXT_INPUT': '#000000','SCROLL': '#b9d4f1','BUTTON': ('#FFFFFF', '#6a759b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],},
+    'LightBlue6': {'BACKGROUND': '#f1f6f8','TEXT': '#21273d','INPUT': '#6a759b','TEXT_INPUT': '#FFFFFF','SCROLL': '#21273d','BUTTON': ('#f1f6f8', '#6a759b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],},
+    'DarkGreen4': {'BACKGROUND': '#044343','TEXT': '#e4e4e4','INPUT': '#045757','TEXT_INPUT': '#e4e4e4','SCROLL': '#045757','BUTTON': ('#e4e4e4', '#045757'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark'],},
+    'DarkGreen5': {'BACKGROUND': '#1b4b36','TEXT': '#e0e7f1','INPUT': '#aebd77','TEXT_INPUT': '#000000','SCROLL': '#aebd77','BUTTON': ('#FFFFFF', '#538f6a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'],'DESCRIPTION': ['Green', 'Grey'],},
+    'DarkTeal10': {'BACKGROUND': '#0d3446','TEXT': '#d8dfe2','INPUT': '#71adb5','TEXT_INPUT': '#000000','SCROLL': '#71adb5','BUTTON': ('#FFFFFF', '#176d81'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'],},
+    'DarkGrey6': {'BACKGROUND': '#3e3e3e','TEXT': '#ededed','INPUT': '#68868c','TEXT_INPUT': '#ededed','SCROLL': '#68868c','BUTTON': ('#FFFFFF', '#405559'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],},
+    'DarkTeal11': {'BACKGROUND': '#405559','TEXT': '#ededed','INPUT': '#68868c','TEXT_INPUT': '#ededed','SCROLL': '#68868c','BUTTON': ('#ededed', '#68868c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],},
+    'LightBlue7': {'BACKGROUND': '#9ed0e0','TEXT': '#19483f','INPUT': '#5c868e','TEXT_INPUT': '#FFFFFF','SCROLL': '#19483f','BUTTON': ('#FFFFFF', '#19483f'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'],},
+    'LightGreen10': {'BACKGROUND': '#d8ebb5','TEXT': '#205d67','INPUT': '#639a67','TEXT_INPUT': '#FFFFFF','SCROLL': '#205d67','BUTTON': ('#d8ebb5', '#205d67'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'],},
+    'DarkBlue15': {'BACKGROUND': '#151680','TEXT': '#f1fea4','INPUT': '#375fc0','TEXT_INPUT': '#f1fea4','SCROLL': '#375fc0','BUTTON': ('#f1fea4', '#1c44ac'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],},
+    'DarkBlue16': {'BACKGROUND': '#1c44ac','TEXT': '#f1fea4','INPUT': '#375fc0','TEXT_INPUT': '#f1fea4','SCROLL': '#375fc0','BUTTON': ('#f1fea4', '#151680'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],},
+    'DarkTeal12': {'BACKGROUND': '#004a7c','TEXT': '#fafafa','INPUT': '#e8f1f5','TEXT_INPUT': '#000000','SCROLL': '#e8f1f5','BUTTON': ('#fafafa', '#005691'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'],},
+    'LightBrown13': {'BACKGROUND': '#ebf5ee','TEXT': '#921224','INPUT': '#bdc6b8','TEXT_INPUT': '#921224','SCROLL': '#921224','BUTTON': ('#FFFFFF', '#921224'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'],},
+    'DarkBlue17': {'BACKGROUND': '#21294c','TEXT': '#f9f2d7','INPUT': '#f2dea8','TEXT_INPUT': '#000000','SCROLL': '#f2dea8','BUTTON': ('#f9f2d7', '#141829'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],},
+    'DarkBlue18': {'BACKGROUND': '#0c1825','TEXT': '#d1d7dd','INPUT': '#001c35','TEXT_INPUT': '#d1d7dd','SCROLL': '#00438e','BUTTON': ('#75b7ff', '#001c35'),'PROGRESS': ('#0074ff', '#75b7ff'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],},
+    'DarkBrown6': {'BACKGROUND': '#785e4d','TEXT': '#f2eee3','INPUT': '#baaf92','TEXT_INPUT': '#000000','SCROLL': '#baaf92','BUTTON': ('#FFFFFF', '#785e4d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'],},
+    'DarkGreen6': {'BACKGROUND': '#5c715e','TEXT': '#f2f9f1','INPUT': '#ddeedf','TEXT_INPUT': '#000000','SCROLL': '#ddeedf','BUTTON': ('#f2f9f1', '#5c715e'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],'DESCRIPTION': ['Grey', 'Green', 'Vintage'],},
+    'DarkGreen7': {'BACKGROUND': '#0C231E','TEXT': '#efbe1c','INPUT': '#153C33','TEXT_INPUT': '#efbe1c','SCROLL': '#153C33','BUTTON': ('#efbe1c', '#153C33'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey7': {'BACKGROUND': '#4b586e','TEXT': '#dddddd','INPUT': '#574e6d','TEXT_INPUT': '#dddddd','SCROLL': '#574e6d','BUTTON': ('#dddddd', '#43405d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],'DESCRIPTION': ['Grey', 'Winter', 'Cold'],},
+    'DarkRed2': {'BACKGROUND': '#ab1212','TEXT': '#f6e4b5','INPUT': '#cd3131','TEXT_INPUT': '#f6e4b5','SCROLL': '#cd3131','BUTTON': ('#f6e4b5', '#ab1212'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'],},
+    'LightGrey6': {'BACKGROUND': '#e3e3e3','TEXT': '#233142','INPUT': '#455d7a','TEXT_INPUT': '#e3e3e3','SCROLL': '#233142','BUTTON': ('#e3e3e3', '#455d7a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey'],},
+    'HotDogStand': {'BACKGROUND': 'red','TEXT': 'yellow','INPUT': 'yellow','TEXT_INPUT': '#000000','SCROLL': 'yellow','BUTTON': ('red', 'yellow'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey8': {'BACKGROUND': '#19232D','TEXT': '#ffffff','INPUT': '#32414B','TEXT_INPUT': '#ffffff','SCROLL': '#505F69','BUTTON': ('#ffffff', '#32414B'),'PROGRESS': ('#505F69', '#32414B'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey9': {'BACKGROUND': '#36393F','TEXT': '#DCDDDE','INPUT': '#40444B','TEXT_INPUT': '#ffffff','SCROLL': '#202225','BUTTON': ('#202225', '#B9BBBE'),'PROGRESS': ('#202225', '#40444B'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey10': {'BACKGROUND': '#1c1e23','TEXT': '#cccdcf','INPUT': '#272a31','TEXT_INPUT': '#8b9fde','SCROLL': '#313641','BUTTON': ('#f5f5f6', '#2e3d5a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey11': {'BACKGROUND': '#1c1e23','TEXT': '#cccdcf','INPUT': '#313641','TEXT_INPUT': '#cccdcf','SCROLL': '#313641','BUTTON': ('#f5f5f6', '#313641'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey12': {'BACKGROUND': '#1c1e23','TEXT': '#8b9fde','INPUT': '#313641','TEXT_INPUT': '#8b9fde','SCROLL': '#313641','BUTTON': ('#cccdcf', '#2e3d5a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey13': {'BACKGROUND': '#1c1e23','TEXT': '#cccdcf','INPUT': '#272a31','TEXT_INPUT': '#cccdcf','SCROLL': '#313641','BUTTON': ('#8b9fde', '#313641'),'PROGRESS': ('#cccdcf', '#272a31'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey14': {'BACKGROUND': '#24292e','TEXT': '#fafbfc','INPUT': '#1d2125','TEXT_INPUT': '#fafbfc','SCROLL': '#1d2125','BUTTON': ('#fafbfc', '#155398'),'PROGRESS': ('#155398', '#1d2125'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey15': {'BACKGROUND': '#121212','TEXT': '#dddddd','INPUT': '#1e1e1e','TEXT_INPUT': '#69b1ef','SCROLL': '#272727','BUTTON': ('#69b1ef', '#2e2e2e'),'PROGRESS': ('#69b1ef', '#2e2e2e'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkGrey16': {'BACKGROUND': '#353535','TEXT': '#ffffff','INPUT': '#191919','TEXT_INPUT': '#ffffff','SCROLL': '#454545','BUTTON': ('#ffffff', '#454545'),'PROGRESS': ('#757575', '#454545'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'DarkBrown7': {'BACKGROUND': '#2c2417','TEXT': '#baa379','INPUT': '#baa379','TEXT_INPUT': '#000000','SCROLL': '#392e1c','BUTTON': ('#000000', '#baa379'),'PROGRESS': ('#baa379', '#453923'),'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'Python': {'BACKGROUND': '#3d7aab','TEXT': '#ffde56','INPUT': '#295273','TEXT_INPUT': '#ffde56','SCROLL': '#295273','BUTTON': ('#ffde56', '#295273'),'PROGRESS': ('#ffde56', '#295273'),'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'PythonPlus': {'BACKGROUND': '#001d3c','TEXT': '#ffffff','INPUT': '#015bbb','TEXT_INPUT': '#fed500','SCROLL': '#015bbb','BUTTON': ('#fed500', '#015bbb'),'PROGRESS': ('#015bbb', '#fed500'),'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'NeonBlue1': {'BACKGROUND': '#000000','TEXT': '#ffffff','INPUT': '#000000','TEXT_INPUT': '#33ccff','SCROLL': '#33ccff','BUTTON': ('#33ccff', '#000000'),'PROGRESS': ('#33ccff', '#ffffff'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'NeonGreen1': {'BACKGROUND': '#000000','TEXT': '#ffffff','INPUT': '#000000','TEXT_INPUT': '#96ff7b','SCROLL': '#96ff7b','BUTTON': ('#96ff7b', '#000000'),'PROGRESS': ('#96ff7b', '#ffffff'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
+    'NeonYellow1': {'BACKGROUND': '#000000','TEXT': '#ffffff','INPUT': '#000000','TEXT_INPUT': '#ffcf40','SCROLL': '#ffcf40','BUTTON': ('#ffcf40', '#000000'),'PROGRESS': ('#ffcf40', '#ffffff'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
 }
+# fmt: on
 
 
 def list_of_look_and_feel_values():
@@ -25610,7 +22168,7 @@ def theme_add_new(new_theme_name, new_theme_dict):
     try:
         LOOK_AND_FEEL_TABLE[new_theme_name] = new_theme_dict
     except Exception as e:
-        print('Exception during adding new theme {}'.format(e))
+        print(f'Exception during adding new theme {e}')
 
 
 def theme_use_custom_titlebar():
@@ -25642,7 +22200,7 @@ def theme_global(new_theme=None):
         if new_theme not in theme_list():
             popup_error_with_traceback(
                 'Cannot use custom themes with theme_global call',
-                'Your request to use theme {} cannot be performed.'.format(new_theme),
+                f'Your request to use theme {new_theme} cannot be performed.',
                 'The PySimpleGUI Global User Settings are meant for PySimpleGUI standard items, not user config items',
                 'You can use any of the many built-in themes instead or use your own UserSettings file to store your custom theme',
             )
@@ -25654,9 +22212,7 @@ def theme_global(new_theme=None):
         return pysimplegui_user_settings.get('-theme-', CURRENT_LOOK_AND_FEEL)
 
 
-def theme_previewer(
-    columns=12, scrollable=False, scroll_area_size=(None, None), search_string=None, location=(None, None)
-):
+def theme_previewer(columns=12, scrollable=False, scroll_area_size=(None, None), search_string=None, location=(None, None)):
     """
     Displays a "Quick Reference Window" showing all of the different Look and Feel settings that are available.
     They are sorted alphabetically.  The legacy color names are mixed in, but otherwise they are sorted into Dark and Light halves
@@ -25701,7 +22257,7 @@ def theme_previewer(
         names = [name for name in names if search_string.lower().replace(' ', '') in name.lower().replace(' ', '')]
 
     if search_string not in (None, ''):
-        layout = [[Text('Themes containing "{}"'.format(search_string), font='Default 18', background_color=win_bg)]]
+        layout = [[Text(f'Themes containing "{search_string}"', font='Default 18', background_color=win_bg)]]
     else:
         layout = [[Text('List of all themes', font='Default 18', background_color=win_bg)]]
 
@@ -25898,9 +22454,9 @@ def change_look_and_feel(index, force=False):
         ix = lf_values_lowercase.index(opt3)
     else:
         ix = random.randint(0, len(lf_values_lowercase) - 1)
-        print('** Warning - {} Theme is not a valid theme. Change your theme call. **'.format(index))
+        print(f'** Warning - {index} Theme is not a valid theme. Change your theme call. **')
         print('valid values are', list_of_look_and_feel_values())
-        print('Instead, please enjoy a random Theme named {}'.format(list_of_look_and_feel_values()[ix]))
+        print(f'Instead, please enjoy a random Theme named {list_of_look_and_feel_values()[ix]}')
 
     selection = theme_names_list[ix]
     CURRENT_LOOK_AND_FEEL = selection
@@ -26022,11 +22578,7 @@ def obj_to_string_single_obj(obj):
     """
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
-    )
+    return str(obj.__class__) + '\n' + '\n'.join(repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__))
 
 
 def obj_to_string(obj, extra='    '):
@@ -26041,25 +22593,7 @@ def obj_to_string(obj, extra='    '):
     """
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join(
-            (
-                extra
-                + (
-                    str(item)
-                    + ' = '
-                    + (
-                        ObjToString(obj.__dict__[item], extra + '    ')
-                        if hasattr(obj.__dict__[item], '__dict__')
-                        else str(obj.__dict__[item])
-                    )
-                )
-                for item in sorted(obj.__dict__)
-            )
-        )
-    )
+    return str(obj.__class__) + '\n' + '\n'.join(extra + (str(item) + ' = ' + (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(obj.__dict__[item]))) for item in sorted(obj.__dict__))
 
 
 # ...######..##.......####.########..########...#######.....###....########..########.
@@ -26246,9 +22780,7 @@ def popup(
         max_line_total = max(max_line_total, width_used)
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
-        layout += [
-            [Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)]
-        ]
+        layout += [[Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)]]
         total_lines += height
 
     if non_blocking:
@@ -26481,9 +23013,7 @@ def popup_scrolled(
         height_computed += lines_needed + 1
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = (
-        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
-    )
+    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
     if height:
         height_computed = height
     layout += [
@@ -27590,7 +24120,7 @@ def popup_get_folder(
         except Exception as e:
             _error_popup_with_traceback(
                 'popup_get_folder - Something is wrong with your supplied history settings filename',
-                'Exception: {}'.format(e),
+                f'Exception: {e}',
             )
             return None
     elif history:
@@ -27611,9 +24141,7 @@ def popup_get_folder(
             try:
                 root.wm_overrideredirect(True)
             except Exception as e:
-                print(
-                    '* Error performing wm_overrideredirect while hiding the window during creation in get folder *', e
-                )
+                print('* Error performing wm_overrideredirect while hiding the window during creation in get folder *', e)
             root.withdraw()
         except:
             pass
@@ -27801,7 +24329,7 @@ def popup_get_file(
         except Exception as e:
             _error_popup_with_traceback(
                 'popup_get_file - Something is wrong with your supplied history settings filename',
-                'Exception: {}'.format(e),
+                f'Exception: {e}',
             )
             return None
     elif history:
@@ -27850,9 +24378,7 @@ def popup_get_file(
             if running_mac():
                 is_all = [(x, y) for (x, y) in file_types if all(ch in '* .' for ch in y)]
                 if not len(set(file_types)) > 1 and (len(is_all) != 0 or file_types == FILE_TYPES_ALL_FILES):
-                    filename = tk.filedialog.asksaveasfilename(
-                        initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension
-                    )  # show the 'get file' dialog box
+                    filename = tk.filedialog.asksaveasfilename(initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension)  # show the 'get file' dialog box
                 else:
                     filename = tk.filedialog.asksaveasfilename(
                         filetypes=file_types,
@@ -27872,9 +24398,7 @@ def popup_get_file(
             if running_mac():
                 is_all = [(x, y) for (x, y) in file_types if all(ch in '* .' for ch in y)]
                 if not len(set(file_types)) > 1 and (len(is_all) != 0 or file_types == FILE_TYPES_ALL_FILES):
-                    filename = tk.filedialog.askopenfilenames(
-                        initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension
-                    )  # show the 'get file' dialog box
+                    filename = tk.filedialog.askopenfilenames(initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension)  # show the 'get file' dialog box
                 else:
                     filename = tk.filedialog.askopenfilenames(
                         filetypes=file_types,
@@ -27894,9 +24418,7 @@ def popup_get_file(
             if running_mac():
                 is_all = [(x, y) for (x, y) in file_types if all(ch in '* .' for ch in y)]
                 if not len(set(file_types)) > 1 and (len(is_all) != 0 or file_types == FILE_TYPES_ALL_FILES):
-                    filename = tk.filedialog.askopenfilename(
-                        initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension
-                    )  # show the 'get files' dialog box
+                    filename = tk.filedialog.askopenfilename(initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension)  # show the 'get files' dialog box
                 else:
                     filename = tk.filedialog.askopenfilename(
                         filetypes=file_types,
@@ -27922,13 +24444,9 @@ def popup_get_file(
         return filename
 
     if save_as:
-        browse_button = SaveAs(
-            file_types=file_types, initial_folder=initial_folder, default_extension=default_extension
-        )
+        browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder, default_extension=default_extension)
     elif multiple_files:
-        browse_button = FilesBrowse(
-            file_types=file_types, initial_folder=initial_folder, files_delimiter=files_delimiter
-        )
+        browse_button = FilesBrowse(file_types=file_types, initial_folder=initial_folder, files_delimiter=files_delimiter)
     else:
         browse_button = FileBrowse(file_types=file_types, initial_folder=initial_folder)
 
@@ -27981,12 +24499,8 @@ def popup_get_file(
     )
 
     if running_linux() and show_hidden is True:
-        window.TKroot.tk.eval(
-            'catch {tk_getOpenFile -badoption}'
-        )  # dirty hack to force autoloading of Tk's file dialog code
-        window.TKroot.setvar(
-            '::tk::dialog::file::showHiddenBtn', 1
-        )  # enable the "show hidden files" checkbox (it's necessary)
+        window.TKroot.tk.eval('catch {tk_getOpenFile -badoption}')  # dirty hack to force autoloading of Tk's file dialog code
+        window.TKroot.setvar('::tk::dialog::file::showHiddenBtn', 1)  # enable the "show hidden files" checkbox (it's necessary)
         window.TKroot.setvar('::tk::dialog::file::showHiddenVar', 0)  # start with the hidden files... well... hidden
 
     while True:
@@ -28097,7 +24611,7 @@ def popup_get_text(
         except Exception as e:
             _error_popup_with_traceback(
                 'popup_get_file - Something is wrong with your supplied history settings filename',
-                'Exception: {}'.format(e),
+                f'Exception: {e}',
             )
             return None
     elif history:
@@ -28315,11 +24829,7 @@ def popup_get_date(
     else:
         day_names = day_abbreviations
 
-    mon_names = (
-        month_names
-        if month_names is not None and len(month_names) == 12
-        else [calendar.month_name[i] for i in range(1, 13)]
-    )
+    mon_names = month_names if month_names is not None and len(month_names) == 12 else [calendar.month_name[i] for i in range(1, 13)]
     days_layout = make_days_layout()
 
     layout = [
@@ -28327,7 +24837,7 @@ def popup_get_date(
             B('◄◄', font=arrow_font, border_width=0, key='-YEAR-DOWN-', pad=((10, 2), 2)),
             B('◄', font=arrow_font, border_width=0, key='-MON-DOWN-', pad=(0, 2)),
             Text(
-                '{} {}'.format(mon_names[cur_month - 1], cur_year),
+                f'{mon_names[cur_month - 1]} {cur_year}',
                 size=(16, 1),
                 justification='c',
                 font=mon_year_font,
@@ -28361,9 +24871,7 @@ def popup_get_date(
     ]
     layout += days_layout
     if not close_when_chosen:
-        layout += [
-            [Button('Ok', border_width=0, font='TkFixedFont 8'), Button('Cancel', border_width=0, font='TkFixedFont 8')]
-        ]
+        layout += [[Button('Ok', border_width=0, font='TkFixedFont 8'), Button('Cancel', border_width=0, font='TkFixedFont 8')]]
 
     window = Window(
         title,
@@ -28413,7 +24921,7 @@ def popup_get_date(
             elif cur_month < 1:
                 cur_month = 12
                 cur_year -= 1
-            window['-MON-YEAR-'].update('{} {}'.format(mon_names[cur_month - 1], cur_year))
+            window['-MON-YEAR-'].update(f'{mon_names[cur_month - 1]} {cur_year}')
             update_days(window, cur_month, cur_year, begin_at_sunday_plus)
             if prev_choice:
                 window[prev_choice].update(background_color=theme_background_color(), text_color=theme_text_color())
@@ -28729,9 +25237,7 @@ def _error_popup_with_code(title, filename, line_num, *args, emoji=None):
     lines = []
     for msg in args:
         if isinstance(msg, Exception):
-            lines += [
-                [f'Additional Exception info pased in by PySimpleGUI or user: Error type is: {type(msg).__name__}']
-            ]
+            lines += [[f'Additional Exception info pased in by PySimpleGUI or user: Error type is: {type(msg).__name__}']]
             lines += [[f'In file {__file__} Line number {msg.__traceback__.tb_lineno}']]
             lines += [[f'{msg}']]
         else:
@@ -28785,7 +25291,7 @@ def _process_thread(*args):
     try:
         __shell_process__ = subprocess.run(args, shell=True, stdout=subprocess.PIPE)
     except Exception:
-        print('Exception running process args = {}'.format(args))
+        print(f'Exception running process args = {args}')
         __shell_process__ = None
 
 
@@ -28925,13 +25431,7 @@ def _create_error_message():
         error_parts = error_message.split(', ')
         if len(error_parts) < 4:
             error_message = error_parts[0] + '\n' + error_parts[1] + '\n' + ''.join(error_parts[2:])
-    return (
-        'The PySimpleGUI internal reporting function is '
-        + called_func
-        + '\n'
-        + 'The error originated from:\n'
-        + error_message
-    )
+    return 'The PySimpleGUI internal reporting function is ' + called_func + '\n' + 'The error originated from:\n' + error_message
 
 
 #   .d8888b.           888    888    d8b
@@ -29015,9 +25515,7 @@ class UserSettings:
     class _SectionDict:
         item_count = 0
 
-        def __init__(
-            self, section_name, section_dict, config, user_settings_parent
-        ):  # (str, Dict, configparser.ConfigParser)
+        def __init__(self, section_name, section_dict, config, user_settings_parent):  # (str, Dict, configparser.ConfigParser)
             """
             The Section Dictionary.  It holds the values for a section.
 
@@ -29057,9 +25555,9 @@ class UserSettings:
             :return: the dictionary as a string
             :rtype:  (str)
             """
-            return_string = '{}:\n'.format(self.section_name)
+            return_string = f'{self.section_name}:\n'
             for entry in self.section_dict.keys():
-                return_string += '          {} : {}\n'.format(entry, self.section_dict[entry])
+                return_string += f'          {entry} : {self.section_dict[entry]}\n'
 
             return return_string
 
@@ -29196,9 +25694,7 @@ class UserSettings:
         if path is None:
             if self.path is not None:
                 # path = self.path
-                path = os.path.expanduser(
-                    self.path
-                )  # expand user provided path in case it has user ~ in it. Don't think it'll hurt
+                path = os.path.expanduser(self.path)  # expand user provided path in case it has user ~ in it. Don't think it'll hurt
             elif DEFAULT_USER_SETTINGS_PATH is not None:  # if user set the path manually system-wide using set options
                 path = os.path.expanduser(DEFAULT_USER_SETTINGS_PATH)
             elif running_trinket():
@@ -29251,11 +25747,7 @@ class UserSettings:
         :return:         The full pathname of the settings file that has both the path and filename combined.
         :rtype:          (str)
         """
-        if (
-            filename is not None
-            or path is not None
-            or (filename is None and path is None and self.full_filename is None)
-        ):
+        if filename is not None or path is not None or (filename is None and path is None and self.full_filename is None):
             self.set_location(filename=filename, path=path)
             self.read()
         return self.full_filename
@@ -29333,9 +25825,7 @@ class UserSettings:
             os.remove(self.full_filename)
         except Exception as e:
             if report_error:
-                _error_popup_with_traceback(
-                    'UserSettings delete_file warning ***', 'Exception trying to perform os.remove', e
-                )
+                _error_popup_with_traceback('UserSettings delete_file warning ***', 'Exception trying to perform os.remove', e)
         self.dict = {}
 
     def write_new_dictionary(self, settings_dict):
@@ -29361,7 +25851,7 @@ class UserSettings:
             return {}
         try:
             if os.path.exists(self.full_filename):
-                with open(self.full_filename, 'r') as f:
+                with open(self.full_filename) as f:
                     if not self.use_config_file:  # if using json
                         self.dict = json.load(f)
                     else:  # if using a config file
@@ -29370,9 +25860,7 @@ class UserSettings:
                         self.section_class_dict = {}
                         for section in self.config.sections():
                             section_dict = dict(self.config[section])
-                            self.section_class_dict[section] = self._SectionDict(
-                                section, section_dict, self.config, self
-                            )
+                            self.section_class_dict[section] = self._SectionDict(section, section_dict, self.config, self)
 
                         self.dict = self.section_class_dict
                         self.config_sections = self.config.sections()
@@ -29381,9 +25869,7 @@ class UserSettings:
                     #     self.config_file_contents = f.readlines()
         except Exception as e:
             if not self.silent_on_error:
-                _error_popup_with_traceback(
-                    'User Settings read warning', 'Error reading settings from file', self.full_filename, e
-                )
+                _error_popup_with_traceback('User Settings read warning', 'Error reading settings from file', self.full_filename, e)
                 # print('*** UserSettings.read - Error reading settings from file: ***\n', self.full_filename, e)
                 # print(_create_error_message())
 
@@ -29424,9 +25910,7 @@ class UserSettings:
                     self.save()
             else:
                 if silent_on_error is False or (silent_on_error is not True and not self.silent_on_error):
-                    _error_popup_with_traceback(
-                        'User Settings delete_entry Warning - key', key, ' not found in settings'
-                    )
+                    _error_popup_with_traceback('User Settings delete_entry Warning - key', key, ' not found in settings')
 
         else:
             if section is not None:
@@ -29778,9 +26262,7 @@ These are the functions used to implement the subprocess APIs (Exec APIs) of PyS
 '''
 
 
-def execute_command_subprocess(
-    command, *args, wait=False, cwd=None, pipe_output=False, merge_stderr_with_stdout=True, stdin=None
-):
+def execute_command_subprocess(command, *args, wait=False, cwd=None, pipe_output=False, merge_stderr_with_stdout=True, stdin=None):
     """
     Runs the specified command as a subprocess.
     By default the call is non-blocking.
@@ -29843,9 +26325,7 @@ def execute_command_subprocess(
                     stdin=stdin,
                 )
         else:
-            sp = subprocess.Popen(
-                command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, stdin=stdin
-            )
+            sp = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, stdin=stdin)
         if wait:
             out, err = sp.communicate()
             if out:
@@ -29853,21 +26333,19 @@ def execute_command_subprocess(
             if err:
                 print(err.decode('utf-8'))
     except Exception as e:
-        warnings.warn('Error in execute_command_subprocess {}'.format(e), UserWarning)
+        warnings.warn(f'Error in execute_command_subprocess {e}', UserWarning)
         _error_popup_with_traceback(
             'Error in execute_command_subprocess',
             e,
-            'command={}'.format(command),
-            'args={}'.format(args),
-            'cwd={}'.format(cwd),
+            f'command={command}',
+            f'args={args}',
+            f'cwd={cwd}',
         )
         sp = None
     return sp
 
 
-def execute_py_file(
-    pyfile, parms=None, cwd=None, interpreter_command=None, wait=False, pipe_output=False, merge_stderr_with_stdout=True
-):
+def execute_py_file(pyfile, parms=None, cwd=None, interpreter_command=None, wait=False, pipe_output=False, merge_stderr_with_stdout=True):
     """
     Executes a Python file.
     The interpreter to use is chosen based on this priority order:
@@ -29974,12 +26452,7 @@ def execute_editor(file_to_edit, line_number=None):
     :return:             Popen object
     :rtype:              (subprocess.Popen) | None
     """
-    if (
-        file_to_edit is not None
-        and len(file_to_edit) != 0
-        and file_to_edit[0] not in ('\"', "\'")
-        and ' ' in file_to_edit
-    ):
+    if file_to_edit is not None and len(file_to_edit) != 0 and file_to_edit[0] not in ('\"', "\'") and ' ' in file_to_edit:
         file_to_edit = '"' + file_to_edit + '"'
     pysimplegui_user_settings.load()  # Refresh the settings just in case they've changed via another program
     editor_program = pysimplegui_user_settings.get('-editor program-', None)
@@ -30173,12 +26646,8 @@ def _read_mac_global_settings():
     global ENABLE_MAC_DISABLE_GRAB_ANYWHERE_WITH_TITLEBAR
     global ENABLE_MAC_ALPHA_99_PATCH
 
-    ENABLE_MAC_MODAL_DISABLE_PATCH = pysimplegui_user_settings.get(
-        MAC_PATCH_DICT['Disable Modal Windows'][0], MAC_PATCH_DICT['Disable Modal Windows'][1]
-    )
-    ENABLE_MAC_NOTITLEBAR_PATCH = pysimplegui_user_settings.get(
-        MAC_PATCH_DICT['Enable No Titlebar Patch'][0], MAC_PATCH_DICT['Enable No Titlebar Patch'][1]
-    )
+    ENABLE_MAC_MODAL_DISABLE_PATCH = pysimplegui_user_settings.get(MAC_PATCH_DICT['Disable Modal Windows'][0], MAC_PATCH_DICT['Disable Modal Windows'][1])
+    ENABLE_MAC_NOTITLEBAR_PATCH = pysimplegui_user_settings.get(MAC_PATCH_DICT['Enable No Titlebar Patch'][0], MAC_PATCH_DICT['Enable No Titlebar Patch'][1])
     ENABLE_MAC_DISABLE_GRAB_ANYWHERE_WITH_TITLEBAR = pysimplegui_user_settings.get(
         MAC_PATCH_DICT['Disable Grab Anywhere with Titlebar'][0],
         MAC_PATCH_DICT['Disable Grab Anywhere with Titlebar'][1],
@@ -30206,9 +26675,7 @@ def _mac_should_apply_notitlebar_patch():
         if tver[0] == 8 and tver[1] == 6 and tver[2] < 10 and ENABLE_MAC_NOTITLEBAR_PATCH:
             return True
     except Exception as e:
-        warnings.warn(
-            'Exception while trying to parse tkinter version {} Error = {}'.format(framework_version, e), UserWarning
-        )
+        warnings.warn(f'Exception while trying to parse tkinter version {framework_version} Error = {e}', UserWarning)
 
     return False
 
@@ -30234,9 +26701,7 @@ def _mac_should_set_alpha_to_99():
             # print("Mac OS Version is {} and patch enabled so applying the patch".format(platform_mac_ver))
             return True
     except Exception as e:
-        warnings.warn(
-            '_mac_should_seet_alpha_to_99 Exception while trying check mac_ver. Error = {}'.format(e), UserWarning
-        )
+        warnings.warn(f'_mac_should_seet_alpha_to_99 Exception while trying check mac_ver. Error = {e}', UserWarning)
         return False
 
     return False
@@ -30266,13 +26731,7 @@ def main_mac_feature_control():
     for key, value in MAC_PATCH_DICT.items():
         layout += [[Checkbox(key, k=value[0], default=pysimplegui_user_settings.get(value[0], value[1]))]]
     layout += [
-        [
-            T(
-                'Currently the no titlebar patch '
-                + ('WILL' if _mac_should_apply_notitlebar_patch() else 'WILL NOT')
-                + ' be applied'
-            )
-        ],
+        [T('Currently the no titlebar patch ' + ('WILL' if _mac_should_apply_notitlebar_patch() else 'WILL NOT') + ' be applied')],
         [T('The no titlebar patch will ONLY be applied on tkinter versions < 8.6.10')],
     ]
     layout += [[Button('Ok'), Button('Cancel')]]
@@ -30284,7 +26743,7 @@ def main_mac_feature_control():
             break
         if event == 'Ok':
             for key, value in values.items():
-                print('setting {} to {}'.format(key, value))
+                print(f'setting {key} to {value}')
                 pysimplegui_user_settings.set(key, value)
             break
     window.close()
@@ -30482,23 +26941,23 @@ class _Debugger:
         # BUTTON - GO (NOTE - This button is invisible!!)
         if event == 'Go':  # GO BUTTON
             self.watcher_window.Element('-REPL-').Update('')
-            self.watcher_window.Element('-OUTPUT-').Update('>>> {}\n'.format(cmd), append=True, autoscroll=True)
+            self.watcher_window.Element('-OUTPUT-').Update(f'>>> {cmd}\n', append=True, autoscroll=True)
 
             try:
-                result = eval('{}'.format(cmd), myglobals, mylocals)
+                result = eval(f'{cmd}', myglobals, mylocals)
             except Exception:
                 if sys.version_info[0] < 3:
                     result = 'Not available in Python 2'
                 else:
                     try:
-                        result = exec('{}'.format(cmd), myglobals, mylocals)
+                        result = exec(f'{cmd}', myglobals, mylocals)
                     except Exception as e:
-                        result = 'Exception {}\n'.format(e)
+                        result = f'Exception {e}\n'
 
-            self.watcher_window.Element('-OUTPUT-').Update('{}\n'.format(result), append=True, autoscroll=True)
+            self.watcher_window.Element('-OUTPUT-').Update(f'{result}\n', append=True, autoscroll=True)
         # BUTTON - DETAIL
         elif event.endswith('_DETAIL_'):  # DETAIL BUTTON
-            var = values['_VAR{}_'.format(event[4])]
+            var = values[f'_VAR{event[4]}_']
             try:
                 result = str(eval(str(var), myglobals, mylocals))
             except:
@@ -30506,7 +26965,7 @@ class _Debugger:
             old_theme = theme()
             theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
             popup_scrolled(
-                str(values['_VAR{}_'.format(event[4])]) + '\n' + result,
+                str(values[f'_VAR{event[4]}_']) + '\n' + result,
                 title=var,
                 non_blocking=True,
                 font=_Debugger.DEBUGGER_VARIABLE_DETAILS_FONT,
@@ -30514,15 +26973,15 @@ class _Debugger:
             theme(old_theme)
         # BUTTON - OBJ
         elif event.endswith('_OBJ_'):  # OBJECT BUTTON
-            var = values['_VAR{}_'.format(event[4])]
+            var = values[f'_VAR{event[4]}_']
             try:
                 result = ObjToStringSingleObj(mylocals[var])
             except Exception:
                 try:
-                    result = eval('{}'.format(var), myglobals, mylocals)
+                    result = eval(f'{var}', myglobals, mylocals)
                     result = ObjToStringSingleObj(result)
                 except Exception as e:
-                    result = '{}\nError showing object {}'.format(e, var)
+                    result = f'{e}\nError showing object {var}'
             old_theme = theme()
             theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
             popup_scrolled(
@@ -30558,8 +27017,8 @@ class _Debugger:
 
         # -------------------- Process the manual "watch list" ------------------
         for i in range(3):
-            key = '_VAR{}_'.format(i)
-            out_key = '_VAR{}_CHANGED_'.format(i)
+            key = f'_VAR{i}_'
+            out_key = f'_VAR{i}_CHANGED_'
             self.myrc = ''
             if self.watcher_window.Element(key):
                 var = values[key]
@@ -30577,30 +27036,28 @@ class _Debugger:
             if key == '-CUSTOM_WATCH-':
                 continue
             if self.local_choices[key]:
-                self.watcher_window.Element('_WATCH{}_'.format(slot)).Update(key)
+                self.watcher_window.Element(f'_WATCH{slot}_').Update(key)
                 try:
-                    self.watcher_window.Element('_WATCH{}_RESULT_'.format(slot), silent_on_error=True).Update(
-                        mylocals[key]
-                    )
+                    self.watcher_window.Element(f'_WATCH{slot}_RESULT_', silent_on_error=True).Update(mylocals[key])
                 except:
-                    self.watcher_window.Element('_WATCH{}_RESULT_'.format(slot)).Update('')
+                    self.watcher_window.Element(f'_WATCH{slot}_RESULT_').Update('')
                 slot += 1
 
             if slot + int(self.custom_watch not in (None, '')) >= _Debugger.NUM_AUTO_WATCH:
                 break
         # If a custom watch was set, display that value in the window
         if self.custom_watch:
-            self.watcher_window.Element('_WATCH{}_'.format(slot)).Update(self.custom_watch)
+            self.watcher_window.Element(f'_WATCH{slot}_').Update(self.custom_watch)
             try:
                 self.myrc = eval(self.custom_watch, myglobals, mylocals)
             except:
                 self.myrc = ''
-            self.watcher_window.Element('_WATCH{}_RESULT_'.format(slot)).Update(self.myrc)
+            self.watcher_window.Element(f'_WATCH{slot}_RESULT_').Update(self.myrc)
             slot += 1
         # blank out all of the slots not used (blank)
         for i in range(slot, _Debugger.NUM_AUTO_WATCH):
-            self.watcher_window.Element('_WATCH{}_'.format(i)).Update('')
-            self.watcher_window.Element('_WATCH{}_RESULT_'.format(i)).Update('')
+            self.watcher_window.Element(f'_WATCH{i}_').Update('')
+            self.watcher_window.Element(f'_WATCH{i}_RESULT_').Update('')
 
         return True  # return indicating the window stayed open
 
@@ -30656,7 +27113,7 @@ class _Debugger:
         for key in sorted_dict:
             value = dict[key]
             wrapped_text = str(value)
-            out_text += '{} - {}\n'.format(key, wrapped_text)
+            out_text += f'{key} - {wrapped_text}\n'
         old_theme = theme()
         theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
         popup_scrolled(
@@ -30804,7 +27261,7 @@ class _Debugger:
                 value = str(self.locals.get(key))
                 h = min(len(value) // width_value + 1, _Debugger.MAX_LINES_PER_RESULT_FLOATING)
                 line += [
-                    Text('{}'.format(key), size=(width_var, 1), font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
+                    Text(f'{key}', size=(width_var, 1), font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
                     Text(' = ', font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
                     Text(value, key=key, size=(width_value, h), font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
                 ]
@@ -31600,7 +28057,7 @@ These items may solve your problem. Please check those you've done by changing -
 
 def _github_issue_post_make_github_link(title, body):
     pysimplegui_url = 'https://github.com/spyoungtech/FreeSimpleGui'
-    pysimplegui_issues = '{}/issues/new?'.format(pysimplegui_url)
+    pysimplegui_issues = f'{pysimplegui_url}/issues/new?'
 
     # Fix body cuz urllib can't do it smfh
     getVars = {'title': str(title), 'body': str(body)}
@@ -31637,9 +28094,7 @@ def _github_issue_post_validate(values, checklist, issue_types):
 
     checkboxes = any([values[('-CB-', i)] for i in range(len(checklist))])
     if not checkboxes:
-        popup_error(
-            'None of the checkboxes were checked.... you need to have tried something...anything...', keep_on_top=True
-        )
+        popup_error('None of the checkboxes were checked.... you need to have tried something...anything...', keep_on_top=True)
         return False
 
     title = values['-TITLE-'].strip()
@@ -31778,17 +28233,11 @@ def main_open_github_issue():
     )
 
     checklist_col1 = Col(
-        [
-            [CB(c, k=('-CB-', i)), T(t, k='-T{}-'.format(i), enable_events=True)]
-            for i, (c, t) in enumerate(checklist[:4])
-        ],
+        [[CB(c, k=('-CB-', i)), T(t, k=f'-T{i}-', enable_events=True)] for i, (c, t) in enumerate(checklist[:4])],
         k='-C FRAME CBs1-',
     )
     checklist_col2 = Col(
-        [
-            [CB(c, k=('-CB-', i + 4)), T(t, k='-T{}-'.format(i + 4), enable_events=True)]
-            for i, (c, t) in enumerate(checklist[4:])
-        ],
+        [[CB(c, k=('-CB-', i + 4)), T(t, k=f'-T{i + 4}-', enable_events=True)] for i, (c, t) in enumerate(checklist[4:])],
         pad=(0, 0),
         k='-C FRAME CBs2-',
     )
@@ -31806,9 +28255,7 @@ def main_open_github_issue():
 
     frame_details = [[Multiline(size=(65, 10), font='Courier 10', k='-ML DETAILS-', expand_x=True, expand_y=True)]]
 
-    tooltip_project_details = (
-        'If you care to share a little about your project,\nthen by all means tell us what you are making!'
-    )
+    tooltip_project_details = 'If you care to share a little about your project,\nthen by all means tell us what you are making!'
     frame_project_details = [
         [
             Multiline(
@@ -31837,9 +28284,7 @@ def main_open_github_issue():
     ]
 
     tooltip_code = 'A short program that can be immediately run will considerably speed up getting you quality help.'
-    frame_code = [
-        [Multiline(size=(80, 10), font='Courier 8', k='-ML CODE-', expand_x=True, expand_y=True, tooltip=tooltip_code)]
-    ]
+    frame_code = [[Multiline(size=(80, 10), font='Courier 8', k='-ML CODE-', expand_x=True, expand_y=True, tooltip=tooltip_code)]]
 
     frame_markdown = [[Multiline(size=(80, 10), font='Courier 8', k='-ML MARKDOWN-', expand_x=True, expand_y=True)]]
 
@@ -31907,12 +28352,10 @@ def main_open_github_issue():
         [Col([[B('Post Issue'), B('Create Markdown Only'), B('Quit')]])],
     ]
 
-    window = Window(
-        'Open A GitHub Issue', layout, finalize=True, resizable=True, enable_close_attempted_event=True, margins=(0, 0)
-    )
+    window = Window('Open A GitHub Issue', layout, finalize=True, resizable=True, enable_close_attempted_event=True, margins=(0, 0))
 
     # for i in range(len(checklist)):
-    [window['-T{}-'.format(i)].set_cursor('hand1') for i in range(len(checklist))]
+    [window[f'-T{i}-'].set_cursor('hand1') for i in range(len(checklist))]
 
     if running_mac():
         window['-OS MAC VER-'].update(platform.mac_ver())
@@ -31943,7 +28386,7 @@ def main_open_github_issue():
                 break
         if event == WIN_CLOSED:
             break
-        if event in ['-T{}-'.format(i) for i in range(len(checklist))]:
+        if event in [f'-T{i}-' for i in range(len(checklist))]:
             webbrowser.open_new_tab(window[event].get())
         if event in issue_types:
             title = str(values['-TITLE-'])
@@ -31951,12 +28394,10 @@ def main_open_github_issue():
                 if title[0] == '[' and title.find(']'):
                     title = title[title.find(']') + 1 :]
                     title = title.strip()
-            window['-TITLE-'].update('[{}] {}'.format(event, title))
+            window['-TITLE-'].update(f'[{event}] {title}')
         if event == '-HIDE CLIST-':
             window['-TOP COL-'].update(visible=not window['-TOP COL-'].visible)
-            window['-HIDE CLIST-'].update(
-                text=SYMBOL_UP if window['-HIDE CLIST-'].get_text() == SYMBOL_DOWN else SYMBOL_DOWN
-            )
+            window['-HIDE CLIST-'].update(text=SYMBOL_UP if window['-HIDE CLIST-'].get_text() == SYMBOL_DOWN else SYMBOL_DOWN)
         if event == 'Help':
             _github_issue_help()
         elif event in ('Post Issue', 'Create Markdown Only'):
@@ -32170,20 +28611,12 @@ def _global_settings_get_watermark_info():
     forced = Window._watermark_temp_forced
     prefix_text = pysimplegui_user_settings.get('-watermark text-', '')
 
-    ver_text = (
-        ' ' + version.split(' ', 1)[0]
-        if pysimplegui_user_settings.get('-watermark ver-', False if not forced else True) or forced
-        else ''
-    )
-    framework_ver_text = (
-        ' Tk ' + framework_version
-        if pysimplegui_user_settings.get('-watermark framework ver-', False if not forced else True) or forced
-        else ''
-    )
+    ver_text = ' ' + version.split(' ', 1)[0] if pysimplegui_user_settings.get('-watermark ver-', False if not forced else True) or forced else ''
+    framework_ver_text = ' Tk ' + framework_version if pysimplegui_user_settings.get('-watermark framework ver-', False if not forced else True) or forced else ''
     watermark_font = pysimplegui_user_settings.get('-watermark font-', '_ 9 bold')
     # background_color = pysimplegui_user_settings.get('-watermark bg color-', 'window.BackgroundColor')
     user_text = pysimplegui_user_settings.get('-watermark text-', '')
-    python_text = ' Py {}.{}.{}'.format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+    python_text = f' Py {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'
     if user_text:
         text = str(user_text)
     else:
@@ -32192,9 +28625,7 @@ def _global_settings_get_watermark_info():
 
 
 def main_global_get_screen_snapshot_symcode():
-    pysimplegui_user_settings = UserSettings(
-        filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH
-    )
+    pysimplegui_user_settings = UserSettings(filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH)
 
     settings = pysimplegui_user_settings.read()
 
@@ -32202,7 +28633,7 @@ def main_global_get_screen_snapshot_symcode():
     for i in range(4):
         keysym = settings.get(json.dumps(('-snapshot keysym-', i)), '')
         if keysym:
-            screenshot_keysym += '<{}>'.format(keysym)
+            screenshot_keysym += f'<{keysym}>'
 
     screenshot_keysym_manual = settings.get('-snapshot keysym manual-', '')
 
@@ -32268,17 +28699,9 @@ def main_global_pysimplegui_settings():
         + 'IDLE - <editor> <file>\n'
     )
 
-    tooltip_file_explorer = (
-        'This is the program you normally use to "Browse" for files\n'
-        + 'For Windows this is normally "explorer". On Linux "nemo" is sometimes used.'
-    )
+    tooltip_file_explorer = 'This is the program you normally use to "Browse" for files\n' + 'For Windows this is normally "explorer". On Linux "nemo" is sometimes used.'
 
-    tooltip_theme = (
-        'The normal default theme for PySimpleGUI is "Dark Blue 13\n'
-        + 'If you do not call theme("theme name") by your program to change the theme, then the default is used.\n'
-        + 'This setting allows you to set the theme that PySimpleGUI will use for ALL of your programs that\n'
-        + 'do not set a theme specifically.'
-    )
+    tooltip_theme = 'The normal default theme for PySimpleGUI is "Dark Blue 13\n' + 'If you do not call theme("theme name") by your program to change the theme, then the default is used.\n' + 'This setting allows you to set the theme that PySimpleGUI will use for ALL of your programs that\n' + 'do not set a theme specifically.'
 
     # ------------------------- TTK Tab -------------------------
     ttk_scrollbar_tab_layout = [
@@ -32435,7 +28858,7 @@ def main_global_pysimplegui_settings():
     theme_tab = Tab(
         'Theme',
         [
-            [T('Leave blank for "official" PySimpleGUI default theme: {}'.format(OFFICIAL_PYSIMPLEGUI_THEME))],
+            [T(f'Leave blank for "official" PySimpleGUI default theme: {OFFICIAL_PYSIMPLEGUI_THEME}')],
             [
                 T('Default Theme For All Programs:'),
                 Combo(
@@ -32776,11 +29199,7 @@ def main_sdk_help():
                     if inspect.isfunction(elem):
                         ml.print('Not a class...It is a function', background_color='red', text_color='white')
                     else:
-                        element_methods = [
-                            m[0]
-                            for m in inspect.getmembers(Element, inspect.isfunction)
-                            if not m[0].startswith('_') and not m[0][0].isupper()
-                        ]
+                        element_methods = [m[0] for m in inspect.getmembers(Element, inspect.isfunction) if not m[0].startswith('_') and not m[0][0].isupper()]
                         methods = inspect.getmembers(elem, inspect.isfunction)
                         methods = [m[0] for m in methods if not m[0].startswith('_') and not m[0][0].isupper()]
 
@@ -32799,14 +29218,12 @@ def main_sdk_help():
                         ml.print('========== Init Parms ==========', background_color='#FFFF00', text_color='black')
                         elem_text_name = event
                         for parm, default in element_arg_default_dict[elem_text_name]:
-                            ml.print('{:18}'.format(parm), end=' = ')
+                            ml.print(f'{parm:18}', end=' = ')
                             ml.print(default, end=',\n')
                         if elem_text_name in element_arg_default_dict_update:
-                            ml.print(
-                                '========== Update Parms ==========', background_color='#FFFF00', text_color='black'
-                            )
+                            ml.print('========== Update Parms ==========', background_color='#FFFF00', text_color='black')
                             for parm, default in element_arg_default_dict_update[elem_text_name]:
-                                ml.print('{:18}'.format(parm), end=' = ')
+                                ml.print(f'{parm:18}', end=' = ')
                                 ml.print(default, end=',\n')
                 ml.set_vscroll_position(0)  # scroll to top of multoline
             elif event == 'Func Search':
@@ -32892,11 +29309,11 @@ def _create_main_window():
     print(
         'PySimpleGUI Version ',
         ver,
-        '\ntcl ver = {}'.format(tclversion),
-        'tkinter version = {}'.format(tkversion),
-        '\nPython Version {}'.format(sys.version),
+        f'\ntcl ver = {tclversion}',
+        f'tkinter version = {tkversion}',
+        f'\nPython Version {sys.version}',
     )
-    print('tcl detailed version = {}'.format(tclversion_detailed))
+    print(f'tcl detailed version = {tclversion_detailed}')
     print('PySimpleGUI.py location', __file__)
     # ------ Menu Definition ------ #
     menu_def = [
@@ -33158,9 +29575,7 @@ def _create_main_window():
     layout_top = Column(
         [
             [
-                Image(
-                    EMOJI_BASE64_HAPPY_BIG_SMILE, enable_events=True, key='-LOGO-', tooltip='This is PySimpleGUI logo'
-                ),
+                Image(EMOJI_BASE64_HAPPY_BIG_SMILE, enable_events=True, key='-LOGO-', tooltip='This is PySimpleGUI logo'),
                 Image(data=DEFAULT_BASE64_LOADING_GIF, enable_events=True, key='-IMAGE-'),
                 Text('PySimpleGUI Test Harness', font='ANY 14', tooltip='My tooltip', key='-TEXT1-'),
             ],
@@ -33169,8 +29584,7 @@ def _create_main_window():
             VerLine(tclversion_detailed, 'detailed tkinter version'),
             VerLine(os.path.dirname(os.path.abspath(__file__)), 'PySimpleGUI Location', size=(40, None)),
             VerLine(sys.executable, 'Python Executable'),
-            VerLine(sys.version, 'Python Version', size=(40, 2))
-            + [Image(PYTHON_COLORED_HEARTS_BASE64, subsample=3, k='-PYTHON HEARTS-', enable_events=True)],
+            VerLine(sys.version, 'Python Version', size=(40, 2)) + [Image(PYTHON_COLORED_HEARTS_BASE64, subsample=3, k='-PYTHON HEARTS-', enable_events=True)],
         ],
         pad=0,
     )
@@ -33199,9 +29613,7 @@ def _create_main_window():
             B('SDK Reference', pad=(1, 0)),
             B('Open GitHub Issue', pad=(1, 0)),
             B('Versions for GitHub', pad=(1, 0)),
-            ButtonMenu(
-                'ButtonMenu', button_menu_def, pad=(1, 0), key='-BMENU-', tearoff=True, disabled_text_color='yellow'
-            ),
+            ButtonMenu('ButtonMenu', button_menu_def, pad=(1, 0), key='-BMENU-', tearoff=True, disabled_text_color='yellow'),
         ],
     ]
 
@@ -33288,12 +29700,7 @@ def main():
             print(event, values)
             # Print(event, text_color='white', background_color='red', end='')
             # Print(values)
-        if (
-            event == WIN_CLOSED
-            or event == WIN_CLOSE_ATTEMPTED_EVENT
-            or event == 'Exit'
-            or (event == '-BMENU-' and values['-BMENU-'] == 'Exit')
-        ):
+        if event == WIN_CLOSED or event == WIN_CLOSE_ATTEMPTED_EVENT or event == 'Exit' or (event == '-BMENU-' and values['-BMENU-'] == 'Exit'):
             break
         if i < graph_elem.CanvasSize[0]:
             x = i % graph_elem.CanvasSize[0]
@@ -33301,7 +29708,7 @@ def main():
                 (x, 0),
                 (x, random.randint(0, graph_elem.CanvasSize[1])),
                 width=1,
-                color='#{:06x}'.format(random.randint(0, 0xFFFFFF)),
+                color=f'#{random.randint(0, 0xFFFFFF):06x}',
             )
             graph_figures.append(fig)
         else:
@@ -33311,7 +29718,7 @@ def main():
                 (x, 0),
                 (x, random.randint(0, graph_elem.CanvasSize[1])),
                 width=1,
-                color='#{:06x}'.format(random.randint(0, 0xFFFFFF)),
+                color=f'#{random.randint(0, 0xFFFFFF):06x}',
             )
             graph_figures.append(fig)
             graph_elem.delete_figure(graph_figures[0])
@@ -33357,9 +29764,7 @@ def main():
         elif event in ('-EMOJI-HEARTS-', '-HEART-', '-PYTHON HEARTS-'):
             pass
         elif event == 'Themes':
-            search_string = popup_get_text(
-                'Enter a search term or leave blank for all themes', 'Show Available Themes', keep_on_top=True
-            )
+            search_string = popup_get_text('Enter a search term or leave blank for all themes', 'Show Available Themes', keep_on_top=True)
             if search_string is not None:
                 theme_previewer(search_string=search_string)
         elif event == 'Theme Swatches':
@@ -33494,9 +29899,7 @@ def _optional_window_data(window):
     return None
 
 
-pysimplegui_user_settings = UserSettings(
-    filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH
-)
+pysimplegui_user_settings = UserSettings(filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH)
 # ------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
 
 
@@ -33513,9 +29916,7 @@ if running_trinket():
 
 if tclversion_detailed.startswith('8.5'):
     warnings.warn(
-        'You are running a VERY old version of tkinter {}. You cannot use PNG formatted images for example.  Please upgrade to 8.6.x'.format(
-            tclversion_detailed
-        ),
+        'You are running a VERY old version of tkinter {}. You cannot use PNG formatted images for example.  Please upgrade to 8.6.x'.format(tclversion_detailed),
         UserWarning,
     )
 

--- a/FreeSimpleGUI/FreeSimpleGUI.py
+++ b/FreeSimpleGUI/FreeSimpleGUI.py
@@ -13691,14 +13691,14 @@ class Window:
 
     def _OnMotion(self, event):
 
-        self.TKroot.geometry(f'+{event.x_root-self._mouse_offset_x}+{event.y_root-self._mouse_offset_y}')
+        self.TKroot.geometry(f'+{event.x_root - self._mouse_offset_x}+{event.y_root - self._mouse_offset_y}')
         # ------ Move All Windows code ------
         try:
             if Window._move_all_windows:
                 for win in Window._active_windows:
                     if win == self:
                         continue
-                    win.TKroot.geometry(f'+{event.x_root-win._mouse_offset_x}+{event.y_root-win._mouse_offset_y}')
+                    win.TKroot.geometry(f'+{event.x_root - win._mouse_offset_x}+{event.y_root - win._mouse_offset_y}')
         except Exception as e:
             print('on motion error', e)
 

--- a/FreeSimpleGUI/FreeSimpleGUI.py
+++ b/FreeSimpleGUI/FreeSimpleGUI.py
@@ -1,10 +1,54 @@
 #!/usr/bin/python3
+from __future__ import annotations
 
-version = __version__ = '5.0.0rc1'
+import calendar
+import configparser
+import copy
+import ctypes
+import datetime
+import difflib
+import inspect
+import itertools
+import json
+import os
+import pickle
+import platform
+import pprint
+import pydoc
+import queue
+import random
+import socket
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+import tkinter as tk
+import tkinter.font
+import traceback
+import urllib.error
+import urllib.parse
+import warnings
+from functools import wraps
+from math import fabs
+from math import floor
+from tkinter import filedialog  # noqa
+from tkinter import ttk
+from tkinter.colorchooser import askcolor  # noqa
+from typing import Any  # noqa
+from typing import Dict  # noqa
+from typing import List  # noqa
+from typing import Tuple  # noqa
+
+
+# get the tkinter detailed version
+tclversion_detailed = tkinter.Tcl().eval('info patchlevel')
+framework_version = tclversion_detailed
+
+version = __version__ = '5.0.1'
 
 _change_log = ''
 
-__version__ = version.split()[0]  # For PEP 396 and PEP 345
 
 # The shortened version of version
 try:
@@ -13,75 +57,16 @@ except:
     ver = ''
 
 # __version__ = version
-
-port = 'PySimpleGUI'
-
-# all of the tkinter involved imports
-import tkinter as tk
-from tkinter import filedialog
-from tkinter.colorchooser import askcolor
-from tkinter import ttk
-# import tkinter.scrolledtext as tkst
-import tkinter.font
-from uuid import uuid4
-
-# end of tkinter specific imports
-# get the tkinter detailed version
-tclversion_detailed = tkinter.Tcl().eval('info patchlevel')
-framework_version = tclversion_detailed
-
-import time
-import pickle
-import calendar
-import datetime
-import textwrap
-
-import socket
-import inspect
-import traceback
-import difflib
-import copy
-import pprint
-try:  # Because Raspberry Pi is still on 3.4....it's not critical if this module isn't imported on the Pi
-    from typing import List, Any, Union, Tuple, Dict, SupportsAbs, Optional  # because this code has to run on 2.7 can't use real type hints.  Must do typing only in comments
-except:
-    print('*** Skipping import of Typing module. "pip3 install typing" to remove this warning ***')
-import random
-import warnings
-from math import floor
-from math import fabs
-from functools import wraps
-
-try:  # Because Raspberry Pi is still on 3.4....
-    # from subprocess import run, PIPE, Popen
-    import subprocess
-except Exception as e:
-    print('** Import error {} **'.format(e))
-
-import threading
-import itertools
-import json
-import configparser
-import queue
-
 try:
     import webbrowser
 
     webbrowser_available = True
 except:
     webbrowser_available = False
-# used for github upgrades
-import urllib.request
-import urllib.error
-import urllib.parse
-import pydoc
-from urllib import request
-import os
-import sys
-import re
-import tempfile
-import ctypes
-import platform
+
+
+port = 'FreeSimpleGUI'
+
 
 pil_import_attempted = pil_imported = False
 
@@ -95,6 +80,7 @@ g_time_delta = 0
 # These timer routines are to help you quickly time portions of code.  Place the timer_start call at the point
 # you want to start timing and the timer_stop at the end point. The delta between the start and stop calls
 # is returned from calling timer_stop
+
 
 def timer_start():
     """
@@ -118,6 +104,7 @@ def timer_stop():
     g_time_end = time.time()
     g_time_delta = g_time_end - g_time_start
     return int(g_time_delta * 1000)
+
 
 def timer_stop_usec():
     """
@@ -200,7 +187,6 @@ def formatted_datetime_now():
     return current_time
 
 
-
 def running_linux():
     """
     Determines the OS is Linux by using sys.platform
@@ -265,8 +251,6 @@ def running_replit():
     if 'REPL_OWNER' in os.environ and sys.platform.startswith('linux'):
         return True
     return False
-
-
 
 
 # Handy python statements to increment and decrement with wrapping that I don't want to forget
@@ -349,14 +333,18 @@ PURPLES = ('#480656', '#4F2398', '#380474')
 GREENS = ('#01826B', '#40A860', '#96D2AB', '#00A949', '#003532')
 YELLOWS = ('#F3FB62', '#F0F595')
 TANS = ('#FFF9D5', '#F4EFCF', '#DDD8BA')
-NICE_BUTTON_COLORS = ((GREENS[3], TANS[0]),
-                      ('#000000', '#FFFFFF'),
-                      ('#FFFFFF', '#000000'),
-                      (YELLOWS[0], PURPLES[1]),
-                      (YELLOWS[0], GREENS[3]),
-                      (YELLOWS[0], BLUES[2]))
+NICE_BUTTON_COLORS = (
+    (GREENS[3], TANS[0]),
+    ('#000000', '#FFFFFF'),
+    ('#FFFFFF', '#000000'),
+    (YELLOWS[0], PURPLES[1]),
+    (YELLOWS[0], GREENS[3]),
+    (YELLOWS[0], BLUES[2]),
+)
 
-COLOR_SYSTEM_DEFAULT = '1234567890'  # A Magic Number kind of signal to PySimpleGUI that the color should not be set at all
+COLOR_SYSTEM_DEFAULT = (
+    '1234567890'  # A Magic Number kind of signal to PySimpleGUI that the color should not be set at all
+)
 DEFAULT_BUTTON_COLOR = ('white', BLUES[0])  # Foreground, Background (None, None) == System Default
 OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR = ('white', BLUES[0])
 
@@ -415,7 +403,10 @@ ttk_theme_in_use = None
 USE_TTK_BUTTONS = None
 
 DEFAULT_PROGRESS_BAR_COLOR = ('#01826B', '#D0D0D0')  # a nice green progress bar
-DEFAULT_PROGRESS_BAR_COMPUTE = ('#000000', '#000000')  # Means that the progress bar colors should be computed from other colors
+DEFAULT_PROGRESS_BAR_COMPUTE = (
+    '#000000',
+    '#000000',
+)  # Means that the progress bar colors should be computed from other colors
 DEFAULT_PROGRESS_BAR_COLOR_OFFICIAL = ('#01826B', '#D0D0D0')  # a nice green progress bar
 DEFAULT_PROGRESS_BAR_SIZE = (20, 20)  # Size of Progress Bar (characters for length, pixels for width)
 DEFAULT_PROGRESS_BAR_BORDER_WIDTH = 1
@@ -442,7 +433,9 @@ TABLE_SELECT_MODE_NONE = tk.NONE
 TABLE_SELECT_MODE_BROWSE = tk.BROWSE
 TABLE_SELECT_MODE_EXTENDED = tk.EXTENDED
 DEFAULT_TABLE_SELECT_MODE = TABLE_SELECT_MODE_EXTENDED
-TABLE_CLICKED_INDICATOR = '+CLICKED+'           # Part of the tuple returned as an event when a Table element has click events enabled
+TABLE_CLICKED_INDICATOR = (
+    '+CLICKED+'  # Part of the tuple returned as an event when a Table element has click events enabled
+)
 DEFAULT_MODAL_WINDOWS_ENABLED = True
 DEFAULT_MODAL_WINDOWS_FORCED = False
 
@@ -479,7 +472,18 @@ TEXT_LOCATION_BOTTOM_LEFT = tk.SW
 TEXT_LOCATION_BOTTOM_RIGHT = tk.SE
 TEXT_LOCATION_CENTER = tk.CENTER
 
-GRAB_ANYWHERE_IGNORE_THESE_WIDGETS = (ttk.Sizegrip, tk.Scale, ttk.Scrollbar, tk.Scrollbar, tk.Entry, tk.Text, tk.PanedWindow, tk.Listbox, tk.OptionMenu, ttk.Treeview)
+GRAB_ANYWHERE_IGNORE_THESE_WIDGETS = (
+    ttk.Sizegrip,
+    tk.Scale,
+    ttk.Scrollbar,
+    tk.Scrollbar,
+    tk.Entry,
+    tk.Text,
+    tk.PanedWindow,
+    tk.Listbox,
+    tk.OptionMenu,
+    ttk.Treeview,
+)
 
 # ----====----====----==== Constants the user should NOT f-with ====----====----====----#
 ThisRow = 555666777  # magic number
@@ -536,7 +540,7 @@ ENABLE_TREEVIEW_869_PATCH = True
 ENABLE_MAC_NOTITLEBAR_PATCH = False
 ENABLE_MAC_MODAL_DISABLE_PATCH = False
 ENABLE_MAC_DISABLE_GRAB_ANYWHERE_WITH_TITLEBAR = True
-ENABLE_MAC_ALPHA_99_PATCH= False
+ENABLE_MAC_ALPHA_99_PATCH = False
 
 OLD_TABLE_TREE_SELECTED_ROW_COLORS = ('#FFFFFF', '#4A6984')
 ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS = ('SystemHighlightText', 'SystemHighlight')
@@ -584,7 +588,9 @@ DEFAULT_USER_SETTINGS_REPLIT_PATH = r'.'
 DEFAULT_USER_SETTINGS_UNKNOWN_OS_PATH = r'~/Library/Application Support/PySimpleGUI/settings'
 DEFAULT_USER_SETTINGS_PATH = None  # value set by user to override all paths above
 DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH = None  # location of the global PySimpleGUI settings
-DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME = '_PySimpleGUI_settings_global_.json'  # location of the global PySimpleGUI settings
+DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME = (
+    '_PySimpleGUI_settings_global_.json'  # location of the global PySimpleGUI settings
+)
 
 
 # ====================================================================== #
@@ -676,7 +682,6 @@ POPUP_BUTTONS_OK = 0
 POPUP_BUTTONS_NO_BUTTONS = 5
 
 
-
 PSG_THEME_PART_BUTTON_TEXT = 'Button Text Color'
 PSG_THEME_PART_BUTTON_BACKGROUND = 'Button Background Color'
 PSG_THEME_PART_BACKGROUND = 'Background Color'
@@ -684,7 +689,15 @@ PSG_THEME_PART_INPUT_BACKGROUND = 'Input Element Background Color'
 PSG_THEME_PART_INPUT_TEXT = 'Input Element Text Color'
 PSG_THEME_PART_TEXT = 'Text Color'
 PSG_THEME_PART_SLIDER = 'Slider Color'
-PSG_THEME_PART_LIST = [PSG_THEME_PART_BACKGROUND, PSG_THEME_PART_BUTTON_BACKGROUND, PSG_THEME_PART_BUTTON_TEXT,PSG_THEME_PART_INPUT_BACKGROUND, PSG_THEME_PART_INPUT_TEXT, PSG_THEME_PART_TEXT, PSG_THEME_PART_SLIDER ]
+PSG_THEME_PART_LIST = [
+    PSG_THEME_PART_BACKGROUND,
+    PSG_THEME_PART_BUTTON_BACKGROUND,
+    PSG_THEME_PART_BUTTON_TEXT,
+    PSG_THEME_PART_INPUT_BACKGROUND,
+    PSG_THEME_PART_INPUT_TEXT,
+    PSG_THEME_PART_TEXT,
+    PSG_THEME_PART_SLIDER,
+]
 
 # theme_button
 
@@ -695,26 +708,50 @@ TTK_SCROLLBAR_PART_FRAME_COLOR = 'Frame Color'
 TTK_SCROLLBAR_PART_SCROLL_WIDTH = 'Frame Width'
 TTK_SCROLLBAR_PART_ARROW_WIDTH = 'Arrow Width'
 TTK_SCROLLBAR_PART_RELIEF = 'Relief'
-TTK_SCROLLBAR_PART_LIST = [TTK_SCROLLBAR_PART_TROUGH_COLOR, TTK_SCROLLBAR_PART_BACKGROUND_COLOR, TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR,
-                           TTK_SCROLLBAR_PART_FRAME_COLOR, TTK_SCROLLBAR_PART_SCROLL_WIDTH, TTK_SCROLLBAR_PART_ARROW_WIDTH, TTK_SCROLLBAR_PART_RELIEF]
-TTK_SCROLLBAR_PART_THEME_BASED_LIST = [TTK_SCROLLBAR_PART_TROUGH_COLOR, TTK_SCROLLBAR_PART_BACKGROUND_COLOR, TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR,
-                           TTK_SCROLLBAR_PART_FRAME_COLOR]
-DEFAULT_TTK_PART_MAPPING_DICT = {TTK_SCROLLBAR_PART_TROUGH_COLOR: PSG_THEME_PART_SLIDER,
-                                 TTK_SCROLLBAR_PART_BACKGROUND_COLOR : PSG_THEME_PART_BUTTON_BACKGROUND,
-                                 TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR :PSG_THEME_PART_BUTTON_TEXT,
-                                 TTK_SCROLLBAR_PART_FRAME_COLOR : PSG_THEME_PART_BACKGROUND,
-                                 TTK_SCROLLBAR_PART_SCROLL_WIDTH : 12,
-                                 TTK_SCROLLBAR_PART_ARROW_WIDTH: 12,
-                                 TTK_SCROLLBAR_PART_RELIEF: RELIEF_RAISED}
+TTK_SCROLLBAR_PART_LIST = [
+    TTK_SCROLLBAR_PART_TROUGH_COLOR,
+    TTK_SCROLLBAR_PART_BACKGROUND_COLOR,
+    TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR,
+    TTK_SCROLLBAR_PART_FRAME_COLOR,
+    TTK_SCROLLBAR_PART_SCROLL_WIDTH,
+    TTK_SCROLLBAR_PART_ARROW_WIDTH,
+    TTK_SCROLLBAR_PART_RELIEF,
+]
+TTK_SCROLLBAR_PART_THEME_BASED_LIST = [
+    TTK_SCROLLBAR_PART_TROUGH_COLOR,
+    TTK_SCROLLBAR_PART_BACKGROUND_COLOR,
+    TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR,
+    TTK_SCROLLBAR_PART_FRAME_COLOR,
+]
+DEFAULT_TTK_PART_MAPPING_DICT = {
+    TTK_SCROLLBAR_PART_TROUGH_COLOR: PSG_THEME_PART_SLIDER,
+    TTK_SCROLLBAR_PART_BACKGROUND_COLOR: PSG_THEME_PART_BUTTON_BACKGROUND,
+    TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR: PSG_THEME_PART_BUTTON_TEXT,
+    TTK_SCROLLBAR_PART_FRAME_COLOR: PSG_THEME_PART_BACKGROUND,
+    TTK_SCROLLBAR_PART_SCROLL_WIDTH: 12,
+    TTK_SCROLLBAR_PART_ARROW_WIDTH: 12,
+    TTK_SCROLLBAR_PART_RELIEF: RELIEF_RAISED,
+}
 
 ttk_part_mapping_dict = copy.copy(DEFAULT_TTK_PART_MAPPING_DICT)
 
-class TTKPartOverrides():
+
+class TTKPartOverrides:
     """
     This class contains "overrides" to the defaults for ttk scrollbars that are defined in the global settings file.
     This class is used in every element, in the Window class and there's a global one that is used by set_options.
     """
-    def __init__(self, sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None):
+
+    def __init__(
+        self,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+    ):
         self.sbar_trough_color = sbar_trough_color
         self.sbar_background_color = sbar_background_color
         self.sbar_arrow_color = sbar_arrow_color
@@ -723,42 +760,1087 @@ class TTKPartOverrides():
         self.sbar_frame_color = sbar_frame_color
         self.sbar_relief = sbar_relief
 
+
 ttk_part_overrides_from_options = TTKPartOverrides()
 
 
 # -------------------------  tkinter BASIC cursors... there are some OS dependent ones too  ------------------------- #
-TKINTER_CURSORS = ['X_cursor', 'arrow', 'based_arrow_down', 'based_arrow_up', 'boat',
-                   'bogosity', 'bottom_left_corner', 'bottom_right_corner', 'bottom_side',
-                   'bottom_tee', 'box_spiral', 'center_ptr', 'circle', 'clock',
-                   'coffee_mug', 'cross', 'cross_reverse', 'crosshair', 'diamond_cross',
-                   'dot', 'dotbox', 'double_arrow', 'draft_large', 'draft_small', 'draped_box',
-                   'exchange', 'fleur', 'gobbler', 'gumby', 'hand1', 'hand2', 'heart',
-                   'icon', 'iron_cross', 'left_ptr', 'left_side', 'left_tee', 'leftbutton',
-                   'll_angle', 'lr_angle', 'man', 'middlebutton', 'mouse', 'pencil', 'pirate',
-                   'plus', 'question_arrow', 'right_ptr', 'right_side', 'right_tee',
-                   'rightbutton', 'rtl_logo', 'sailboat', 'sb_down_arrow', 'sb_h_double_arrow',
-                   'sb_left_arrow', 'sb_right_arrow', 'sb_up_arrow', 'sb_v_double_arrow',
-                   'shuttle', 'sizing', 'spider', 'spraycan', 'star', 'target', 'tcross',
-                   'top_left_arrow', 'top_left_corner', 'top_right_corner', 'top_side', 'top_tee',
-                   'trek', 'ul_angle', 'umbrella', 'ur_angle', 'watch', 'xterm']
+TKINTER_CURSORS = [
+    'X_cursor',
+    'arrow',
+    'based_arrow_down',
+    'based_arrow_up',
+    'boat',
+    'bogosity',
+    'bottom_left_corner',
+    'bottom_right_corner',
+    'bottom_side',
+    'bottom_tee',
+    'box_spiral',
+    'center_ptr',
+    'circle',
+    'clock',
+    'coffee_mug',
+    'cross',
+    'cross_reverse',
+    'crosshair',
+    'diamond_cross',
+    'dot',
+    'dotbox',
+    'double_arrow',
+    'draft_large',
+    'draft_small',
+    'draped_box',
+    'exchange',
+    'fleur',
+    'gobbler',
+    'gumby',
+    'hand1',
+    'hand2',
+    'heart',
+    'icon',
+    'iron_cross',
+    'left_ptr',
+    'left_side',
+    'left_tee',
+    'leftbutton',
+    'll_angle',
+    'lr_angle',
+    'man',
+    'middlebutton',
+    'mouse',
+    'pencil',
+    'pirate',
+    'plus',
+    'question_arrow',
+    'right_ptr',
+    'right_side',
+    'right_tee',
+    'rightbutton',
+    'rtl_logo',
+    'sailboat',
+    'sb_down_arrow',
+    'sb_h_double_arrow',
+    'sb_left_arrow',
+    'sb_right_arrow',
+    'sb_up_arrow',
+    'sb_v_double_arrow',
+    'shuttle',
+    'sizing',
+    'spider',
+    'spraycan',
+    'star',
+    'target',
+    'tcross',
+    'top_left_arrow',
+    'top_left_corner',
+    'top_right_corner',
+    'top_side',
+    'top_tee',
+    'trek',
+    'ul_angle',
+    'umbrella',
+    'ur_angle',
+    'watch',
+    'xterm',
+]
 
 
-TKINTER_CURSORS = ['X_cursor', 'arrow', 'based_arrow_down', 'based_arrow_up', 'boat', 'bogosity', 'bottom_left_corner', 'bottom_right_corner', 'bottom_side', 'bottom_tee', 'box_spiral', 'center_ptr', 'circle', 'clock', 'coffee_mug', 'cross', 'cross_reverse', 'crosshair', 'diamond_cross', 'dot', 'dotbox', 'double_arrow', 'draft_large', 'draft_small', 'draped_box', 'exchange', 'fleur', 'gobbler', 'gumby', 'hand1', 'hand2', 'heart', 'ibeam', 'icon', 'iron_cross', 'left_ptr', 'left_side', 'left_tee', 'leftbutton', 'll_angle', 'lr_angle', 'man', 'middlebutton', 'mouse', 'no', 'none', 'pencil', 'pirate', 'plus', 'question_arrow', 'right_ptr', 'right_side', 'right_tee', 'rightbutton', 'rtl_logo', 'sailboat', 'sb_down_arrow', 'sb_h_double_arrow', 'sb_left_arrow', 'sb_right_arrow', 'sb_up_arrow', 'sb_v_double_arrow', 'shuttle', 'size', 'size_ne_sw', 'size_ns', 'size_nw_se', 'size_we', 'sizing', 'spider', 'spraycan', 'star', 'starting', 'target', 'tcross', 'top_left_arrow', 'top_left_corner', 'top_right_corner', 'top_side', 'top_tee', 'trek', 'ul_angle', 'umbrella', 'uparrow', 'ur_angle', 'wait', 'watch', 'xterm']
+TKINTER_CURSORS = [
+    'X_cursor',
+    'arrow',
+    'based_arrow_down',
+    'based_arrow_up',
+    'boat',
+    'bogosity',
+    'bottom_left_corner',
+    'bottom_right_corner',
+    'bottom_side',
+    'bottom_tee',
+    'box_spiral',
+    'center_ptr',
+    'circle',
+    'clock',
+    'coffee_mug',
+    'cross',
+    'cross_reverse',
+    'crosshair',
+    'diamond_cross',
+    'dot',
+    'dotbox',
+    'double_arrow',
+    'draft_large',
+    'draft_small',
+    'draped_box',
+    'exchange',
+    'fleur',
+    'gobbler',
+    'gumby',
+    'hand1',
+    'hand2',
+    'heart',
+    'ibeam',
+    'icon',
+    'iron_cross',
+    'left_ptr',
+    'left_side',
+    'left_tee',
+    'leftbutton',
+    'll_angle',
+    'lr_angle',
+    'man',
+    'middlebutton',
+    'mouse',
+    'no',
+    'none',
+    'pencil',
+    'pirate',
+    'plus',
+    'question_arrow',
+    'right_ptr',
+    'right_side',
+    'right_tee',
+    'rightbutton',
+    'rtl_logo',
+    'sailboat',
+    'sb_down_arrow',
+    'sb_h_double_arrow',
+    'sb_left_arrow',
+    'sb_right_arrow',
+    'sb_up_arrow',
+    'sb_v_double_arrow',
+    'shuttle',
+    'size',
+    'size_ne_sw',
+    'size_ns',
+    'size_nw_se',
+    'size_we',
+    'sizing',
+    'spider',
+    'spraycan',
+    'star',
+    'starting',
+    'target',
+    'tcross',
+    'top_left_arrow',
+    'top_left_corner',
+    'top_right_corner',
+    'top_side',
+    'top_tee',
+    'trek',
+    'ul_angle',
+    'umbrella',
+    'uparrow',
+    'ur_angle',
+    'wait',
+    'watch',
+    'xterm',
+]
 # -------------------------  tkinter key codes for bindings  ------------------------- #
 
 # The keycode that when pressed will take a snapshot of the current window
 DEFAULT_WINDOW_SNAPSHOT_KEY_CODE = None
 DEFAULT_WINDOW_SNAPSHOT_KEY = '--SCREENSHOT THIS WINDOW--'
 
-tkinter_keysyms = ('space', 'exclam', 'quotedbl', 'numbersign', 'dollar', 'percent', 'ampersand', 'quoteright', 'parenleft', 'parenright', 'asterisk', 'plus', 'comma', 'minus', 'period', 'slash', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'colon', 'semicolon', 'less', 'equal', 'greater', 'question', 'at', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'bracketleft', 'backslash', 'bracketright', 'asciicircum', 'underscore', 'quoteleft', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'braceleft', 'bar', 'braceright', 'asciitilde', 'nobreakspace', 'exclamdown', 'cent', 'sterling', 'currency', 'yen', 'brokenbar', 'section', 'diaeresis', 'copyright', 'ordfeminine', 'guillemotleft', 'notsign', 'hyphen', 'registered', 'macron', 'degree', 'plusminus', 'twosuperior', 'threesuperior', 'acute', 'mu', 'paragraph', 'periodcentered', 'cedilla', 'onesuperior', 'masculine', 'guillemotright', 'onequarter', 'onehalf', 'threequarters', 'questiondown', 'Agrave', 'Aacute', 'Acircumflex', 'Atilde', 'Adiaeresis', 'Aring', 'AE', 'Ccedilla', 'Egrave', 'Eacute', 'Ecircumflex', 'Ediaeresis', 'Igrave', 'Iacute', 'Icircumflex', 'Idiaeresis', 'Eth', 'Ntilde', 'Ograve', 'Oacute', 'Ocircumflex', 'Otilde', 'Odiaeresis', 'multiply', 'Ooblique', 'Ugrave', 'Uacute', 'Ucircumflex', 'Udiaeresis', 'Yacute', 'Thorn', 'ssharp', 'agrave', 'aacute', 'acircumflex', 'atilde', 'adiaeresis', 'aring', 'ae', 'ccedilla', 'egrave', 'eacute', 'ecircumflex', 'ediaeresis', 'igrave', 'iacute', 'icircumflex', 'idiaeresis', 'eth', 'ntilde', 'ograve', 'oacute', 'ocircumflex', 'otilde', 'odiaeresis', 'division', 'oslash', 'ugrave', 'uacute', 'ucircumflex', 'udiaeresis', 'yacute', 'thorn', 'ydiaeresis', 'Aogonek', 'breve', 'Lstroke', 'Lcaron', 'Sacute', 'Scaron', 'Scedilla', 'Tcaron', 'Zacute', 'Zcaron', 'Zabovedot', 'aogonek', 'ogonek', 'lstroke', 'lcaron', 'sacute', 'caron', 'scaron', 'scedilla', 'tcaron', 'zacute', 'doubleacute', 'zcaron', 'zabovedot', 'Racute', 'Abreve', 'Cacute', 'Ccaron', 'Eogonek', 'Ecaron', 'Dcaron', 'Nacute', 'Ncaron', 'Odoubleacute', 'Rcaron', 'Uring', 'Udoubleacute', 'Tcedilla', 'racute', 'abreve', 'cacute', 'ccaron', 'eogonek', 'ecaron', 'dcaron', 'nacute', 'ncaron', 'odoubleacute', 'rcaron', 'uring', 'udoubleacute', 'tcedilla', 'abovedot', 'Hstroke', 'Hcircumflex', 'Iabovedot', 'Gbreve', 'Jcircumflex', 'hstroke', 'hcircumflex', 'idotless', 'gbreve', 'jcircumflex', 'Cabovedot', 'Ccircumflex', 'Gabovedot', 'Gcircumflex', 'Ubreve', 'Scircumflex', 'cabovedot', 'ccircumflex', 'gabovedot', 'gcircumflex', 'ubreve', 'scircumflex', 'kappa', 'Rcedilla', 'Itilde', 'Lcedilla', 'Emacron', 'Gcedilla', 'Tslash', 'rcedilla', 'itilde', 'lcedilla', 'emacron', 'gacute', 'tslash', 'ENG', 'eng', 'Amacron', 'Iogonek', 'Eabovedot', 'Imacron', 'Ncedilla', 'Omacron', 'Kcedilla', 'Uogonek', 'Utilde', 'Umacron', 'amacron', 'iogonek', 'eabovedot', 'imacron', 'ncedilla', 'omacron', 'kcedilla', 'uogonek', 'utilde', 'umacron', 'overline', 'kana_fullstop', 'kana_openingbracket', 'kana_closingbracket', 'kana_comma', 'kana_middledot', 'kana_WO', 'kana_a', 'kana_i', 'kana_u', 'kana_e', 'kana_o', 'kana_ya', 'kana_yu', 'kana_yo', 'kana_tu', 'prolongedsound', 'kana_A', 'kana_I', 'kana_U', 'kana_E', 'kana_O', 'kana_KA', 'kana_KI', 'kana_KU', 'kana_KE', 'kana_KO', 'kana_SA', 'kana_SHI', 'kana_SU', 'kana_SE', 'kana_SO', 'kana_TA', 'kana_TI', 'kana_TU', 'kana_TE', 'kana_TO', 'kana_NA', 'kana_NI', 'kana_NU', 'kana_NE', 'kana_NO', 'kana_HA', 'kana_HI', 'kana_HU', 'kana_HE', 'kana_HO', 'kana_MA', 'kana_MI', 'kana_MU', 'kana_ME', 'kana_MO', 'kana_YA', 'kana_YU', 'kana_YO', 'kana_RA', 'kana_RI', 'kana_RU', 'kana_RE', 'kana_RO', 'kana_WA', 'kana_N', 'voicedsound', 'semivoicedsound', 'Arabic_comma', 'Arabic_semicolon', 'Arabic_question_mark', 'Arabic_hamza', 'Arabic_maddaonalef', 'Arabic_hamzaonalef', 'Arabic_hamzaonwaw', 'Arabic_hamzaunderalef', 'Arabic_hamzaonyeh', 'Arabic_alef', 'Arabic_beh', 'Arabic_tehmarbuta', 'Arabic_teh', 'Arabic_theh', 'Arabic_jeem', 'Arabic_hah', 'Arabic_khah', 'Arabic_dal', 'Arabic_thal', 'Arabic_ra', 'Arabic_zain', 'Arabic_seen', 'Arabic_sheen', 'Arabic_sad', 'Arabic_dad', 'Arabic_tah', 'Arabic_zah', 'Arabic_ain', 'Arabic_ghain', 'Arabic_tatweel', 'Arabic_feh', 'Arabic_qaf', 'Arabic_kaf', 'Arabic_lam', 'Arabic_meem', 'Arabic_noon', 'Arabic_heh', 'Arabic_waw', 'Arabic_alefmaksura', 'Arabic_yeh', 'Arabic_fathatan', 'Arabic_dammatan', 'Arabic_kasratan', 'Arabic_fatha', 'Arabic_damma', 'Arabic_kasra', 'Arabic_shadda', 'Arabic_sukun', 'Serbian_dje', 'Macedonia_gje', 'Cyrillic_io', 'Ukranian_je', 'Macedonia_dse', 'Ukranian_i', 'Ukranian_yi', 'Serbian_je', 'Serbian_lje', 'Serbian_nje', 'Serbian_tshe', 'Macedonia_kje', 'Byelorussian_shortu', 'Serbian_dze', 'numerosign', 'Serbian_DJE', 'Macedonia_GJE', 'Cyrillic_IO', 'Ukranian_JE', 'Macedonia_DSE', 'Ukranian_I', 'Ukranian_YI', 'Serbian_JE', 'Serbian_LJE', 'Serbian_NJE', 'Serbian_TSHE', 'Macedonia_KJE', 'Byelorussian_SHORTU', 'Serbian_DZE', 'Cyrillic_yu', 'Cyrillic_a', 'Cyrillic_be', 'Cyrillic_tse', 'Cyrillic_de', 'Cyrillic_ie', 'Cyrillic_ef', 'Cyrillic_ghe', 'Cyrillic_ha', 'Cyrillic_i', 'Cyrillic_shorti', 'Cyrillic_ka', 'Cyrillic_el', 'Cyrillic_em', 'Cyrillic_en', 'Cyrillic_o', 'Cyrillic_pe', 'Cyrillic_ya', 'Cyrillic_er', 'Cyrillic_es', 'Cyrillic_te', 'Cyrillic_u', 'Cyrillic_zhe', 'Cyrillic_ve', 'Cyrillic_softsign', 'Cyrillic_yeru', 'Cyrillic_ze', 'Cyrillic_sha', 'Cyrillic_e', 'Cyrillic_shcha', 'Cyrillic_che', 'Cyrillic_hardsign', 'Cyrillic_YU', 'Cyrillic_A', 'Cyrillic_BE', 'Cyrillic_TSE', 'Cyrillic_DE', 'Cyrillic_IE', 'Cyrillic_EF', 'Cyrillic_GHE', 'Cyrillic_HA', 'Cyrillic_I', 'Cyrillic_SHORTI', 'Cyrillic_KA', 'Cyrillic_EL', 'Cyrillic_EM', 'Cyrillic_EN', 'Cyrillic_O', 'Cyrillic_PE', 'Cyrillic_YA', 'Cyrillic_ER', 'Cyrillic_ES', 'Cyrillic_TE', 'Cyrillic_U', 'Cyrillic_ZHE', 'Cyrillic_VE', 'Cyrillic_SOFTSIGN', 'Cyrillic_YERU', 'Cyrillic_ZE', 'Cyrillic_SHA', 'Cyrillic_E', 'Cyrillic_SHCHA', 'Cyrillic_CHE', 'Cyrillic_HARDSIGN', 'Greek_ALPHAaccent', 'Greek_EPSILONaccent', 'Greek_ETAaccent', 'Greek_IOTAaccent', 'Greek_IOTAdiaeresis', 'Greek_IOTAaccentdiaeresis', 'Greek_OMICRONaccent', 'Greek_UPSILONaccent', 'Greek_UPSILONdieresis', 'Greek_UPSILONaccentdieresis', 'Greek_OMEGAaccent', 'Greek_alphaaccent', 'Greek_epsilonaccent', 'Greek_etaaccent', 'Greek_iotaaccent', 'Greek_iotadieresis', 'Greek_iotaaccentdieresis', 'Greek_omicronaccent', 'Greek_upsilonaccent', 'Greek_upsilondieresis', 'Greek_upsilonaccentdieresis', 'Greek_omegaaccent', 'Greek_ALPHA', 'Greek_BETA', 'Greek_GAMMA', 'Greek_DELTA', 'Greek_EPSILON', 'Greek_ZETA', 'Greek_ETA', 'Greek_THETA', 'Greek_IOTA', 'Greek_KAPPA', 'Greek_LAMBDA', 'Greek_MU', 'Greek_NU', 'Greek_XI', 'Greek_OMICRON', 'Greek_PI', 'Greek_RHO', 'Greek_SIGMA', 'Greek_TAU', 'Greek_UPSILON', 'Greek_PHI', 'Greek_CHI', 'Greek_PSI', 'Greek_OMEGA', 'Greek_alpha', 'Greek_beta', 'Greek_gamma', 'Greek_delta', 'Greek_epsilon', 'Greek_zeta', 'Greek_eta', 'Greek_theta', 'Greek_iota', 'Greek_kappa', 'Greek_lambda', 'Greek_mu', 'Greek_nu', 'Greek_xi', 'Greek_omicron', 'Greek_pi', 'Greek_rho', 'Greek_sigma', 'Greek_finalsmallsigma', 'Greek_tau', 'Greek_upsilon', 'Greek_phi', 'Greek_chi', 'Greek_psi', 'Greek_omega', 'leftradical', 'topleftradical', 'horizconnector', 'topintegral', 'botintegral', 'vertconnector', 'topleftsqbracket', 'botleftsqbracket', 'toprightsqbracket', 'botrightsqbracket', 'topleftparens', 'botleftparens', 'toprightparens', 'botrightparens', 'leftmiddlecurlybrace', 'rightmiddlecurlybrace', 'topleftsummation', 'botleftsummation', 'topvertsummationconnector', 'botvertsummationconnector', 'toprightsummation', 'botrightsummation', 'rightmiddlesummation', 'lessthanequal', 'notequal', 'greaterthanequal', 'integral', 'therefore', 'variation', 'infinity', 'nabla', 'approximate', 'similarequal', 'ifonlyif', 'implies', 'identical', 'radical', 'includedin', 'includes', 'intersection', 'union', 'logicaland', 'logicalor', 'partialderivative', 'function', 'leftarrow', 'uparrow', 'rightarrow', 'downarrow', 'blank', 'soliddiamond', 'checkerboard', 'ht', 'ff', 'cr', 'lf', 'nl', 'vt', 'lowrightcorner', 'uprightcorner', 'upleftcorner', 'lowleftcorner', 'crossinglines', 'horizlinescan1', 'horizlinescan3', 'horizlinescan5', 'horizlinescan7', 'horizlinescan9', 'leftt', 'rightt', 'bott', 'topt', 'vertbar', 'emspace', 'enspace', 'em3space', 'em4space', 'digitspace', 'punctspace', 'thinspace', 'hairspace', 'emdash', 'endash', 'signifblank', 'ellipsis', 'doubbaselinedot', 'onethird', 'twothirds', 'onefifth', 'twofifths', 'threefifths', 'fourfifths', 'onesixth', 'fivesixths', 'careof', 'figdash', 'leftanglebracket', 'decimalpoint', 'rightanglebracket', 'marker', 'oneeighth', 'threeeighths', 'fiveeighths', 'seveneighths', 'trademark', 'signaturemark', 'trademarkincircle', 'leftopentriangle', 'rightopentriangle', 'emopencircle', 'emopenrectangle', 'leftsinglequotemark', 'rightsinglequotemark', 'leftdoublequotemark', 'rightdoublequotemark', 'prescription', 'minutes', 'seconds', 'latincross', 'hexagram', 'filledrectbullet', 'filledlefttribullet', 'filledrighttribullet', 'emfilledcircle', 'emfilledrect', 'enopencircbullet', 'enopensquarebullet', 'openrectbullet', 'opentribulletup', 'opentribulletdown', 'openstar', 'enfilledcircbullet', 'enfilledsqbullet', 'filledtribulletup', 'filledtribulletdown', 'leftpointer', 'rightpointer', 'club', 'diamond', 'heart', 'maltesecross', 'dagger', 'doubledagger', 'checkmark', 'ballotcross', 'musicalsharp', 'musicalflat', 'malesymbol', 'femalesymbol', 'telephone', 'telephonerecorder', 'phonographcopyright', 'caret', 'singlelowquotemark', 'doublelowquotemark', 'cursor', 'leftcaret', 'rightcaret', 'downcaret', 'upcaret', 'overbar', 'downtack', 'upshoe', 'downstile', 'underbar', 'jot', 'quad', 'uptack', 'circle', 'upstile', 'downshoe', 'rightshoe', 'leftshoe', 'lefttack', 'righttack', 'hebrew_aleph', 'hebrew_beth', 'hebrew_gimmel', 'hebrew_daleth', 'hebrew_he', 'hebrew_waw', 'hebrew_zayin', 'hebrew_het', 'hebrew_teth', 'hebrew_yod', 'hebrew_finalkaph', 'hebrew_kaph', 'hebrew_lamed', 'hebrew_finalmem', 'hebrew_mem', 'hebrew_finalnun', 'hebrew_nun', 'hebrew_samekh', 'hebrew_ayin', 'hebrew_finalpe', 'hebrew_pe', 'hebrew_finalzadi', 'hebrew_zadi', 'hebrew_kuf', 'hebrew_resh', 'hebrew_shin', 'hebrew_taf', 'BackSpace', 'Tab', 'Linefeed', 'Clear', 'Return', 'Pause', 'Scroll_Lock', 'Sys_Req', 'Escape', 'Multi_key', 'Kanji', 'Home', 'Left', 'Up', 'Right', 'Down', 'Prior', 'Next', 'End', 'Begin', 'Win_L', 'Win_R', 'App', 'Select', 'Print', 'Execute', 'Insert', 'Undo', 'Redo', 'Menu', 'Find', 'Cancel', 'Help', 'Break', 'Hebrew_switch', 'Num_Lock', 'KP_Space', 'KP_Tab', 'KP_Enter', 'KP_F1', 'KP_F2', 'KP_F3', 'KP_F4', 'KP_Multiply', 'KP_Add', 'KP_Separator', 'KP_Subtract', 'KP_Decimal', 'KP_Divide', 'KP_0', 'KP_1', 'KP_2', 'KP_3', 'KP_4', 'KP_5', 'KP_6', 'KP_7', 'KP_8', 'KP_9', 'KP_Equal', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12', 'L1', 'L2', 'L3', 'L4', 'L5', 'L6', 'L7', 'L8', 'L9', 'L10', 'R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7', 'R8', 'R9', 'R10', 'R11', 'R12', 'F33', 'R14', 'R15', 'Shift_L', 'Shift_R', 'Control_L', 'Control_R', 'Caps_Lock', 'Shift_Lock', 'Meta_L', 'Meta_R', 'Alt_L', 'Alt_R', 'Super_L', 'Super_R', 'Hyper_L', 'Hyper_R', 'Delete')
-
-
-
+tkinter_keysyms = (
+    'space',
+    'exclam',
+    'quotedbl',
+    'numbersign',
+    'dollar',
+    'percent',
+    'ampersand',
+    'quoteright',
+    'parenleft',
+    'parenright',
+    'asterisk',
+    'plus',
+    'comma',
+    'minus',
+    'period',
+    'slash',
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    'colon',
+    'semicolon',
+    'less',
+    'equal',
+    'greater',
+    'question',
+    'at',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'I',
+    'J',
+    'K',
+    'L',
+    'M',
+    'N',
+    'O',
+    'P',
+    'Q',
+    'R',
+    'S',
+    'T',
+    'U',
+    'V',
+    'W',
+    'X',
+    'Y',
+    'Z',
+    'bracketleft',
+    'backslash',
+    'bracketright',
+    'asciicircum',
+    'underscore',
+    'quoteleft',
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+    'h',
+    'i',
+    'j',
+    'k',
+    'l',
+    'm',
+    'n',
+    'o',
+    'p',
+    'q',
+    'r',
+    's',
+    't',
+    'u',
+    'v',
+    'w',
+    'x',
+    'y',
+    'z',
+    'braceleft',
+    'bar',
+    'braceright',
+    'asciitilde',
+    'nobreakspace',
+    'exclamdown',
+    'cent',
+    'sterling',
+    'currency',
+    'yen',
+    'brokenbar',
+    'section',
+    'diaeresis',
+    'copyright',
+    'ordfeminine',
+    'guillemotleft',
+    'notsign',
+    'hyphen',
+    'registered',
+    'macron',
+    'degree',
+    'plusminus',
+    'twosuperior',
+    'threesuperior',
+    'acute',
+    'mu',
+    'paragraph',
+    'periodcentered',
+    'cedilla',
+    'onesuperior',
+    'masculine',
+    'guillemotright',
+    'onequarter',
+    'onehalf',
+    'threequarters',
+    'questiondown',
+    'Agrave',
+    'Aacute',
+    'Acircumflex',
+    'Atilde',
+    'Adiaeresis',
+    'Aring',
+    'AE',
+    'Ccedilla',
+    'Egrave',
+    'Eacute',
+    'Ecircumflex',
+    'Ediaeresis',
+    'Igrave',
+    'Iacute',
+    'Icircumflex',
+    'Idiaeresis',
+    'Eth',
+    'Ntilde',
+    'Ograve',
+    'Oacute',
+    'Ocircumflex',
+    'Otilde',
+    'Odiaeresis',
+    'multiply',
+    'Ooblique',
+    'Ugrave',
+    'Uacute',
+    'Ucircumflex',
+    'Udiaeresis',
+    'Yacute',
+    'Thorn',
+    'ssharp',
+    'agrave',
+    'aacute',
+    'acircumflex',
+    'atilde',
+    'adiaeresis',
+    'aring',
+    'ae',
+    'ccedilla',
+    'egrave',
+    'eacute',
+    'ecircumflex',
+    'ediaeresis',
+    'igrave',
+    'iacute',
+    'icircumflex',
+    'idiaeresis',
+    'eth',
+    'ntilde',
+    'ograve',
+    'oacute',
+    'ocircumflex',
+    'otilde',
+    'odiaeresis',
+    'division',
+    'oslash',
+    'ugrave',
+    'uacute',
+    'ucircumflex',
+    'udiaeresis',
+    'yacute',
+    'thorn',
+    'ydiaeresis',
+    'Aogonek',
+    'breve',
+    'Lstroke',
+    'Lcaron',
+    'Sacute',
+    'Scaron',
+    'Scedilla',
+    'Tcaron',
+    'Zacute',
+    'Zcaron',
+    'Zabovedot',
+    'aogonek',
+    'ogonek',
+    'lstroke',
+    'lcaron',
+    'sacute',
+    'caron',
+    'scaron',
+    'scedilla',
+    'tcaron',
+    'zacute',
+    'doubleacute',
+    'zcaron',
+    'zabovedot',
+    'Racute',
+    'Abreve',
+    'Cacute',
+    'Ccaron',
+    'Eogonek',
+    'Ecaron',
+    'Dcaron',
+    'Nacute',
+    'Ncaron',
+    'Odoubleacute',
+    'Rcaron',
+    'Uring',
+    'Udoubleacute',
+    'Tcedilla',
+    'racute',
+    'abreve',
+    'cacute',
+    'ccaron',
+    'eogonek',
+    'ecaron',
+    'dcaron',
+    'nacute',
+    'ncaron',
+    'odoubleacute',
+    'rcaron',
+    'uring',
+    'udoubleacute',
+    'tcedilla',
+    'abovedot',
+    'Hstroke',
+    'Hcircumflex',
+    'Iabovedot',
+    'Gbreve',
+    'Jcircumflex',
+    'hstroke',
+    'hcircumflex',
+    'idotless',
+    'gbreve',
+    'jcircumflex',
+    'Cabovedot',
+    'Ccircumflex',
+    'Gabovedot',
+    'Gcircumflex',
+    'Ubreve',
+    'Scircumflex',
+    'cabovedot',
+    'ccircumflex',
+    'gabovedot',
+    'gcircumflex',
+    'ubreve',
+    'scircumflex',
+    'kappa',
+    'Rcedilla',
+    'Itilde',
+    'Lcedilla',
+    'Emacron',
+    'Gcedilla',
+    'Tslash',
+    'rcedilla',
+    'itilde',
+    'lcedilla',
+    'emacron',
+    'gacute',
+    'tslash',
+    'ENG',
+    'eng',
+    'Amacron',
+    'Iogonek',
+    'Eabovedot',
+    'Imacron',
+    'Ncedilla',
+    'Omacron',
+    'Kcedilla',
+    'Uogonek',
+    'Utilde',
+    'Umacron',
+    'amacron',
+    'iogonek',
+    'eabovedot',
+    'imacron',
+    'ncedilla',
+    'omacron',
+    'kcedilla',
+    'uogonek',
+    'utilde',
+    'umacron',
+    'overline',
+    'kana_fullstop',
+    'kana_openingbracket',
+    'kana_closingbracket',
+    'kana_comma',
+    'kana_middledot',
+    'kana_WO',
+    'kana_a',
+    'kana_i',
+    'kana_u',
+    'kana_e',
+    'kana_o',
+    'kana_ya',
+    'kana_yu',
+    'kana_yo',
+    'kana_tu',
+    'prolongedsound',
+    'kana_A',
+    'kana_I',
+    'kana_U',
+    'kana_E',
+    'kana_O',
+    'kana_KA',
+    'kana_KI',
+    'kana_KU',
+    'kana_KE',
+    'kana_KO',
+    'kana_SA',
+    'kana_SHI',
+    'kana_SU',
+    'kana_SE',
+    'kana_SO',
+    'kana_TA',
+    'kana_TI',
+    'kana_TU',
+    'kana_TE',
+    'kana_TO',
+    'kana_NA',
+    'kana_NI',
+    'kana_NU',
+    'kana_NE',
+    'kana_NO',
+    'kana_HA',
+    'kana_HI',
+    'kana_HU',
+    'kana_HE',
+    'kana_HO',
+    'kana_MA',
+    'kana_MI',
+    'kana_MU',
+    'kana_ME',
+    'kana_MO',
+    'kana_YA',
+    'kana_YU',
+    'kana_YO',
+    'kana_RA',
+    'kana_RI',
+    'kana_RU',
+    'kana_RE',
+    'kana_RO',
+    'kana_WA',
+    'kana_N',
+    'voicedsound',
+    'semivoicedsound',
+    'Arabic_comma',
+    'Arabic_semicolon',
+    'Arabic_question_mark',
+    'Arabic_hamza',
+    'Arabic_maddaonalef',
+    'Arabic_hamzaonalef',
+    'Arabic_hamzaonwaw',
+    'Arabic_hamzaunderalef',
+    'Arabic_hamzaonyeh',
+    'Arabic_alef',
+    'Arabic_beh',
+    'Arabic_tehmarbuta',
+    'Arabic_teh',
+    'Arabic_theh',
+    'Arabic_jeem',
+    'Arabic_hah',
+    'Arabic_khah',
+    'Arabic_dal',
+    'Arabic_thal',
+    'Arabic_ra',
+    'Arabic_zain',
+    'Arabic_seen',
+    'Arabic_sheen',
+    'Arabic_sad',
+    'Arabic_dad',
+    'Arabic_tah',
+    'Arabic_zah',
+    'Arabic_ain',
+    'Arabic_ghain',
+    'Arabic_tatweel',
+    'Arabic_feh',
+    'Arabic_qaf',
+    'Arabic_kaf',
+    'Arabic_lam',
+    'Arabic_meem',
+    'Arabic_noon',
+    'Arabic_heh',
+    'Arabic_waw',
+    'Arabic_alefmaksura',
+    'Arabic_yeh',
+    'Arabic_fathatan',
+    'Arabic_dammatan',
+    'Arabic_kasratan',
+    'Arabic_fatha',
+    'Arabic_damma',
+    'Arabic_kasra',
+    'Arabic_shadda',
+    'Arabic_sukun',
+    'Serbian_dje',
+    'Macedonia_gje',
+    'Cyrillic_io',
+    'Ukranian_je',
+    'Macedonia_dse',
+    'Ukranian_i',
+    'Ukranian_yi',
+    'Serbian_je',
+    'Serbian_lje',
+    'Serbian_nje',
+    'Serbian_tshe',
+    'Macedonia_kje',
+    'Byelorussian_shortu',
+    'Serbian_dze',
+    'numerosign',
+    'Serbian_DJE',
+    'Macedonia_GJE',
+    'Cyrillic_IO',
+    'Ukranian_JE',
+    'Macedonia_DSE',
+    'Ukranian_I',
+    'Ukranian_YI',
+    'Serbian_JE',
+    'Serbian_LJE',
+    'Serbian_NJE',
+    'Serbian_TSHE',
+    'Macedonia_KJE',
+    'Byelorussian_SHORTU',
+    'Serbian_DZE',
+    'Cyrillic_yu',
+    'Cyrillic_a',
+    'Cyrillic_be',
+    'Cyrillic_tse',
+    'Cyrillic_de',
+    'Cyrillic_ie',
+    'Cyrillic_ef',
+    'Cyrillic_ghe',
+    'Cyrillic_ha',
+    'Cyrillic_i',
+    'Cyrillic_shorti',
+    'Cyrillic_ka',
+    'Cyrillic_el',
+    'Cyrillic_em',
+    'Cyrillic_en',
+    'Cyrillic_o',
+    'Cyrillic_pe',
+    'Cyrillic_ya',
+    'Cyrillic_er',
+    'Cyrillic_es',
+    'Cyrillic_te',
+    'Cyrillic_u',
+    'Cyrillic_zhe',
+    'Cyrillic_ve',
+    'Cyrillic_softsign',
+    'Cyrillic_yeru',
+    'Cyrillic_ze',
+    'Cyrillic_sha',
+    'Cyrillic_e',
+    'Cyrillic_shcha',
+    'Cyrillic_che',
+    'Cyrillic_hardsign',
+    'Cyrillic_YU',
+    'Cyrillic_A',
+    'Cyrillic_BE',
+    'Cyrillic_TSE',
+    'Cyrillic_DE',
+    'Cyrillic_IE',
+    'Cyrillic_EF',
+    'Cyrillic_GHE',
+    'Cyrillic_HA',
+    'Cyrillic_I',
+    'Cyrillic_SHORTI',
+    'Cyrillic_KA',
+    'Cyrillic_EL',
+    'Cyrillic_EM',
+    'Cyrillic_EN',
+    'Cyrillic_O',
+    'Cyrillic_PE',
+    'Cyrillic_YA',
+    'Cyrillic_ER',
+    'Cyrillic_ES',
+    'Cyrillic_TE',
+    'Cyrillic_U',
+    'Cyrillic_ZHE',
+    'Cyrillic_VE',
+    'Cyrillic_SOFTSIGN',
+    'Cyrillic_YERU',
+    'Cyrillic_ZE',
+    'Cyrillic_SHA',
+    'Cyrillic_E',
+    'Cyrillic_SHCHA',
+    'Cyrillic_CHE',
+    'Cyrillic_HARDSIGN',
+    'Greek_ALPHAaccent',
+    'Greek_EPSILONaccent',
+    'Greek_ETAaccent',
+    'Greek_IOTAaccent',
+    'Greek_IOTAdiaeresis',
+    'Greek_IOTAaccentdiaeresis',
+    'Greek_OMICRONaccent',
+    'Greek_UPSILONaccent',
+    'Greek_UPSILONdieresis',
+    'Greek_UPSILONaccentdieresis',
+    'Greek_OMEGAaccent',
+    'Greek_alphaaccent',
+    'Greek_epsilonaccent',
+    'Greek_etaaccent',
+    'Greek_iotaaccent',
+    'Greek_iotadieresis',
+    'Greek_iotaaccentdieresis',
+    'Greek_omicronaccent',
+    'Greek_upsilonaccent',
+    'Greek_upsilondieresis',
+    'Greek_upsilonaccentdieresis',
+    'Greek_omegaaccent',
+    'Greek_ALPHA',
+    'Greek_BETA',
+    'Greek_GAMMA',
+    'Greek_DELTA',
+    'Greek_EPSILON',
+    'Greek_ZETA',
+    'Greek_ETA',
+    'Greek_THETA',
+    'Greek_IOTA',
+    'Greek_KAPPA',
+    'Greek_LAMBDA',
+    'Greek_MU',
+    'Greek_NU',
+    'Greek_XI',
+    'Greek_OMICRON',
+    'Greek_PI',
+    'Greek_RHO',
+    'Greek_SIGMA',
+    'Greek_TAU',
+    'Greek_UPSILON',
+    'Greek_PHI',
+    'Greek_CHI',
+    'Greek_PSI',
+    'Greek_OMEGA',
+    'Greek_alpha',
+    'Greek_beta',
+    'Greek_gamma',
+    'Greek_delta',
+    'Greek_epsilon',
+    'Greek_zeta',
+    'Greek_eta',
+    'Greek_theta',
+    'Greek_iota',
+    'Greek_kappa',
+    'Greek_lambda',
+    'Greek_mu',
+    'Greek_nu',
+    'Greek_xi',
+    'Greek_omicron',
+    'Greek_pi',
+    'Greek_rho',
+    'Greek_sigma',
+    'Greek_finalsmallsigma',
+    'Greek_tau',
+    'Greek_upsilon',
+    'Greek_phi',
+    'Greek_chi',
+    'Greek_psi',
+    'Greek_omega',
+    'leftradical',
+    'topleftradical',
+    'horizconnector',
+    'topintegral',
+    'botintegral',
+    'vertconnector',
+    'topleftsqbracket',
+    'botleftsqbracket',
+    'toprightsqbracket',
+    'botrightsqbracket',
+    'topleftparens',
+    'botleftparens',
+    'toprightparens',
+    'botrightparens',
+    'leftmiddlecurlybrace',
+    'rightmiddlecurlybrace',
+    'topleftsummation',
+    'botleftsummation',
+    'topvertsummationconnector',
+    'botvertsummationconnector',
+    'toprightsummation',
+    'botrightsummation',
+    'rightmiddlesummation',
+    'lessthanequal',
+    'notequal',
+    'greaterthanequal',
+    'integral',
+    'therefore',
+    'variation',
+    'infinity',
+    'nabla',
+    'approximate',
+    'similarequal',
+    'ifonlyif',
+    'implies',
+    'identical',
+    'radical',
+    'includedin',
+    'includes',
+    'intersection',
+    'union',
+    'logicaland',
+    'logicalor',
+    'partialderivative',
+    'function',
+    'leftarrow',
+    'uparrow',
+    'rightarrow',
+    'downarrow',
+    'blank',
+    'soliddiamond',
+    'checkerboard',
+    'ht',
+    'ff',
+    'cr',
+    'lf',
+    'nl',
+    'vt',
+    'lowrightcorner',
+    'uprightcorner',
+    'upleftcorner',
+    'lowleftcorner',
+    'crossinglines',
+    'horizlinescan1',
+    'horizlinescan3',
+    'horizlinescan5',
+    'horizlinescan7',
+    'horizlinescan9',
+    'leftt',
+    'rightt',
+    'bott',
+    'topt',
+    'vertbar',
+    'emspace',
+    'enspace',
+    'em3space',
+    'em4space',
+    'digitspace',
+    'punctspace',
+    'thinspace',
+    'hairspace',
+    'emdash',
+    'endash',
+    'signifblank',
+    'ellipsis',
+    'doubbaselinedot',
+    'onethird',
+    'twothirds',
+    'onefifth',
+    'twofifths',
+    'threefifths',
+    'fourfifths',
+    'onesixth',
+    'fivesixths',
+    'careof',
+    'figdash',
+    'leftanglebracket',
+    'decimalpoint',
+    'rightanglebracket',
+    'marker',
+    'oneeighth',
+    'threeeighths',
+    'fiveeighths',
+    'seveneighths',
+    'trademark',
+    'signaturemark',
+    'trademarkincircle',
+    'leftopentriangle',
+    'rightopentriangle',
+    'emopencircle',
+    'emopenrectangle',
+    'leftsinglequotemark',
+    'rightsinglequotemark',
+    'leftdoublequotemark',
+    'rightdoublequotemark',
+    'prescription',
+    'minutes',
+    'seconds',
+    'latincross',
+    'hexagram',
+    'filledrectbullet',
+    'filledlefttribullet',
+    'filledrighttribullet',
+    'emfilledcircle',
+    'emfilledrect',
+    'enopencircbullet',
+    'enopensquarebullet',
+    'openrectbullet',
+    'opentribulletup',
+    'opentribulletdown',
+    'openstar',
+    'enfilledcircbullet',
+    'enfilledsqbullet',
+    'filledtribulletup',
+    'filledtribulletdown',
+    'leftpointer',
+    'rightpointer',
+    'club',
+    'diamond',
+    'heart',
+    'maltesecross',
+    'dagger',
+    'doubledagger',
+    'checkmark',
+    'ballotcross',
+    'musicalsharp',
+    'musicalflat',
+    'malesymbol',
+    'femalesymbol',
+    'telephone',
+    'telephonerecorder',
+    'phonographcopyright',
+    'caret',
+    'singlelowquotemark',
+    'doublelowquotemark',
+    'cursor',
+    'leftcaret',
+    'rightcaret',
+    'downcaret',
+    'upcaret',
+    'overbar',
+    'downtack',
+    'upshoe',
+    'downstile',
+    'underbar',
+    'jot',
+    'quad',
+    'uptack',
+    'circle',
+    'upstile',
+    'downshoe',
+    'rightshoe',
+    'leftshoe',
+    'lefttack',
+    'righttack',
+    'hebrew_aleph',
+    'hebrew_beth',
+    'hebrew_gimmel',
+    'hebrew_daleth',
+    'hebrew_he',
+    'hebrew_waw',
+    'hebrew_zayin',
+    'hebrew_het',
+    'hebrew_teth',
+    'hebrew_yod',
+    'hebrew_finalkaph',
+    'hebrew_kaph',
+    'hebrew_lamed',
+    'hebrew_finalmem',
+    'hebrew_mem',
+    'hebrew_finalnun',
+    'hebrew_nun',
+    'hebrew_samekh',
+    'hebrew_ayin',
+    'hebrew_finalpe',
+    'hebrew_pe',
+    'hebrew_finalzadi',
+    'hebrew_zadi',
+    'hebrew_kuf',
+    'hebrew_resh',
+    'hebrew_shin',
+    'hebrew_taf',
+    'BackSpace',
+    'Tab',
+    'Linefeed',
+    'Clear',
+    'Return',
+    'Pause',
+    'Scroll_Lock',
+    'Sys_Req',
+    'Escape',
+    'Multi_key',
+    'Kanji',
+    'Home',
+    'Left',
+    'Up',
+    'Right',
+    'Down',
+    'Prior',
+    'Next',
+    'End',
+    'Begin',
+    'Win_L',
+    'Win_R',
+    'App',
+    'Select',
+    'Print',
+    'Execute',
+    'Insert',
+    'Undo',
+    'Redo',
+    'Menu',
+    'Find',
+    'Cancel',
+    'Help',
+    'Break',
+    'Hebrew_switch',
+    'Num_Lock',
+    'KP_Space',
+    'KP_Tab',
+    'KP_Enter',
+    'KP_F1',
+    'KP_F2',
+    'KP_F3',
+    'KP_F4',
+    'KP_Multiply',
+    'KP_Add',
+    'KP_Separator',
+    'KP_Subtract',
+    'KP_Decimal',
+    'KP_Divide',
+    'KP_0',
+    'KP_1',
+    'KP_2',
+    'KP_3',
+    'KP_4',
+    'KP_5',
+    'KP_6',
+    'KP_7',
+    'KP_8',
+    'KP_9',
+    'KP_Equal',
+    'F1',
+    'F2',
+    'F3',
+    'F4',
+    'F5',
+    'F6',
+    'F7',
+    'F8',
+    'F9',
+    'F10',
+    'F11',
+    'F12',
+    'L1',
+    'L2',
+    'L3',
+    'L4',
+    'L5',
+    'L6',
+    'L7',
+    'L8',
+    'L9',
+    'L10',
+    'R1',
+    'R2',
+    'R3',
+    'R4',
+    'R5',
+    'R6',
+    'R7',
+    'R8',
+    'R9',
+    'R10',
+    'R11',
+    'R12',
+    'F33',
+    'R14',
+    'R15',
+    'Shift_L',
+    'Shift_R',
+    'Control_L',
+    'Control_R',
+    'Caps_Lock',
+    'Shift_Lock',
+    'Meta_L',
+    'Meta_R',
+    'Alt_L',
+    'Alt_R',
+    'Super_L',
+    'Super_R',
+    'Hyper_L',
+    'Hyper_R',
+    'Delete',
+)
 
 
 # ------------------------------------------------------------------------- #
 #                       ToolTip used by the Elements                        #
 # ------------------------------------------------------------------------- #
+
 
 class ToolTip:
     """
@@ -843,8 +1925,14 @@ class ToolTip:
         self.tipwindow.wm_geometry('+%d+%d' % (x, y))
         self.tipwindow.wm_attributes('-topmost', 1)
 
-        label = ttk.Label(self.tipwindow, text=self.text, justify=tk.LEFT,
-                          background=TOOLTIP_BACKGROUND_COLOR, relief=tk.SOLID, borderwidth=1)
+        label = ttk.Label(
+            self.tipwindow,
+            text=self.text,
+            justify=tk.LEFT,
+            background=TOOLTIP_BACKGROUND_COLOR,
+            relief=tk.SOLID,
+            borderwidth=1,
+        )
         if TOOLTIP_FONT is not None:
             label.config(font=TOOLTIP_FONT)
         label.pack()
@@ -868,12 +1956,30 @@ class ToolTip:
 # ------------------------------------------------------------------------- #
 #                       Element CLASS                                       #
 # ------------------------------------------------------------------------- #
-class Element():
-    """ The base class for all Elements. Holds the basic description of an Element like size and colors """
+class Element:
+    """The base class for all Elements. Holds the basic description of an Element like size and colors"""
 
-    def __init__(self, type, size=(None, None), auto_size_text=None, font=None, background_color=None, text_color=None, key=None, pad=None, tooltip=None,
-                 visible=True, metadata=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None):
+    def __init__(
+        self,
+        type,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        metadata=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+    ):
         """
         Element base class. Only used internally.  User will not create an Element object by itself
 
@@ -919,12 +2025,11 @@ class Element():
             if isinstance(size, int):
                 size = (size, 1)
             if isinstance(size, tuple) and len(size) == 1:
-                size = (size[0],  1)
+                size = (size[0], 1)
 
         if pad is not None and pad != (None, None):
             if isinstance(pad, int):
                 pad = (pad, pad)
-
 
         self.Size = size
         self.Type = type
@@ -938,8 +2043,8 @@ class Element():
         self.TKText = None
         self.TKEntry = None
         self.TKImage = None
-        self.ttk_style_name = ''        # The ttk style name (if this is a ttk widget)
-        self.ttk_style = None           # The ttk Style object (if this is a ttk widget)
+        self.ttk_style_name = ''  # The ttk style name (if this is a ttk widget)
+        self.ttk_style = None  # The ttk Style object (if this is a ttk widget)
         self._metadata = None  # type: Any
 
         self.ParentForm = None  # type: Window
@@ -957,58 +2062,81 @@ class Element():
         self.Tearoff = False  # needed because of right click menu code
         self.ParentRowFrame = None  # type tk.Frame
         self.metadata = metadata
-        self.user_bind_dict = {}  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
-        self.user_bind_event = None  # Used when user defines a tkinter binding using bind method - event data from tkinter
+        self.user_bind_dict = (
+            {}
+        )  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
+        self.user_bind_event = (
+            None  # Used when user defines a tkinter binding using bind method - event data from tkinter
+        )
         # self.pad_used = (0, 0)  # the amount of pad used when was inserted into the layout
         self._popup_menu_location = (None, None)
         self.pack_settings = None
-        self.vsb_style_name = None           # ttk style name used for the verical scrollbar if one is attached to element
-        self.hsb_style_name = None           # ttk style name used for the horizontal scrollbar if one is attached to element
-        self.vsb_style = None                # The ttk style used for the vertical scrollbar if one is attached to element
-        self.hsb_style = None                # The ttk style used for the horizontal scrollbar if one is attached to element
-        self.hsb = None                      # The horizontal scrollbar if one is attached to element
-        self.vsb = None                      # The vertical scrollbar if one is attached to element
+        self.vsb_style_name = None  # ttk style name used for the verical scrollbar if one is attached to element
+        self.hsb_style_name = None  # ttk style name used for the horizontal scrollbar if one is attached to element
+        self.vsb_style = None  # The ttk style used for the vertical scrollbar if one is attached to element
+        self.hsb_style = None  # The ttk style used for the horizontal scrollbar if one is attached to element
+        self.hsb = None  # The horizontal scrollbar if one is attached to element
+        self.vsb = None  # The vertical scrollbar if one is attached to element
         ## TTK Scrollbar Settings
-        self.ttk_part_overrides = TTKPartOverrides(sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
+        self.ttk_part_overrides = TTKPartOverrides(
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
 
-        PSG_THEME_PART_FUNC_MAP = {PSG_THEME_PART_BACKGROUND: theme_background_color,
-                                       PSG_THEME_PART_BUTTON_BACKGROUND: theme_button_color_background,
-                                       PSG_THEME_PART_BUTTON_TEXT: theme_button_color_text,
-                                       PSG_THEME_PART_INPUT_BACKGROUND: theme_input_background_color,
-                                       PSG_THEME_PART_INPUT_TEXT: theme_input_text_color,
-                                       PSG_THEME_PART_TEXT: theme_text_color,
-                                       PSG_THEME_PART_SLIDER: theme_slider_color}
+        PSG_THEME_PART_FUNC_MAP = {
+            PSG_THEME_PART_BACKGROUND: theme_background_color,
+            PSG_THEME_PART_BUTTON_BACKGROUND: theme_button_color_background,
+            PSG_THEME_PART_BUTTON_TEXT: theme_button_color_text,
+            PSG_THEME_PART_INPUT_BACKGROUND: theme_input_background_color,
+            PSG_THEME_PART_INPUT_TEXT: theme_input_text_color,
+            PSG_THEME_PART_TEXT: theme_text_color,
+            PSG_THEME_PART_SLIDER: theme_slider_color,
+        }
 
         # class Theme_Parts():
         #     PSG_THEME_PART_FUNC_MAP = {PSG_THEME_PART_BACKGROUND: theme_background_color,
         if sbar_trough_color is not None:
             self.scroll_trough_color = sbar_trough_color
         else:
-            self.scroll_trough_color = PSG_THEME_PART_FUNC_MAP.get(ttk_part_mapping_dict[TTK_SCROLLBAR_PART_TROUGH_COLOR], ttk_part_mapping_dict[TTK_SCROLLBAR_PART_TROUGH_COLOR])
+            self.scroll_trough_color = PSG_THEME_PART_FUNC_MAP.get(
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_TROUGH_COLOR],
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_TROUGH_COLOR],
+            )
             if callable(self.scroll_trough_color):
                 self.scroll_trough_color = self.scroll_trough_color()
-
 
         if sbar_background_color is not None:
             self.scroll_background_color = sbar_background_color
         else:
-            self.scroll_background_color = PSG_THEME_PART_FUNC_MAP.get(ttk_part_mapping_dict[TTK_SCROLLBAR_PART_BACKGROUND_COLOR], ttk_part_mapping_dict[TTK_SCROLLBAR_PART_BACKGROUND_COLOR])
+            self.scroll_background_color = PSG_THEME_PART_FUNC_MAP.get(
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_BACKGROUND_COLOR],
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_BACKGROUND_COLOR],
+            )
             if callable(self.scroll_background_color):
-                    self.scroll_background_color = self.scroll_background_color()
-
+                self.scroll_background_color = self.scroll_background_color()
 
         if sbar_arrow_color is not None:
             self.scroll_arrow_color = sbar_arrow_color
         else:
-            self.scroll_arrow_color = PSG_THEME_PART_FUNC_MAP.get(ttk_part_mapping_dict[TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR], ttk_part_mapping_dict[TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR])
+            self.scroll_arrow_color = PSG_THEME_PART_FUNC_MAP.get(
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR],
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_ARROW_BUTTON_ARROW_COLOR],
+            )
             if callable(self.scroll_arrow_color):
                 self.scroll_arrow_color = self.scroll_arrow_color()
-
 
         if sbar_frame_color is not None:
             self.scroll_frame_color = sbar_frame_color
         else:
-            self.scroll_frame_color = PSG_THEME_PART_FUNC_MAP.get(ttk_part_mapping_dict[TTK_SCROLLBAR_PART_FRAME_COLOR], ttk_part_mapping_dict[TTK_SCROLLBAR_PART_FRAME_COLOR])
+            self.scroll_frame_color = PSG_THEME_PART_FUNC_MAP.get(
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_FRAME_COLOR],
+                ttk_part_mapping_dict[TTK_SCROLLBAR_PART_FRAME_COLOR],
+            )
             if callable(self.scroll_frame_color):
                 self.scroll_frame_color = self.scroll_frame_color()
 
@@ -1027,7 +2155,6 @@ class Element():
         else:
             self.scroll_arrow_width = ttk_part_mapping_dict[TTK_SCROLLBAR_PART_ARROW_WIDTH]
 
-
         if not hasattr(self, 'DisabledTextColor'):
             self.DisabledTextColor = None
         if not hasattr(self, 'ItemFont'):
@@ -1035,7 +2162,7 @@ class Element():
         if not hasattr(self, 'RightClickMenu'):
             self.RightClickMenu = None
         if not hasattr(self, 'Disabled'):
-            self.Disabled = None        # in case the element hasn't defined this, add it here
+            self.Disabled = None  # in case the element hasn't defined this, add it here
 
     @property
     def visible(self):
@@ -1074,8 +2201,6 @@ class Element():
         """
         return self.Key
 
-
-
     @property
     def widget(self):
         """
@@ -1085,9 +2210,6 @@ class Element():
         :rtype:     (tkinter.Widget)
         """
         return self.Widget
-
-
-
 
     def _RightClickMenuCallback(self, event):
         """
@@ -1099,11 +2221,13 @@ class Element():
         """
         if self.Type == ELEM_TYPE_TAB_GROUP:
             try:
-                index  = self.Widget.index('@{},{}'.format(event.x,event.y))
+                index = self.Widget.index('@{},{}'.format(event.x, event.y))
                 tab = self.Widget.tab(index, 'text')
                 key = self.find_key_from_tab_name(tab)
                 tab_element = self.ParentForm.key_dict[key]
-                if tab_element.RightClickMenu is None:      # if this tab didn't explicitly have a menu, then don't show anything
+                if (
+                    tab_element.RightClickMenu is None
+                ):  # if this tab didn't explicitly have a menu, then don't show anything
                     return
                 tab_element.TKRightClickMenu.tk_popup(event.x_root, event.y_root, 0)
                 self.TKRightClickMenu.grab_release()
@@ -1202,7 +2326,6 @@ class Element():
         self._generic_callback_handler(self.DisplayText)
         return
 
-
     def _ReturnKeyHandler(self, event):
         """
         Internal callback for the ENTER / RETURN key. Results in calling the ButtonCallBack for element that has the return key bound to it, just as if button was clicked.
@@ -1264,7 +2387,6 @@ class Element():
 
         """
         self._generic_callback_handler('')
-
 
     def _SpinboxSelectHandler(self, event=None):
         """
@@ -1353,7 +2475,6 @@ class Element():
 
         return 'break' if propagate is not True else None
 
-
     def bind(self, bind_string, key_modifier, propagate=True):
         """
         Used to add tkinter events to an Element.
@@ -1370,7 +2491,7 @@ class Element():
 
         try:
             self.Widget.bind(bind_string, lambda evt: self._user_bind_callback(bind_string, evt, propagate))
-        except Exception as e:
+        except Exception:
             self.Widget.unbind_all(bind_string)
             return
 
@@ -1420,7 +2541,6 @@ class Element():
         except Exception as e:
             _error_popup_with_traceback("Exception blocking focus. Check your element's Widget", e)
 
-
     def block_focus(self, block=True):
         """
         Enable or disable the element from getting focus by using the keyboard.
@@ -1442,7 +2562,6 @@ class Element():
         except Exception as e:
             _error_popup_with_traceback("Exception blocking focus. Check your element's Widget", e)
 
-
     def get_next_focus(self):
         """
         Gets the next element that should get focus after this element.
@@ -1459,7 +2578,6 @@ class Element():
         except Exception as e:
             _error_popup_with_traceback("Exception getting next focus. Check your element's Widget", e)
 
-
     def get_previous_focus(self):
         """
         Gets the element that should get focus previous to this element.
@@ -1470,11 +2588,10 @@ class Element():
         if not self._widget_was_created():  # if widget hasn't been created yet, then don't allow
             return None
         try:
-            next_widget_focus = self.widget.tk_focusPrev()      # tkinter.Widget
+            next_widget_focus = self.widget.tk_focusPrev()  # tkinter.Widget
             return self.ParentForm.widget_to_element(next_widget_focus)
         except Exception as e:
             _error_popup_with_traceback("Exception getting previous focus. Check your element's Widget", e)
-
 
     def set_size(self, size=(None, None)):
         """
@@ -1485,12 +2602,12 @@ class Element():
         :type size:  (int, int)
         """
         try:
-            if size[0] != None:
+            if size[0] is not None:
                 self.Widget.config(width=size[0])
         except:
             print('Warning, error setting width on element with key=', self.Key)
         try:
-            if size[1] != None:
+            if size[1] is not None:
                 self.Widget.config(height=size[1])
         except:
             try:
@@ -1500,7 +2617,6 @@ class Element():
 
         if self.Type == ELEM_TYPE_GRAPH:
             self.CanvasSize = size
-
 
     def get_size(self):
         """
@@ -1598,7 +2714,7 @@ class Element():
         :type percent_from_top:  (float)
         """
         if self.Type == ELEM_TYPE_COLUMN and self.Scrollable:
-            widget = self.widget.canvas     # scrollable column is a special case
+            widget = self.widget.canvas  # scrollable column is a special case
         else:
             widget = self.widget
 
@@ -1621,16 +2737,21 @@ class Element():
             if SUPPRESS_WIDGET_NOT_FINALIZED_WARNINGS:
                 return False
 
-            warnings.warn('You cannot Update element with key = {} until the window.read() is called or set finalize=True when creating window'.format(self.Key), UserWarning)
+            warnings.warn(
+                'You cannot Update element with key = {} until the window.read() is called or set finalize=True when creating window'.format(
+                    self.Key
+                ),
+                UserWarning,
+            )
             if not SUPPRESS_ERROR_POPUPS:
-                _error_popup_with_traceback('Unable to complete operation on element with key {}'.format(self.Key),
-                                            'You cannot perform operations (such as calling update) on an Element until:',
-                                            ' window.read() is called or finalize=True when Window created.',
-                                            'Adding a "finalize=True" parameter to your Window creation will likely fix this.',
-                                            _create_error_message(),
-                                            )
+                _error_popup_with_traceback(
+                    'Unable to complete operation on element with key {}'.format(self.Key),
+                    'You cannot perform operations (such as calling update) on an Element until:',
+                    ' window.read() is called or finalize=True when Window created.',
+                    'Adding a "finalize=True" parameter to your Window creation will likely fix this.',
+                    _create_error_message(),
+                )
             return False
-
 
     def _grab_anywhere_on_using_control_key(self):
         """
@@ -1640,7 +2761,6 @@ class Element():
         self.Widget.bind('<Control-Button-1>', self.ParentForm._StartMove)
         self.Widget.bind('<Control-ButtonRelease-1>', self.ParentForm._StopMove)
         self.Widget.bind('<Control-B1-Motion>', self.ParentForm._OnMotion)
-
 
     def _grab_anywhere_on(self):
         """
@@ -1674,8 +2794,6 @@ class Element():
         """
         self.ParentForm._grab_anywhere_include_these_list.append(self.Widget)
 
-
-
     def set_right_click_menu(self, menu=None):
         """
         Sets a right click menu for an element.
@@ -1696,7 +2814,11 @@ class Element():
                     self.TKRightClickMenu.destroy()
                 except:
                     pass
-            top_menu = tk.Menu(self.ParentForm.TKroot, tearoff=self.ParentForm.right_click_menu_tearoff, tearoffcommand=self._tearoff_menu_callback)
+            top_menu = tk.Menu(
+                self.ParentForm.TKroot,
+                tearoff=self.ParentForm.right_click_menu_tearoff,
+                tearoffcommand=self._tearoff_menu_callback,
+            )
 
             if self.ParentForm.right_click_menu_background_color not in (COLOR_SYSTEM_DEFAULT, None):
                 top_menu.config(bg=self.ParentForm.right_click_menu_background_color)
@@ -1713,18 +2835,19 @@ class Element():
                 top_menu.config(activebackground=self.ParentForm.right_click_menu_selected_colors[1])
             AddMenuItem(top_menu, menu[1], self, right_click_menu=True)
             self.TKRightClickMenu = top_menu
-            if self.ParentForm.RightClickMenu:            # if the top level has a right click menu, then setup a callback for the Window itself
+            if (
+                self.ParentForm.RightClickMenu
+            ):  # if the top level has a right click menu, then setup a callback for the Window itself
                 if self.ParentForm.TKRightClickMenu is None:
                     self.ParentForm.TKRightClickMenu = top_menu
-                    if (running_mac()):
+                    if running_mac():
                         self.ParentForm.TKroot.bind('<ButtonRelease-2>', self.ParentForm._RightClickMenuCallback)
                     else:
                         self.ParentForm.TKroot.bind('<ButtonRelease-3>', self.ParentForm._RightClickMenuCallback)
-            if (running_mac()):
+            if running_mac():
                 self.Widget.bind('<ButtonRelease-2>', self._RightClickMenuCallback)
             else:
                 self.Widget.bind('<ButtonRelease-3>', self._RightClickMenuCallback)
-
 
     def save_element_screenshot_to_disk(self, filename=None):
         """
@@ -1741,6 +2864,7 @@ class Element():
                 import PIL as PIL
                 from PIL import ImageGrab
                 from PIL import Image
+
                 pil_imported = True
                 pil_import_attempted = True
             except:
@@ -1750,13 +2874,20 @@ class Element():
                 return None
         try:
             # Add a little to the X direction if window has a titlebar
-            rect = (self.widget.winfo_rootx(), self.widget.winfo_rooty(), self.widget.winfo_rootx() + self.widget.winfo_width(), self.widget.winfo_rooty() + self.widget.winfo_height())
+            rect = (
+                self.widget.winfo_rootx(),
+                self.widget.winfo_rooty(),
+                self.widget.winfo_rootx() + self.widget.winfo_width(),
+                self.widget.winfo_rooty() + self.widget.winfo_height(),
+            )
 
             grab = ImageGrab.grab(bbox=rect)
             # Save the grabbed image to disk
         except Exception as e:
             # print(e)
-            popup_error_with_traceback('Screen capture failure', 'Error happened while trying to save screencapture of an element', e)
+            popup_error_with_traceback(
+                'Screen capture failure', 'Error happened while trying to save screencapture of an element', e
+            )
             return None
 
         # return grab
@@ -1770,13 +2901,15 @@ class Element():
             try:
                 grab.save(full_filename)
             except Exception as e:
-                popup_error_with_traceback('Screen capture failure', 'Error happened while trying to save screencapture', e)
+                popup_error_with_traceback(
+                    'Screen capture failure', 'Error happened while trying to save screencapture', e
+                )
         else:
-            popup_error_with_traceback('Screen capture failure', 'You have attempted a screen capture but have not set up a good filename to save to')
+            popup_error_with_traceback(
+                'Screen capture failure',
+                'You have attempted a screen capture but have not set up a good filename to save to',
+            )
         return grab
-
-
-
 
     def _pack_forget_save_settings(self, alternate_widget=None):
         """
@@ -1816,7 +2949,6 @@ class Element():
         if widget is not None:
             widget.pack(**self.pack_settings)
 
-
     def update(self, *args, **kwargs):
         """
         A dummy update call.  This will only be called if an element hasn't implemented an update method
@@ -1828,7 +2960,6 @@ class Element():
         """
         print('* Base Element Class update was called. Your element does not seem to have an update method')
 
-
     def __call__(self, *args, **kwargs):
         """
         Makes it possible to "call" an already existing element.  When you do make the "call", it actually calls
@@ -1839,11 +2970,6 @@ class Element():
                     window.find_element('T')('new text value')
         """
         return self.update(*args, **kwargs)
-
-
-
-
-
 
     SetTooltip = set_tooltip
     SetFocus = set_focus
@@ -1857,11 +2983,39 @@ class Input(Element):
     Display a single text input field.  Based on the tkinter Widget `Entry`
     """
 
-    def __init__(self, default_text='', size=(None, None), s=(None, None), disabled=False, password_char='',
-                 justification=None, background_color=None, text_color=None, font=None, tooltip=None, border_width=None,
-                 change_submits=False, enable_events=False, do_not_clear=True, key=None, k=None, focus=False, pad=None, p=None,
-                 use_readonly_for_disable=True, readonly=False, disabled_readonly_background_color=None, disabled_readonly_text_color=None, selected_text_color=None, selected_background_color=None, expand_x=False, expand_y=False,
-                 right_click_menu=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        default_text='',
+        size=(None, None),
+        s=(None, None),
+        disabled=False,
+        password_char='',
+        justification=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        tooltip=None,
+        border_width=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        k=None,
+        focus=False,
+        pad=None,
+        p=None,
+        use_readonly_for_disable=True,
+        readonly=False,
+        disabled_readonly_background_color=None,
+        disabled_readonly_text_color=None,
+        selected_text_color=None,
+        selected_background_color=None,
+        expand_x=False,
+        expand_y=False,
+        right_click_menu=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param default_text:                       Text initially shown in the input box as a default value(Default value = ''). Will automatically be converted to string
         :type default_text:                        (Any)
@@ -1925,7 +3079,6 @@ class Input(Element):
         :type metadata:                            (Any)
         """
 
-
         self.DefaultText = default_text if default_text is not None else ''
         self.PasswordCharacter = password_char
         bg = background_color if background_color is not None else DEFAULT_INPUT_ELEMENTS_COLOR
@@ -1950,10 +3103,33 @@ class Input(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_INPUT_TEXT, size=sz, background_color=bg, text_color=fg, key=key, pad=pad,
-                         font=font, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_TEXT,
+            size=sz,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            font=font,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
 
-    def update(self, value=None, disabled=None, select=None, visible=None, text_color=None, background_color=None, font=None, move_cursor_to='end', password_char=None, paste=None, readonly=None):
+    def update(
+        self,
+        value=None,
+        disabled=None,
+        select=None,
+        visible=None,
+        text_color=None,
+        background_color=None,
+        font=None,
+        move_cursor_to='end',
+        password_char=None,
+        paste=None,
+        readonly=None,
+    ):
         """
         Changes some of the settings for the Input Element. Must call `Window.Read` or `Window.Finalize` prior.
         Changes will not be visible in your window until you call window.read or window.refresh.
@@ -2020,9 +3196,6 @@ class Input(Element):
         elif readonly is False:
             self.TKEntry['state'] = 'normal'
 
-
-
-
         if value is not None:
             if paste is not True:
                 try:
@@ -2057,8 +3230,6 @@ class Input(Element):
         if font is not None:
             self.TKEntry.configure(font=font)
 
-
-
     def set_ibeam_color(self, ibeam_color=None):
         """
         Sets the color of the I-Beam that is used to "insert" characters. This is oftens called a "Cursor" by
@@ -2073,13 +3244,14 @@ class Input(Element):
         if ibeam_color is not None:
             try:
                 self.Widget.config(insertbackground=ibeam_color)
-            except Exception as e:
-                _error_popup_with_traceback('Error setting I-Beam color in set_ibeam_color',
-                           'The element has a key:', self.Key,
-                            'The color passed in was:', ibeam_color)
-
-
-
+            except Exception:
+                _error_popup_with_traceback(
+                    'Error setting I-Beam color in set_ibeam_color',
+                    'The element has a key:',
+                    self.Key,
+                    'The color passed in was:',
+                    ibeam_color,
+                )
 
     def get(self):
         """
@@ -2101,7 +3273,7 @@ class Input(Element):
 # -------------------------  INPUT TEXT Element lazy functions  ------------------------- #
 In = Input
 InputText = Input
-I = Input
+I = Input  # noqa
 
 
 # ---------------------------------------------------------------------- #
@@ -2112,7 +3284,34 @@ class Combo(Element):
     ComboBox Element - A combination of a single-line input and a drop-down menu. User can type in their own value or choose from list.
     """
 
-    def __init__(self, values, default_value=None, size=(None, None), s=(None, None), auto_size_text=None, background_color=None, text_color=None, button_background_color=None, button_arrow_color=None, bind_return_key=False, change_submits=False, enable_events=False, enable_per_char_events=None, disabled=False, key=None, k=None, pad=None, p=None, expand_x=False, expand_y=False, tooltip=None, readonly=False, font=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        s=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        button_background_color=None,
+        button_arrow_color=None,
+        bind_return_key=False,
+        change_submits=False,
+        enable_events=False,
+        enable_per_char_events=None,
+        disabled=False,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        expand_x=False,
+        expand_y=False,
+        tooltip=None,
+        readonly=False,
+        font=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param values:                  values to choose. While displayed as text, the items returned are what the caller supplied, not text
         :type values:                   List[Any] or Tuple[Any]
@@ -2166,7 +3365,6 @@ class Combo(Element):
         :type metadata:                 (Any)
         """
 
-
         self.Values = values
         self.DefaultValue = default_value
         self.ChangeSubmits = change_submits or enable_events
@@ -2191,10 +3389,34 @@ class Combo(Element):
             self.button_arrow_color = button_arrow_color
         self.enable_per_char_events = enable_per_char_events
 
-        super().__init__(ELEM_TYPE_INPUT_COMBO, size=sz, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_COMBO,
+            size=sz,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            metadata=metadata,
+        )
 
-    def update(self, value=None, values=None, set_to_index=None, disabled=None, readonly=None, font=None, visible=None, size=(None, None), select=None, text_color=None, background_color=None):
+    def update(
+        self,
+        value=None,
+        values=None,
+        set_to_index=None,
+        disabled=None,
+        readonly=None,
+        font=None,
+        visible=None,
+        size=(None, None),
+        select=None,
+        text_color=None,
+        background_color=None,
+    ):
         """
         Changes some of the settings for the Combo Element. Must call `Window.Read` or `Window.Finalize` prior.
         Note that the state can be in 3 states only.... enabled, disabled, readonly even
@@ -2235,7 +3457,7 @@ class Combo(Element):
             if isinstance(size, int):
                 size = (size, 1)
             if isinstance(size, tuple) and len(size) == 1:
-                size = (size[0],  1)
+                size = (size[0], 1)
 
         if not self._widget_was_created():  # if widget hasn't been created yet, then don't allow
             return
@@ -2243,7 +3465,6 @@ class Combo(Element):
         if self._this_elements_window_closed():
             _error_popup_with_traceback('Error in Combo.update - The window was closed')
             return
-
 
         if values is not None:
             try:
@@ -2255,7 +3476,7 @@ class Combo(Element):
             if value is None:
                 self.TKCombo.set('')
             if size == (None, None):
-                max_line_len = max([len(str(l)) for l in self.Values]) if len(self.Values) else 0
+                max_line_len = max([len(str(line)) for line in self.Values]) if len(self.Values) else 0
                 if self.AutoSizeText is False:
                     width = self.Size[0]
                 else:
@@ -2291,9 +3512,9 @@ class Combo(Element):
         if disabled is True:
             self.TKCombo['state'] = 'disable'
         elif disabled is False and self.Readonly is True:
-                self.TKCombo['state'] = 'readonly'
+            self.TKCombo['state'] = 'readonly'
         elif disabled is False and self.Readonly is False:
-                self.TKCombo['state'] = 'enable'
+            self.TKCombo['state'] = 'enable'
         self.Disabled = disabled if disabled is not None else self.Disabled
 
         combostyle = self.ttk_style
@@ -2316,22 +3537,30 @@ class Combo(Element):
             if background_color not in (None, COLOR_SYSTEM_DEFAULT):
                 combostyle.configure(style_name, selectbackground=background_color)
 
-
         if font is not None:
             self.Font = font
             self.TKCombo.configure(font=font)
             self._dropdown_newfont = tkinter.font.Font(font=font)
             self.ParentRowFrame.option_add('*TCombobox*Listbox*Font', self._dropdown_newfont)
 
-
         # make tcl call to deal with colors for the drop-down formatting
         try:
-            if self.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT) and \
-                self.TextColor not in (None, COLOR_SYSTEM_DEFAULT):
+            if self.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT) and self.TextColor not in (
+                None,
+                COLOR_SYSTEM_DEFAULT,
+            ):
                 self.Widget.tk.eval(
-            '[ttk::combobox::PopdownWindow {}].f.l configure -foreground {} -background {} -selectforeground {} -selectbackground {} -font {}'.format(self.Widget, self.TextColor, self.BackgroundColor, self.BackgroundColor, self.TextColor, self._dropdown_newfont))
-        except Exception as e:
-            pass    # going to let this one slide
+                    '[ttk::combobox::PopdownWindow {}].f.l configure -foreground {} -background {} -selectforeground {} -selectbackground {} -font {}'.format(
+                        self.Widget,
+                        self.TextColor,
+                        self.BackgroundColor,
+                        self.BackgroundColor,
+                        self.TextColor,
+                        self._dropdown_newfont,
+                    )
+                )
+        except Exception:
+            pass  # going to let this one slide
 
         if visible is False:
             self._pack_forget_save_settings()
@@ -2342,10 +3571,9 @@ class Combo(Element):
         if visible is not None:
             self._visible = visible
         if select is True:
-           self.TKCombo.select_range(0, tk.END)
+            self.TKCombo.select_range(0, tk.END)
         elif select is False:
-           self.TKCombo.select_clear()
-
+            self.TKCombo.select_clear()
 
     def get(self):
         """
@@ -2386,8 +3614,26 @@ class OptionMenu(Element):
     it looks like a Combo Box that you scroll to select a choice.
     """
 
-    def __init__(self, values, default_value=None, size=(None, None), s=(None, None), disabled=False, auto_size_text=None, expand_x=False, expand_y=False,
-                 background_color=None, text_color=None, key=None, k=None, pad=None, p=None, tooltip=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        s=(None, None),
+        disabled=False,
+        auto_size_text=None,
+        expand_x=False,
+        expand_y=False,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        tooltip=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param values:           Values to be displayed
         :type values:            List[Any] or Tuple[Any]
@@ -2437,9 +3683,18 @@ class OptionMenu(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-
-        super().__init__(ELEM_TYPE_INPUT_OPTION_MENU, size=sz, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_OPTION_MENU,
+            size=sz,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
 
     def update(self, value=None, values=None, disabled=None, visible=None, size=(None, None)):
         """
@@ -2469,7 +3724,6 @@ class OptionMenu(Element):
             _error_popup_with_traceback('Error in OptionMenu.update - The window was closed')
             return
 
-
         if values is not None:
             self.Values = values
             self.TKOptionMenu['menu'].delete(0, 'end')
@@ -2482,7 +3736,7 @@ class OptionMenu(Element):
                 self.TKStringVar.set('')
 
             if size == (None, None):
-                max_line_len = max([len(str(l)) for l in self.Values]) if len(self.Values) else 0
+                max_line_len = max([len(str(line)) for line in self.Values]) if len(self.Values) else 0
                 if self.AutoSizeText is False:
                     width = self.Size[0]
                 else:
@@ -2525,11 +3779,44 @@ class Listbox(Element):
     when a window.read() is executed.
     """
 
-    def __init__(self, values, default_values=None, select_mode=None, change_submits=False, enable_events=False,
-                 bind_return_key=False, size=(None, None), s=(None, None), disabled=False, justification=None, auto_size_text=None, font=None, no_scrollbar=False, horizontal_scroll=False,
-                 background_color=None, text_color=None, highlight_background_color=None, highlight_text_color=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None,
-                 key=None, k=None, pad=None, p=None, tooltip=None, expand_x=False, expand_y=False,right_click_menu=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        values,
+        default_values=None,
+        select_mode=None,
+        change_submits=False,
+        enable_events=False,
+        bind_return_key=False,
+        size=(None, None),
+        s=(None, None),
+        disabled=False,
+        justification=None,
+        auto_size_text=None,
+        font=None,
+        no_scrollbar=False,
+        horizontal_scroll=False,
+        background_color=None,
+        text_color=None,
+        highlight_background_color=None,
+        highlight_text_color=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        tooltip=None,
+        expand_x=False,
+        expand_y=False,
+        right_click_menu=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param values:                     list of values to display. Can be any type including mixed types as long as they have __str__ method
         :type values:                      List[Any] or Tuple[Any]
@@ -2604,7 +3891,10 @@ class Listbox(Element):
         """
 
         if values is None:
-            _error_popup_with_traceback('Error in your Listbox definition - The values parameter cannot be None', 'Use an empty list if you want no values in your Listbox')
+            _error_popup_with_traceback(
+                'Error in your Listbox definition - The values parameter cannot be None',
+                'Use an empty list if you want no values in your Listbox',
+            )
 
         self.Values = values
         self.DefaultValues = default_values
@@ -2640,11 +3930,30 @@ class Listbox(Element):
         self.expand_y = expand_y
         self.justification = justification
 
-        super().__init__(ELEM_TYPE_INPUT_LISTBOX, size=sz, auto_size_text=auto_size_text, font=font,
-                         background_color=bg, text_color=fg, key=key, pad=pad, tooltip=tooltip, visible=visible, metadata=metadata,
-                         sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
+        super().__init__(
+            ELEM_TYPE_INPUT_LISTBOX,
+            size=sz,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
 
-    def update(self, values=None, disabled=None, set_to_index=None, scroll_to_index=None, select_mode=None, visible=None):
+    def update(
+        self, values=None, disabled=None, set_to_index=None, scroll_to_index=None, select_mode=None, visible=None
+    ):
         """
         Changes some of the settings for the Listbox Element. Must call `Window.Read` or `Window.Finalize` prior
         Changes will not be visible in your window until you call window.read or window.refresh.
@@ -2765,7 +4074,6 @@ class Listbox(Element):
             value = []
         return value
 
-
     def select_index(self, index, highlight_text_color=None, highlight_background_color=None):
         """
         Selects an index while providing capability to setting the selected color for the index to specific text/background color
@@ -2786,7 +4094,11 @@ class Listbox(Element):
             return
 
         if index >= len(self.Values):
-            _error_popup_with_traceback('Index {} is out of range for Listbox.select_index. Max allowed index is {}.'.format(index, len(self.Values)-1))
+            _error_popup_with_traceback(
+                'Index {} is out of range for Listbox.select_index. Max allowed index is {}.'.format(
+                    index, len(self.Values) - 1
+                )
+            )
             return
 
         self.TKListbox.selection_set(index, index)
@@ -2796,8 +4108,9 @@ class Listbox(Element):
         if highlight_background_color is not None:
             self.widget.itemconfig(index, selectbackground=highlight_background_color)
 
-
-    def set_index_color(self, index, text_color=None, background_color=None, highlight_text_color=None, highlight_background_color=None):
+    def set_index_color(
+        self, index, text_color=None, background_color=None, highlight_text_color=None, highlight_background_color=None
+    ):
         """
         Sets the color of a specific item without selecting it
 
@@ -2821,7 +4134,11 @@ class Listbox(Element):
             return
 
         if index >= len(self.Values):
-            _error_popup_with_traceback('Index {} is out of range for Listbox.set_index_color. Max allowed index is {}.'.format(index, len(self.Values)-1))
+            _error_popup_with_traceback(
+                'Index {} is out of range for Listbox.set_index_color. Max allowed index is {}.'.format(
+                    index, len(self.Values) - 1
+                )
+            )
             return
 
         if text_color is not None:
@@ -2832,9 +4149,6 @@ class Listbox(Element):
             self.widget.itemconfig(index, selectforeground=highlight_text_color)
         if highlight_background_color is not None:
             self.widget.itemconfig(index, selectbackground=highlight_background_color)
-
-
-
 
     GetIndexes = get_indexes
     GetListValues = get_list_values
@@ -2855,9 +4169,32 @@ class Radio(Element):
     1 choice in a list of choices.
     """
 
-    def __init__(self, text, group_id, default=False, disabled=False, size=(None, None), s=(None, None), auto_size_text=None,
-                 background_color=None, text_color=None, circle_color=None, font=None, key=None, k=None, pad=None, p=None, tooltip=None,
-                 change_submits=False, enable_events=False, right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        text,
+        group_id,
+        default=False,
+        disabled=False,
+        size=(None, None),
+        s=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        circle_color=None,
+        font=None,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        tooltip=None,
+        change_submits=False,
+        enable_events=False,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param text:             Text to display next to button
         :type text:              (str)
@@ -2907,7 +4244,6 @@ class Radio(Element):
         :type metadata:          (Any)
         """
 
-
         self.InitialState = default
         self.Text = text
         self.Widget = self.TKRadio = None  # type: tk.Radiobutton
@@ -2923,7 +4259,9 @@ class Radio(Element):
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(background_color if background_color else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
+                if (
+                    text_hsl[2] > background_hsl[2]
+                ):  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -2940,11 +4278,30 @@ class Radio(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_INPUT_RADIO, size=sz, auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_RADIO,
+            size=sz,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
 
-    def update(self, value=None, text=None, background_color=None, text_color=None, circle_color=None, disabled=None, visible=None):
+    def update(
+        self,
+        value=None,
+        text=None,
+        background_color=None,
+        text_color=None,
+        circle_color=None,
+        disabled=None,
+        visible=None,
+    ):
         """
         Changes some of the settings for the Radio Button Element. Must call `Window.read` or `Window.finalize` prior
 
@@ -2977,7 +4334,6 @@ class Radio(Element):
             _error_popup_with_traceback('Error in Radio.update - The window was closed')
             return
 
-
         if value is not None:
             try:
                 if value is True:
@@ -3002,13 +4358,19 @@ class Radio(Element):
             self.CircleBackgroundColor = circle_color
             self.TKRadio.configure(selectcolor=self.CircleBackgroundColor)  # The background of the radio button
         elif text_color or background_color:
-            if self.TextColor not in (None, COLOR_SYSTEM_DEFAULT) and self.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT) and self.TextColor.startswith(
-                    '#') and self.BackgroundColor.startswith('#'):
+            if (
+                self.TextColor not in (None, COLOR_SYSTEM_DEFAULT)
+                and self.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT)
+                and self.TextColor.startswith('#')
+                and self.BackgroundColor.startswith('#')
+            ):
                 # ---- compute color of circle background ---
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(self.BackgroundColor if self.BackgroundColor else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
+                if (
+                    text_hsl[2] > background_hsl[2]
+                ):  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -3061,9 +4423,32 @@ class Checkbox(Element):
     Checkbox Element - Displays a checkbox and text next to it
     """
 
-    def __init__(self, text, default=False, size=(None, None), s=(None, None), auto_size_text=None, font=None, background_color=None,
-                 text_color=None, checkbox_color=None, highlight_thickness=1, change_submits=False, enable_events=False, disabled=False, key=None, k=None, pad=None, p=None, tooltip=None,
-                 right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        text,
+        default=False,
+        size=(None, None),
+        s=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        checkbox_color=None,
+        highlight_thickness=1,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param text:                Text to display next to checkbox
         :type text:                 (str)
@@ -3113,8 +4498,6 @@ class Checkbox(Element):
         :type metadata:             (Any)
         """
 
-
-
         self.Text = text
         self.InitialState = bool(default)
         self.Value = None
@@ -3130,7 +4513,9 @@ class Checkbox(Element):
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(background_color if background_color else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
+                if (
+                    text_hsl[2] > background_hsl[2]
+                ):  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -3146,9 +4531,19 @@ class Checkbox(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_INPUT_CHECKBOX, size=sz, auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_CHECKBOX,
+            size=sz,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
 
     def get(self):
         # type: (Checkbox) -> bool
@@ -3160,7 +4555,16 @@ class Checkbox(Element):
         """
         return self.TKIntVar.get() != 0
 
-    def update(self, value=None, text=None, background_color=None, text_color=None, checkbox_color=None, disabled=None, visible=None):
+    def update(
+        self,
+        value=None,
+        text=None,
+        background_color=None,
+        text_color=None,
+        checkbox_color=None,
+        disabled=None,
+        visible=None,
+    ):
         """
         Changes some of the settings for the Checkbox Element. Must call `Window.Read` or `Window.Finalize` prior.
         Note that changing visibility may cause element to change locations when made visible after invisible
@@ -3192,7 +4596,6 @@ class Checkbox(Element):
             _error_popup_with_traceback('Error in Checkbox.update - The window was closed')
             return
 
-
         if value is not None:
             value = bool(value)
             try:
@@ -3220,13 +4623,20 @@ class Checkbox(Element):
             self.CheckboxBackgroundColor = checkbox_color
             self.TKCheckbutton.configure(selectcolor=self.CheckboxBackgroundColor)  # The background of the checkbox
         elif text_color or background_color:
-            if self.CheckboxBackgroundColor is not None and self.TextColor is not None and self.BackgroundColor is not None and self.TextColor.startswith(
-                    '#') and self.BackgroundColor.startswith('#'):
+            if (
+                self.CheckboxBackgroundColor is not None
+                and self.TextColor is not None
+                and self.BackgroundColor is not None
+                and self.TextColor.startswith('#')
+                and self.BackgroundColor.startswith('#')
+            ):
                 # ---- compute color of checkbox background ---
                 text_hsl = _hex_to_hsl(self.TextColor)
                 background_hsl = _hex_to_hsl(self.BackgroundColor if self.BackgroundColor else theme_background_color())
                 l_delta = abs(text_hsl[2] - background_hsl[2]) / 10
-                if text_hsl[2] > background_hsl[2]:  # if the text is "lighter" than the background then make background darker
+                if (
+                    text_hsl[2] > background_hsl[2]
+                ):  # if the text is "lighter" than the background then make background darker
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] - l_delta)
                 else:
                     bg_rbg = _hsl_to_rgb(background_hsl[0], background_hsl[1], background_hsl[2] + l_delta)
@@ -3255,14 +4665,39 @@ Check = Checkbox
 #                           Spin                                         #
 # ---------------------------------------------------------------------- #
 
+
 class Spin(Element):
     """
     A spinner with up/down buttons and a single line of text. Choose 1 values from list
     """
 
-    def __init__(self, values, initial_value=None, disabled=False, change_submits=False, enable_events=False, readonly=False,
-                 size=(None, None), s=(None, None), auto_size_text=None, bind_return_key=None, font=None, background_color=None, text_color=None, key=None, k=None, pad=None, p=None, wrap=None,
-                 tooltip=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        values,
+        initial_value=None,
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        readonly=False,
+        size=(None, None),
+        s=(None, None),
+        auto_size_text=None,
+        bind_return_key=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        wrap=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param values:           List of valid values
         :type values:            Tuple[Any] or List[Any]
@@ -3314,7 +4749,6 @@ class Spin(Element):
         :type metadata:          (Any)
         """
 
-
         self.Values = values
         self.DefaultValue = initial_value
         self.ChangeSubmits = change_submits or enable_events
@@ -3333,9 +4767,19 @@ class Spin(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-
-        super().__init__(ELEM_TYPE_INPUT_SPIN, size=sz, auto_size_text=auto_size_text, font=font, background_color=bg, text_color=fg,
-                         key=key, pad=pad, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_SPIN,
+            size=sz,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def update(self, value=None, values=None, disabled=None, readonly=None, visible=None):
@@ -3370,7 +4814,7 @@ class Spin(Element):
             _error_popup_with_traceback('Error in Spin.update - The window was closed')
             return
 
-        if values != None:
+        if values is not None:
             old_value = self.TKStringVar.get()
             self.Values = values
             self.TKSpinBox.configure(values=values)
@@ -3404,7 +4848,6 @@ class Spin(Element):
         if visible is not None:
             self._visible = visible
 
-
     def _SpinChangedHandler(self, event):
         """
         Callback function. Used internally only. Called by tkinter when Spinbox Widget changes.  Results in Window.Read() call returning
@@ -3423,9 +4866,6 @@ class Spin(Element):
         #     Window._window_that_exited = self.ParentForm
         #     self.ParentForm.TKroot.quit()  # kick the users out of the mainloop
 
-
-
-
     def set_ibeam_color(self, ibeam_color=None):
         """
         Sets the color of the I-Beam that is used to "insert" characters. This is oftens called a "Cursor" by
@@ -3440,12 +4880,14 @@ class Spin(Element):
         if ibeam_color is not None:
             try:
                 self.Widget.config(insertbackground=ibeam_color)
-            except Exception as e:
-                _error_popup_with_traceback('Error setting I-Beam color in set_ibeam_color',
-                           'The element has a key:', self.Key,
-                            'The color passed in was:', ibeam_color)
-
-
+            except Exception:
+                _error_popup_with_traceback(
+                    'Error setting I-Beam color in set_ibeam_color',
+                    'The element has a key:',
+                    self.Key,
+                    'The color passed in was:',
+                    ibeam_color,
+                )
 
     def get(self):
         """
@@ -3480,11 +4922,55 @@ class Multiline(Element):
     one up in the future too.
     """
 
-    def __init__(self, default_text='', enter_submits=False, disabled=False, autoscroll=False, autoscroll_only_at_bottom=False, border_width=None,
-                 size=(None, None), s=(None, None), auto_size_text=None, background_color=None, text_color=None, selected_text_color=None, selected_background_color=None, horizontal_scroll=False, change_submits=False,
-                 enable_events=False, do_not_clear=True, key=None, k=None, write_only=False, auto_refresh=False, reroute_stdout=False, reroute_stderr=False, reroute_cprint=False, echo_stdout_stderr=False, focus=False, font=None, pad=None, p=None, tooltip=None, justification=None, no_scrollbar=False, wrap_lines=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None,
-                 expand_x=False, expand_y=False, rstrip=True, right_click_menu=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        default_text='',
+        enter_submits=False,
+        disabled=False,
+        autoscroll=False,
+        autoscroll_only_at_bottom=False,
+        border_width=None,
+        size=(None, None),
+        s=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        selected_text_color=None,
+        selected_background_color=None,
+        horizontal_scroll=False,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        k=None,
+        write_only=False,
+        auto_refresh=False,
+        reroute_stdout=False,
+        reroute_stderr=False,
+        reroute_cprint=False,
+        echo_stdout_stderr=False,
+        focus=False,
+        font=None,
+        pad=None,
+        p=None,
+        tooltip=None,
+        justification=None,
+        no_scrollbar=False,
+        wrap_lines=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+        expand_x=False,
+        expand_y=False,
+        rstrip=True,
+        right_click_menu=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param default_text:                 Initial text to show
         :type default_text:                  (Any)
@@ -3580,13 +5066,11 @@ class Multiline(Element):
         :type metadata:                      (Any)
         """
 
-
         self.DefaultText = str(default_text)
         self.EnterSubmits = enter_submits
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         self.Focus = focus
         self.do_not_clear = do_not_clear
-        fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
         self.selected_text_color = selected_text_color
         self.selected_background_color = selected_background_color
@@ -3615,17 +5099,47 @@ class Multiline(Element):
         self.reroute_stdout = reroute_stdout
         self.reroute_stderr = reroute_stderr
         self.no_scrollbar = no_scrollbar
-        self.hscrollbar = None      # The horizontal scrollbar
+        self.hscrollbar = None  # The horizontal scrollbar
         self.auto_scroll_only_at_bottom = autoscroll_only_at_bottom
         sz = size if size != (None, None) else s
 
-        super().__init__(ELEM_TYPE_INPUT_MULTILINE, size=sz, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, metadata=metadata,
-                         sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
+        super().__init__(
+            ELEM_TYPE_INPUT_MULTILINE,
+            size=sz,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            metadata=metadata,
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
         return
 
-    def update(self, value=None, disabled=None, append=False, font=None, text_color=None, background_color=None, text_color_for_value=None,
-               background_color_for_value=None, visible=None, autoscroll=None, justification=None, font_for_value=None):
+    def update(
+        self,
+        value=None,
+        disabled=None,
+        append=False,
+        font=None,
+        text_color=None,
+        background_color=None,
+        text_color_for_value=None,
+        background_color_for_value=None,
+        visible=None,
+        autoscroll=None,
+        justification=None,
+        font_for_value=None,
+    ):
         """
         Changes some of the settings for the Multiline Element. Must call `Window.read` or set finalize=True when creating window.
 
@@ -3668,7 +5182,6 @@ class Multiline(Element):
             # _error_popup_with_traceback('Error in Multiline.update - The window was closed')
             return
 
-
         if autoscroll is not None:
             self.Autoscroll = autoscroll
         current_scroll_position = self.TKText.yview()[1]
@@ -3683,13 +5196,20 @@ class Multiline(Element):
         else:
             just_tag = self.justification_tag
 
-        starting_point = self.Widget.index(tk.INSERT)
         tag = None
         if value is not None:
             value = str(value)
             if background_color_for_value is not None or text_color_for_value is not None or font_for_value is not None:
                 try:
-                    tag = 'Multiline(' + str(text_color_for_value) + ',' + str(background_color_for_value) + ',' + str(font_for_value) + ')'
+                    tag = (
+                        'Multiline('
+                        + str(text_color_for_value)
+                        + ','
+                        + str(background_color_for_value)
+                        + ','
+                        + str(font_for_value)
+                        + ')'
+                    )
                     if tag not in self.tags:
                         self.tags.add(tag)
                     if background_color_for_value is not None:
@@ -3709,19 +5229,16 @@ class Multiline(Element):
                     self.TKText.insert(tk.END, value, (just_tag, tag))
                 else:
                     self.TKText.insert(tk.END, value)
-
-                # self.TKText.tag_add(just_tag, starting_point, starting_point)
-
             except Exception as e:
                 print('* Error setting multiline *', e)
             if self.Disabled:
                 self.TKText.configure(state='disabled')
             self.DefaultText = value
 
-        # if self.Autoscroll:
-        #     self.TKText.see(tk.END)
         if self.Autoscroll:
-            if not self.auto_scroll_only_at_bottom or (self.auto_scroll_only_at_bottom and current_scroll_position == 1.0):
+            if not self.auto_scroll_only_at_bottom or (
+                self.auto_scroll_only_at_bottom and current_scroll_position == 1.0
+            ):
                 self.TKText.see(tk.END)
         if disabled is True:
             self.TKText.configure(state='disabled')
@@ -3736,13 +5253,10 @@ class Multiline(Element):
         if font is not None:
             self.TKText.configure(font=font)
 
-
         if visible is False:
             self._pack_forget_save_settings(alternate_widget=self.element_frame)
-            # self.element_frame.pack_forget()
         elif visible is True:
             self._pack_restore_settings(alternate_widget=self.element_frame)
-            # self.element_frame.pack(padx=self.pad_used[0], pady=self.pad_used[1])
 
         if self.AutoRefresh and self.ParentForm:
             try:  # in case the window was destroyed
@@ -3764,9 +5278,21 @@ class Multiline(Element):
             return value.rstrip()
         return value
 
-
-    def print(self, *args, end=None, sep=None, text_color=None, background_color=None, justification=None, font=None, colors=None, t=None, b=None, c=None,
-              autoscroll=True):
+    def print(
+        self,
+        *args,
+        end=None,
+        sep=None,
+        text_color=None,
+        background_color=None,
+        justification=None,
+        font=None,
+        colors=None,
+        t=None,
+        b=None,
+        c=None,
+        autoscroll=True,
+    ):
         """
         Print like Python normally prints except route the output to a multiline element and also add colors if desired
 
@@ -3826,8 +5352,17 @@ class Multiline(Element):
         except Exception as e:
             print('* multiline print warning * you messed up with color formatting', e)
 
-        _print_to_element(self, *args, end=end, sep=sep, text_color=kw_text_color, background_color=kw_background_color, justification=justification,
-                          autoscroll=autoscroll, font=font)
+        _print_to_element(
+            self,
+            *args,
+            end=end,
+            sep=sep,
+            text_color=kw_text_color,
+            background_color=kw_background_color,
+            justification=justification,
+            autoscroll=autoscroll,
+            font=font,
+        )
 
     def reroute_stdout_to_here(self):
         """
@@ -3889,10 +5424,6 @@ class Multiline(Element):
         #     pass
         return
 
-
-
-
-
     def set_ibeam_color(self, ibeam_color=None):
         """
         Sets the color of the I-Beam that is used to "insert" characters. This is oftens called a "Cursor" by
@@ -3907,12 +5438,14 @@ class Multiline(Element):
         if ibeam_color is not None:
             try:
                 self.Widget.config(insertbackground=ibeam_color)
-            except Exception as e:
-                _error_popup_with_traceback('Error setting I-Beam color in set_ibeam_color',
-                           'The element has a key:', self.Key,
-                            'The color passed in was:', ibeam_color)
-
-
+            except Exception:
+                _error_popup_with_traceback(
+                    'Error setting I-Beam color in set_ibeam_color',
+                    'The element has a key:',
+                    self.Key,
+                    'The color passed in was:',
+                    ibeam_color,
+                )
 
     def __del__(self):
         """
@@ -3923,7 +5456,6 @@ class Multiline(Element):
         """
 
         return
-
 
     Get = get
     Update = update
@@ -3941,9 +5473,32 @@ class Text(Element):
     Text - Display some text in the window.  Usually this means a single line of text.  However, the text can also be multiple lines.  If multi-lined there are no scroll bars.
     """
 
-    def __init__(self, text='', size=(None, None), s=(None, None), auto_size_text=None, click_submits=False, enable_events=False, relief=None, font=None,
-                 text_color=None, background_color=None, border_width=None, justification=None, pad=None, p=None, key=None, k=None, right_click_menu=None, expand_x=False, expand_y=False, grab=None,
-                 tooltip=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        text='',
+        size=(None, None),
+        s=(None, None),
+        auto_size_text=None,
+        click_submits=False,
+        enable_events=False,
+        relief=None,
+        font=None,
+        text_color=None,
+        background_color=None,
+        border_width=None,
+        justification=None,
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        grab=None,
+        tooltip=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param text:             The text to display. Can include /n to achieve multiple lines.  Will convert (optional) parameter into a string
         :type text:              Any
@@ -4012,8 +5567,19 @@ class Text(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_TEXT, auto_size_text=auto_size_text, size=sz, background_color=bg, font=font if font else DEFAULT_FONT,
-                         text_color=self.TextColor, pad=pad, key=key, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TEXT,
+            auto_size_text=auto_size_text,
+            size=sz,
+            background_color=bg,
+            font=font if font else DEFAULT_FONT,
+            text_color=self.TextColor,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
 
     def update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
         """
@@ -4055,10 +5621,8 @@ class Text(Element):
             self.TKText.configure(font=font)
         if visible is False:
             self._pack_forget_save_settings()
-            # self.TKText.pack_forget()
         elif visible is True:
             self._pack_restore_settings()
-            # self.TKText.pack(padx=self.pad_used[0], pady=self.pad_used[1])
         if visible is not None:
             self._visible = visible
 
@@ -4075,7 +5639,6 @@ class Text(Element):
             text = ''
         return text
 
-
     @classmethod
     def fonts_installed_list(cls):
         """
@@ -4091,7 +5654,6 @@ class Text(Element):
         fonts.sort()
 
         return fonts
-
 
     @classmethod
     def char_width_in_pixels(cls, font, character='W'):
@@ -4133,7 +5695,6 @@ class Text(Element):
         # A window must exist before can perform this operation. Create the hidden master root if it doesn't exist
         _get_hidden_master_root()
 
-
         size = 0
         try:
             size = tkinter.font.Font(font=font).metrics('linespace')
@@ -4166,7 +5727,18 @@ class Text(Element):
 
         return size
 
-    def _print_to_element(self, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=None, justification=None, font=None, append=None):
+    def _print_to_element(
+        self,
+        *args,
+        end=None,
+        sep=None,
+        text_color=None,
+        background_color=None,
+        autoscroll=None,
+        justification=None,
+        font=None,
+        append=None,
+    ):
         """
         Print like Python normally prints except route the output to a multiline element and also add colors if desired
 
@@ -4208,7 +5780,22 @@ class Text(Element):
         except:
             pass
 
-    def print(self, *args, end=None, sep=None, text_color=None, background_color=None, justification=None, font=None, colors=None, t=None, b=None, c=None, autoscroll=True, append=True):
+    def print(
+        self,
+        *args,
+        end=None,
+        sep=None,
+        text_color=None,
+        background_color=None,
+        justification=None,
+        font=None,
+        colors=None,
+        t=None,
+        b=None,
+        c=None,
+        autoscroll=True,
+        append=True,
+    ):
         """
         Print like Python normally prints except route the output to a multiline element and also add colors if desired
 
@@ -4268,8 +5855,17 @@ class Text(Element):
         except Exception as e:
             print('* multiline print warning * you messed up with color formatting', e)
 
-        self._print_to_element( *args, end=end, sep=sep, text_color=kw_text_color, background_color=kw_background_color, justification=justification, autoscroll=autoscroll, font=font, append=append)
-
+        self._print_to_element(
+            *args,
+            end=end,
+            sep=sep,
+            text_color=kw_text_color,
+            background_color=kw_background_color,
+            justification=justification,
+            autoscroll=autoscroll,
+            font=font,
+            append=append,
+        )
 
     Get = get
     Update = update
@@ -4289,9 +5885,30 @@ class StatusBar(Element):
     A StatusBar Element creates the sunken text-filled strip at the bottom. Many Windows programs have this line
     """
 
-    def __init__(self, text, size=(None, None), s=(None, None), auto_size_text=None, click_submits=None, enable_events=False,
-                 relief=RELIEF_SUNKEN, font=None, text_color=None, background_color=None, justification=None, pad=None, p=None,
-                 key=None, k=None, right_click_menu=None, expand_x=False, expand_y=False, tooltip=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        text,
+        size=(None, None),
+        s=(None, None),
+        auto_size_text=None,
+        click_submits=None,
+        enable_events=False,
+        relief=RELIEF_SUNKEN,
+        font=None,
+        text_color=None,
+        background_color=None,
+        justification=None,
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        tooltip=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param text:             Text that is to be displayed in the widget
         :type text:              (str)
@@ -4337,7 +5954,6 @@ class StatusBar(Element):
         :type metadata:          (Any)
         """
 
-
         self.DisplayText = text
         self.TextColor = text_color if text_color else DEFAULT_TEXT_COLOR
         self.Justification = justification
@@ -4355,9 +5971,19 @@ class StatusBar(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_STATUSBAR, size=sz, auto_size_text=auto_size_text, background_color=bg,
-                         font=font or DEFAULT_FONT, text_color=self.TextColor, pad=pad, key=key, tooltip=tooltip,
-                         visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_STATUSBAR,
+            size=sz,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            font=font or DEFAULT_FONT,
+            text_color=self.TextColor,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
@@ -4401,10 +6027,8 @@ class StatusBar(Element):
             self.TKText.configure(font=font)
         if visible is False:
             self._pack_forget_save_settings()
-            # self.TKText.pack_forget()
         elif visible is True:
             self._pack_restore_settings()
-            # self.TKText.pack(padx=self.pad_used[0], pady=self.pad_used[1])
         if visible is not None:
             self._visible = visible
 
@@ -4419,12 +6043,24 @@ SBar = StatusBar
 #  Emulate the TK ProgressBar using canvas and rectangles
 # ---------------------------------------------------------------------- #
 
-class TKProgressBar():
+
+class TKProgressBar:
     uniqueness_counter = 0
 
-    def __init__(self, root, max, length=400, width=DEFAULT_PROGRESS_BAR_SIZE[1], ttk_theme=DEFAULT_TTK_THEME, style_name='',
-                 relief=DEFAULT_PROGRESS_BAR_RELIEF, border_width=DEFAULT_PROGRESS_BAR_BORDER_WIDTH,
-                 orientation='horizontal', BarColor=(None, None), key=None):
+    def __init__(
+        self,
+        root,
+        max,
+        length=400,
+        width=DEFAULT_PROGRESS_BAR_SIZE[1],
+        ttk_theme=DEFAULT_TTK_THEME,
+        style_name='',
+        relief=DEFAULT_PROGRESS_BAR_RELIEF,
+        border_width=DEFAULT_PROGRESS_BAR_BORDER_WIDTH,
+        orientation='horizontal',
+        BarColor=(None, None),
+        key=None,
+    ):
         """
         :param root:         The root window bar is to be shown in
         :type root:          tk.Tk | tk.TopLevel
@@ -4464,26 +6100,40 @@ class TKProgressBar():
             s = ttk.Style()
             _change_ttk_theme(s, ttk_theme)
 
-            # self.style_name = str(key) + str(TKProgressBar.uniqueness_counter) + "my.Horizontal.TProgressbar"
             if BarColor != COLOR_SYSTEM_DEFAULT and BarColor[0] != COLOR_SYSTEM_DEFAULT:
-                s.configure(self.style_name, background=BarColor[0], troughcolor=BarColor[1],
-                            troughrelief=relief, borderwidth=border_width, thickness=width)
+                s.configure(
+                    self.style_name,
+                    background=BarColor[0],
+                    troughcolor=BarColor[1],
+                    troughrelief=relief,
+                    borderwidth=border_width,
+                    thickness=width,
+                )
             else:
                 s.configure(self.style_name, troughrelief=relief, borderwidth=border_width, thickness=width)
 
-            self.TKProgressBarForReal = ttk.Progressbar(root, maximum=self.Max, style=self.style_name, length=length, orient=tk.HORIZONTAL, mode='determinate')
+            self.TKProgressBarForReal = ttk.Progressbar(
+                root, maximum=self.Max, style=self.style_name, length=length, orient=tk.HORIZONTAL, mode='determinate'
+            )
         else:
             s = ttk.Style()
             _change_ttk_theme(s, ttk_theme)
-            # self.style_name = str(key) + str(TKProgressBar.uniqueness_counter) + "my.Vertical.TProgressbar"
             if BarColor != COLOR_SYSTEM_DEFAULT and BarColor[0] != COLOR_SYSTEM_DEFAULT:
 
-                s.configure(self.style_name, background=BarColor[0],
-                            troughcolor=BarColor[1], troughrelief=relief, borderwidth=border_width, thickness=width)
+                s.configure(
+                    self.style_name,
+                    background=BarColor[0],
+                    troughcolor=BarColor[1],
+                    troughrelief=relief,
+                    borderwidth=border_width,
+                    thickness=width,
+                )
             else:
                 s.configure(self.style_name, troughrelief=relief, borderwidth=border_width, thickness=width)
 
-            self.TKProgressBarForReal = ttk.Progressbar(root, maximum=self.Max, style=self.style_name, length=length, orient=tk.VERTICAL, mode='determinate')
+            self.TKProgressBarForReal = ttk.Progressbar(
+                root, maximum=self.Max, style=self.style_name, length=length, orient=tk.VERTICAL, mode='determinate'
+            )
 
     def Update(self, count=None, max=None):
         """
@@ -4528,9 +6178,35 @@ class Output(Multiline):
     so that an item is not included in the values dictionary on every window.read call
     """
 
-    def __init__(self, size=(None, None), s=(None, None), background_color=None, text_color=None, pad=None, p=None, autoscroll_only_at_bottom=False, echo_stdout_stderr=False, font=None, tooltip=None,
-                 key=None, k=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None, wrap_lines=None, horizontal_scroll=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None,  sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None):
+    def __init__(
+        self,
+        size=(None, None),
+        s=(None, None),
+        background_color=None,
+        text_color=None,
+        pad=None,
+        p=None,
+        autoscroll_only_at_bottom=False,
+        echo_stdout_stderr=False,
+        font=None,
+        tooltip=None,
+        key=None,
+        k=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+        wrap_lines=None,
+        horizontal_scroll=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+    ):
         """
         :param size:                        (w, h) w=characters-wide, h=rows-high. If an int instead of a tuple is supplied, then height is auto-set to 1
         :type size:                         (int, int)  | (None, None) | int
@@ -4586,9 +6262,40 @@ class Output(Multiline):
         :type sbar_relief:                  (str)
         """
 
-
-        super().__init__(size=size, s=s, background_color=background_color, autoscroll_only_at_bottom=autoscroll_only_at_bottom, text_color=text_color, pad=pad, p=p, echo_stdout_stderr=echo_stdout_stderr, font=font, tooltip=tooltip, wrap_lines=wrap_lines, horizontal_scroll=horizontal_scroll, key=key, k=k, right_click_menu=right_click_menu, write_only=True, reroute_stdout=True, reroute_stderr=True, reroute_cprint=True, autoscroll=True, auto_refresh=True, expand_x=expand_x, expand_y=expand_y, visible=visible, metadata=metadata, sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
-
+        super().__init__(
+            size=size,
+            s=s,
+            background_color=background_color,
+            autoscroll_only_at_bottom=autoscroll_only_at_bottom,
+            text_color=text_color,
+            pad=pad,
+            p=p,
+            echo_stdout_stderr=echo_stdout_stderr,
+            font=font,
+            tooltip=tooltip,
+            wrap_lines=wrap_lines,
+            horizontal_scroll=horizontal_scroll,
+            key=key,
+            k=k,
+            right_click_menu=right_click_menu,
+            write_only=True,
+            reroute_stdout=True,
+            reroute_stderr=True,
+            reroute_cprint=True,
+            autoscroll=True,
+            auto_refresh=True,
+            expand_x=expand_x,
+            expand_y=expand_y,
+            visible=visible,
+            metadata=metadata,
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
 
 
 # ---------------------------------------------------------------------- #
@@ -4599,13 +6306,46 @@ class Button(Element):
     Button Element - Defines all possible buttons. The shortcuts such as Submit, FileBrowse, ... each create a Button
     """
 
-    def __init__(self, button_text='', button_type=BUTTON_TYPE_READ_FORM, target=(None, None), tooltip=None,
-                 file_types=FILE_TYPES_ALL_FILES, initial_folder=None, default_extension='', disabled=False, change_submits=False,
-                 enable_events=False, image_filename=None, image_data=None, image_size=(None, None),
-                 image_subsample=None, image_zoom=None, image_source=None, border_width=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None,
-                 disabled_button_color=None,
-                 highlight_colors=None, mouseover_colors=(None, None), use_ttk_buttons=None, font=None, bind_return_key=False, focus=False, pad=None, p=None, key=None,
-                 k=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        button_text='',
+        button_type=BUTTON_TYPE_READ_FORM,
+        target=(None, None),
+        tooltip=None,
+        file_types=FILE_TYPES_ALL_FILES,
+        initial_folder=None,
+        default_extension='',
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        image_filename=None,
+        image_data=None,
+        image_size=(None, None),
+        image_subsample=None,
+        image_zoom=None,
+        image_source=None,
+        border_width=None,
+        size=(None, None),
+        s=(None, None),
+        auto_size_button=None,
+        button_color=None,
+        disabled_button_color=None,
+        highlight_colors=None,
+        mouseover_colors=(None, None),
+        use_ttk_buttons=None,
+        font=None,
+        bind_return_key=False,
+        focus=False,
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param button_text:           Text to be displayed on the button
         :type button_text:            (str)
@@ -4683,11 +6423,20 @@ class Button(Element):
         :type metadata:               (Any)
         """
 
-
         self.AutoSizeButton = auto_size_button
         self.BType = button_type
-        if file_types is not None and len(file_types) == 2 and isinstance(file_types[0], str) and isinstance(file_types[1], str):
-            warnings.warn('file_types parameter not correctly specified. This parameter is a LIST of TUPLES. You have passed (str,str) rather than ((str, str),). Fixing it for you this time.\nchanging {} to {}\nPlease correct your code'.format(file_types, ((file_types[0], file_types[1]),)), UserWarning)
+        if (
+            file_types is not None
+            and len(file_types) == 2
+            and isinstance(file_types[0], str)
+            and isinstance(file_types[1], str)
+        ):
+            warnings.warn(
+                'file_types parameter not correctly specified. This parameter is a LIST of TUPLES. You have passed (str,str) rather than ((str, str),). Fixing it for you this time.\nchanging {} to {}\nPlease correct your code'.format(
+                    file_types, ((file_types[0], file_types[1]),)
+                ),
+                UserWarning,
+            )
             file_types = ((file_types[0], file_types[1]),)
         self.FileTypes = file_types
         self.Widget = self.TKButton = None  # type: tk.Button
@@ -4695,28 +6444,11 @@ class Button(Element):
         self.ButtonText = str(button_text)
         self.RightClickMenu = right_click_menu
         # Button colors can be a tuple (text, background) or a string with format "text on background"
-        # bc = button_color
-        # if button_color is None:
-        #     bc = DEFAULT_BUTTON_COLOR
-        # else:
-        #     try:
-        #         if isinstance(button_color,str):
-        #             bc = button_color.split(' on ')
-        #     except Exception as e:
-        #         print('* cprint warning * you messed up with color formatting', e)
-        #     if bc[1] is None:
-        #         bc = (bc[0], theme_button_color()[1])
-        # self.ButtonColor = bc
         self.ButtonColor = button_color_to_tuple(button_color)
 
-        # experimental code to compute disabled button text color
-        # if disabled_button_color is None:
-        #     try:
-        #         disabled_button_color = (get_complimentary_hex(theme_button_color()[0]), theme_button_color()[1])
-        #         # disabled_button_color = disabled_button_color
-        #     except:
-        #         print('* Problem computing disabled button color *')
-        self.DisabledButtonColor = button_color_to_tuple(disabled_button_color) if disabled_button_color is not None else (None, None)
+        self.DisabledButtonColor = (
+            button_color_to_tuple(disabled_button_color) if disabled_button_color is not None else (None, None)
+        )
         if image_source is not None:
             if isinstance(image_source, bytes):
                 image_data = image_source
@@ -4749,20 +6481,21 @@ class Button(Element):
         self.Disabled = disabled
         self.ChangeSubmits = change_submits or enable_events
         self.UseTtkButtons = use_ttk_buttons
-        self._files_delimiter = BROWSE_FILES_DELIMITER  # used by the file browse button. used when multiple files are selected by user
+        self._files_delimiter = (
+            BROWSE_FILES_DELIMITER  # used by the file browse button. used when multiple files are selected by user
+        )
         if use_ttk_buttons is None and running_mac():
             self.UseTtkButtons = True
-        # if image_filename or image_data:
-        #     self.UseTtkButtons = False              # if an image is to be displayed, then force the button to not be a TTK Button
+
         if key is None and k is None:
             _key = self.ButtonText
             if DEFAULT_USE_BUTTON_SHORTCUTS is True:
                 pos = _key.find(MENU_SHORTCUT_CHARACTER)
                 if pos != -1:
                     if pos < len(MENU_SHORTCUT_CHARACTER) or _key[pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                        _key = _key[:pos] + _key[pos + len(MENU_SHORTCUT_CHARACTER):]
+                        _key = _key[:pos] + _key[pos + len(MENU_SHORTCUT_CHARACTER) :]
                     else:
-                        _key = _key.replace('\\'+MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
+                        _key = _key.replace('\\' + MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
         else:
             _key = key if key is not None else k
         if highlight_colors is not None:
@@ -4772,7 +6505,7 @@ class Button(Element):
 
         if mouseover_colors != (None, None):
             self.MouseOverColors = button_color_to_tuple(mouseover_colors)
-        elif button_color != None:
+        elif button_color is not None:
             self.MouseOverColors = (self.ButtonColor[1], self.ButtonColor[0])
         else:
             self.MouseOverColors = (theme_button_color()[1], theme_button_color()[0])
@@ -4781,7 +6514,9 @@ class Button(Element):
         self.expand_y = expand_y
 
         sz = size if size != (None, None) else s
-        super().__init__(ELEM_TYPE_BUTTON, size=sz, font=font, pad=pad, key=_key, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_BUTTON, size=sz, font=font, pad=pad, key=_key, tooltip=tooltip, visible=visible, metadata=metadata
+        )
         return
 
     def _compute_highlight_colors(self):
@@ -4827,9 +6562,6 @@ class Button(Element):
             self.ParentForm.LastButtonClicked = self.Key
         else:
             self.ParentForm.LastButtonClicked = self.ButtonText
-        # if self.ParentForm.CurrentlyRunningMainloop:
-        #     Window._window_that_exited = self.ParentForm
-        #     self.ParentForm.TKroot.quit()  # kick out of loop if read was called
         _exit_mainloop(self.ParentForm)
 
     def _find_target(self):
@@ -4884,9 +6616,13 @@ class Button(Element):
 
         if self.BType == BUTTON_TYPE_BROWSE_FOLDER:
             if running_mac():  # macs don't like seeing the parent window (go firgure)
-                folder_name = tk.filedialog.askdirectory(initialdir=self.InitialFolder)  # show the 'get folder' dialog box
+                folder_name = tk.filedialog.askdirectory(
+                    initialdir=self.InitialFolder
+                )  # show the 'get folder' dialog box
             else:
-                folder_name = tk.filedialog.askdirectory(initialdir=self.InitialFolder, parent=self.ParentForm.TKroot)  # show the 'get folder' dialog box
+                folder_name = tk.filedialog.askdirectory(
+                    initialdir=self.InitialFolder, parent=self.ParentForm.TKroot
+                )  # show the 'get folder' dialog box
             if folder_name:
                 try:
                     strvar.set(folder_name)
@@ -4902,21 +6638,23 @@ class Button(Element):
                 if not len(set(filetypes)) > 1 and (len(is_all) != 0 or filetypes == FILE_TYPES_ALL_FILES):
                     file_name = tk.filedialog.askopenfilename(initialdir=self.InitialFolder)
                 else:
-                    file_name = tk.filedialog.askopenfilename(initialdir=self.InitialFolder, filetypes=filetypes)  # show the 'get file' dialog box
-                # elif _mac_allow_filetypes():
-                    # file_name = tk.filedialog.askopenfilename(initialdir=self.InitialFolder, filetypes=filetypes)  # show the 'get file' dialog box
-                # else:
-                #     file_name = tk.filedialog.askopenfilename(initialdir=self.InitialFolder)  # show the 'get file' dialog box
+                    file_name = tk.filedialog.askopenfilename(
+                        initialdir=self.InitialFolder, filetypes=filetypes
+                    )  # show the 'get file' dialog box
             else:
-                file_name = tk.filedialog.askopenfilename(filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot)  # show the 'get file' dialog box
+                file_name = tk.filedialog.askopenfilename(
+                    filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot
+                )  # show the 'get file' dialog box
 
             if file_name:
                 strvar.set(file_name)
                 self.TKStringVar.set(file_name)
-            else:           # if "cancel" button clicked, don't generate an event
+            else:  # if "cancel" button clicked, don't generate an event
                 should_submit_window = False
         elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:
-            color = tk.colorchooser.askcolor(parent=self.ParentForm.TKroot, color=self.default_color)  # show the 'get file' dialog box
+            color = tk.colorchooser.askcolor(
+                parent=self.ParentForm.TKroot, color=self.default_color
+            )  # show the 'get file' dialog box
             color = color[1]  # save only the #RRGGBB portion
             if color is not None:
                 strvar.set(color)
@@ -4929,18 +6667,16 @@ class Button(Element):
                     file_name = tk.filedialog.askopenfilenames(initialdir=self.InitialFolder)
                 else:
                     file_name = tk.filedialog.askopenfilenames(filetypes=filetypes, initialdir=self.InitialFolder)
-                # elif _mac_allow_filetypes():
-                #     file_name = tk.filedialog.askopenfilenames(filetypes=filetypes, initialdir=self.InitialFolder)
-                # else:
-                #     file_name = tk.filedialog.askopenfilenames(initialdir=self.InitialFolder)
             else:
-                file_name = tk.filedialog.askopenfilenames(filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot)
+                file_name = tk.filedialog.askopenfilenames(
+                    filetypes=filetypes, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot
+                )
 
             if file_name:
                 file_name = self._files_delimiter.join(file_name)  # normally a ';'
                 strvar.set(file_name)
                 self.TKStringVar.set(file_name)
-            else:           # if "cancel" button clicked, don't generate an event
+            else:  # if "cancel" button clicked, don't generate an event
                 should_submit_window = False
         elif self.BType == BUTTON_TYPE_SAVEAS_FILE:
             # show the 'get file' dialog box
@@ -4948,20 +6684,25 @@ class Button(Element):
                 # Workaround for the "*.*" issue on Mac
                 is_all = [(x, y) for (x, y) in filetypes if all(ch in '* .' for ch in y)]
                 if not len(set(filetypes)) > 1 and (len(is_all) != 0 or filetypes == FILE_TYPES_ALL_FILES):
-                    file_name = tk.filedialog.asksaveasfilename(defaultextension=self.DefaultExtension, initialdir=self.InitialFolder)
+                    file_name = tk.filedialog.asksaveasfilename(
+                        defaultextension=self.DefaultExtension, initialdir=self.InitialFolder
+                    )
                 else:
-                    file_name = tk.filedialog.asksaveasfilename(filetypes=filetypes, defaultextension=self.DefaultExtension, initialdir=self.InitialFolder)
-                # elif _mac_allow_filetypes():
-                #     file_name = tk.filedialog.asksaveasfilename(filetypes=filetypes, defaultextension=self.DefaultExtension, initialdir=self.InitialFolder)
-                # else:
-                #     file_name = tk.filedialog.asksaveasfilename(defaultextension=self.DefaultExtension, initialdir=self.InitialFolder)
+                    file_name = tk.filedialog.asksaveasfilename(
+                        filetypes=filetypes, defaultextension=self.DefaultExtension, initialdir=self.InitialFolder
+                    )
             else:
-                file_name = tk.filedialog.asksaveasfilename(filetypes=filetypes, defaultextension=self.DefaultExtension, initialdir=self.InitialFolder, parent=self.ParentForm.TKroot)
+                file_name = tk.filedialog.asksaveasfilename(
+                    filetypes=filetypes,
+                    defaultextension=self.DefaultExtension,
+                    initialdir=self.InitialFolder,
+                    parent=self.ParentForm.TKroot,
+                )
 
             if file_name:
                 strvar.set(file_name)
                 self.TKStringVar.set(file_name)
-            else:           # if "cancel" button clicked, don't generate an event
+            else:  # if "cancel" button clicked, don't generate an event
                 should_submit_window = False
         elif self.BType == BUTTON_TYPE_CLOSES_WIN:  # this is a return type button so GET RESULTS and destroy window
             # first, get the results table built
@@ -4991,16 +6732,18 @@ class Button(Element):
             self.ParentForm._Close(without_event=True)
             self.ParentForm.TKroot.destroy()  # close the window with tkinter
             Window._DecrementOpenCount()
-        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
+        elif (
+            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
+        ):  # this is a return type button so GET RESULTS and destroy window
             # ------------ new chooser code -------------
             self.ParentForm.LastButtonClicked = self.Key  # key should have been generated already if not set by user
             self.ParentForm.FormRemainedOpen = True
             should_submit_window = False
             _exit_mainloop(self.ParentForm)
         # elif self.BType == BUTTON_TYPE_SHOW_DEBUGGER:
-            # **** DEPRICATED *****
-            # if self.ParentForm.DebuggerEnabled:
-                # show_debugger_popout_window()
+        # **** DEPRICATED *****
+        # if self.ParentForm.DebuggerEnabled:
+        # show_debugger_popout_window()
 
         if should_submit_window:
             self.ParentForm.LastButtonClicked = target_element.Key
@@ -5009,8 +6752,20 @@ class Button(Element):
 
         return
 
-    def update(self, text=None, button_color=(None, None), disabled=None, image_source=None, image_data=None, image_filename=None,
-               visible=None, image_subsample=None, image_zoom=None, disabled_button_color=(None, None), image_size=None):
+    def update(
+        self,
+        text=None,
+        button_color=(None, None),
+        disabled=None,
+        image_source=None,
+        image_data=None,
+        image_filename=None,
+        visible=None,
+        image_subsample=None,
+        image_zoom=None,
+        disabled_button_color=(None, None),
+        image_size=None,
+    ):
         """
         Changes some of the settings for the Button Element. Must call `Window.Read` or `Window.Finalize` prior
 
@@ -5058,7 +6813,7 @@ class Button(Element):
                 image_filename = image_source
 
         if self.UseTtkButtons:
-            style_name = self.ttk_style_name        # created when made initial window (in the pack)
+            style_name = self.ttk_style_name  # created when made initial window (in the pack)
             # style_name = str(self.Key) + 'custombutton.TButton'
             button_style = ttk.Style()
         if text is not None:
@@ -5067,9 +6822,9 @@ class Button(Element):
                 pos = btext.find(MENU_SHORTCUT_CHARACTER)
                 if pos != -1:
                     if pos < len(MENU_SHORTCUT_CHARACTER) or btext[pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                        btext = btext[:pos] + btext[pos + len(MENU_SHORTCUT_CHARACTER):]
+                        btext = btext[:pos] + btext[pos + len(MENU_SHORTCUT_CHARACTER) :]
                     else:
-                        btext = btext.replace('\\'+MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
+                        btext = btext.replace('\\' + MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
                         pos = -1
                 if pos != -1:
                     self.TKButton.config(underline=pos)
@@ -5077,11 +6832,6 @@ class Button(Element):
             self.ButtonText = text
         if button_color != (None, None) and button_color != COLOR_SYSTEM_DEFAULT:
             bc = button_color_to_tuple(button_color, self.ButtonColor)
-            # if isinstance(button_color, str):
-            #     try:
-            #         button_color = button_color.split(' on ')
-            #     except Exception as e:
-            #         print('** Error in formatting your button color **', button_color, e)
             if self.UseTtkButtons:
                 if bc[0] not in (None, COLOR_SYSTEM_DEFAULT):
                     button_style.configure(style_name, foreground=bc[0])
@@ -5143,8 +6893,10 @@ class Button(Element):
                     button_style.map(style_name, foreground=[('disabled', disabled_button_color[0])])
                 if disabled_button_color[1] is not None:
                     button_style.map(style_name, background=[('disabled', disabled_button_color[1])])
-            self.DisabledButtonColor = (disabled_button_color[0] if disabled_button_color[0] is not None else self.DisabledButtonColor[0],
-                                        disabled_button_color[1] if disabled_button_color[1] is not None else self.DisabledButtonColor[1])
+            self.DisabledButtonColor = (
+                disabled_button_color[0] if disabled_button_color[0] is not None else self.DisabledButtonColor[0],
+                disabled_button_color[1] if disabled_button_color[1] is not None else self.DisabledButtonColor[1],
+            )
 
         if visible is not None:
             self._visible = visible
@@ -5186,11 +6938,38 @@ class ButtonMenu(Element):
     The Button Menu Element.  Creates a button that when clicked will show a menu similar to right click menu
     """
 
-    def __init__(self, button_text, menu_def, tooltip=None, disabled=False, image_source=None,
-                 image_filename=None, image_data=None, image_size=(None, None), image_subsample=None, image_zoom=None, border_width=None,
-                 size=(None, None), s=(None, None), auto_size_button=None, button_color=None, text_color=None, background_color=None, disabled_text_color=None,
-                 font=None, item_font=None, pad=None, p=None, expand_x=False, expand_y=False, key=None, k=None, tearoff=False, visible=True,
-                 metadata=None):
+    def __init__(
+        self,
+        button_text,
+        menu_def,
+        tooltip=None,
+        disabled=False,
+        image_source=None,
+        image_filename=None,
+        image_data=None,
+        image_size=(None, None),
+        image_subsample=None,
+        image_zoom=None,
+        border_width=None,
+        size=(None, None),
+        s=(None, None),
+        auto_size_button=None,
+        button_color=None,
+        text_color=None,
+        background_color=None,
+        disabled_text_color=None,
+        font=None,
+        item_font=None,
+        pad=None,
+        p=None,
+        expand_x=False,
+        expand_y=False,
+        key=None,
+        k=None,
+        tearoff=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param button_text:               Text to be displayed on the button
         :type button_text:                (str)
@@ -5252,14 +7031,11 @@ class ButtonMenu(Element):
         :type metadata:                   (Any)
         """
 
-
         self.MenuDefinition = copy.deepcopy(menu_def)
 
         self.AutoSizeButton = auto_size_button
         self.ButtonText = button_text
         self.ButtonColor = button_color_to_tuple(button_color)
-        # self.TextColor = self.ButtonColor[0]
-        # self.BackgroundColor = self.ButtonColor[1]
         self.BackgroundColor = background_color if background_color is not None else theme_input_background_color()
         self.TextColor = text_color if text_color is not None else theme_input_text_color()
         self.DisabledTextColor = disabled_text_color if disabled_text_color is not None else COLOR_SYSTEM_DEFAULT
@@ -5271,7 +7047,9 @@ class ButtonMenu(Element):
             elif isinstance(image_source, bytes):
                 image_data = image_source
             else:
-                warnings.warn('ButtonMenu element - image_source is not a valid type: {}'.format(type(image_source)), UserWarning)
+                warnings.warn(
+                    'ButtonMenu element - image_source is not a valid type: {}'.format(type(image_source)), UserWarning
+                )
 
         self.ImageFilename = image_filename
         self.ImageData = image_data
@@ -5292,10 +7070,19 @@ class ButtonMenu(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_BUTTONMENU, size=sz, font=font, pad=pad, key=key, tooltip=tooltip,
-                         text_color=self.TextColor, background_color=self.BackgroundColor, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_BUTTONMENU,
+            size=sz,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            text_color=self.TextColor,
+            background_color=self.BackgroundColor,
+            visible=visible,
+            metadata=metadata,
+        )
         self.Tearoff = tearoff
-
 
     def _MenuItemChosenCallback(self, item_chosen):  # ButtonMenu Menu Item Chosen Callback
         """
@@ -5308,12 +7095,19 @@ class ButtonMenu(Element):
         self.MenuItemChosen = item_chosen
         self.ParentForm.LastButtonClicked = self.Key
         self.ParentForm.FormRemainedOpen = True
-        # if self.ParentForm.CurrentlyRunningMainloop:
-        #     self.ParentForm.TKroot.quit()  # kick the users out of the mainloop
         _exit_mainloop(self.ParentForm)
 
-
-    def update(self, menu_definition=None, visible=None, image_source=None, image_size=(None, None), image_subsample=None, image_zoom=None, button_text=None, button_color=None):
+    def update(
+        self,
+        menu_definition=None,
+        visible=None,
+        image_source=None,
+        image_size=(None, None),
+        image_subsample=None,
+        image_zoom=None,
+        button_text=None,
+        button_color=None,
+    ):
         """
         Changes some of the settings for the ButtonMenu Element. Must call `Window.Read` or `Window.Finalize` prior
 
@@ -5348,10 +7142,11 @@ class ButtonMenu(Element):
             _error_popup_with_traceback('Error in ButtonMenu.update - The window was closed')
             return
 
-
         if menu_definition is not None:
             self.MenuDefinition = copy.deepcopy(menu_definition)
-            top_menu = self.TKMenu = tk.Menu(self.TKButtonMenu, tearoff=self.Tearoff, font=self.ItemFont, tearoffcommand=self._tearoff_menu_callback)
+            top_menu = self.TKMenu = tk.Menu(
+                self.TKButtonMenu, tearoff=self.Tearoff, font=self.ItemFont, tearoffcommand=self._tearoff_menu_callback
+            )
 
             if self.BackgroundColor not in (COLOR_SYSTEM_DEFAULT, None):
                 top_menu.config(bg=self.BackgroundColor)
@@ -5371,7 +7166,10 @@ class ButtonMenu(Element):
                 elif isinstance(image_source, str):
                     filename = image_source
                 else:
-                    warnings.warn('ButtonMenu element - image_source is not a valid type: {}'.format(type(image_source)), UserWarning)
+                    warnings.warn(
+                        'ButtonMenu element - image_source is not a valid type: {}'.format(type(image_source)),
+                        UserWarning,
+                    )
             image = None
             if filename is not None:
                 image = tk.PhotoImage(file=filename)
@@ -5387,12 +7185,15 @@ class ButtonMenu(Element):
                         image = image.subsample(image_subsample)
                     if image_zoom is not None:
                         image = image.zoom(int(image_zoom))
-                except Exception as e:
+                except Exception:
                     image = data
 
             if image is not None:
                 if type(image) is not bytes:
-                    width, height = image_size[0] if image_size[0] is not None else image.width(), image_size[1] if image_size[1] is not None else image.height()
+                    width, height = (
+                        image_size[0] if image_size[0] is not None else image.width(),
+                        image_size[1] if image_size[1] is not None else image.height(),
+                    )
                 else:
                     width, height = image_size
 
@@ -5428,6 +7229,7 @@ class ButtonMenu(Element):
     Update = update
     Click = click
 
+
 BMenu = ButtonMenu
 BM = ButtonMenu
 
@@ -5440,8 +7242,28 @@ class ProgressBar(Element):
     Progress Bar Element - Displays a colored bar that is shaded as progress of some operation is made
     """
 
-    def __init__(self, max_value, orientation=None, size=(None, None), s=(None, None), size_px=(None, None), auto_size_text=None, bar_color=None, style=None, border_width=None,
-                 relief=None, key=None, k=None, pad=None, p=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        max_value,
+        orientation=None,
+        size=(None, None),
+        s=(None, None),
+        size_px=(None, None),
+        auto_size_text=None,
+        bar_color=None,
+        style=None,
+        border_width=None,
+        relief=None,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param max_value:        max value of progressbar
         :type max_value:         (int)
@@ -5483,7 +7305,6 @@ class ProgressBar(Element):
         :type metadata:          (Any)
         """
 
-
         self.MaxValue = max_value
         self.TKProgressBar = None  # type: TKProgressBar
         self.Cancelled = False
@@ -5508,8 +7329,15 @@ class ProgressBar(Element):
         self.expand_y = expand_y
         self.size_px = size_px
 
-        super().__init__(ELEM_TYPE_PROGRESS_BAR, size=sz, auto_size_text=auto_size_text, key=key, pad=pad,
-                         visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_PROGRESS_BAR,
+            size=sz,
+            auto_size_text=auto_size_text,
+            key=key,
+            pad=pad,
+            visible=visible,
+            metadata=metadata,
+        )
 
     # returns False if update failed
     def update_bar(self, current_count, max=None):
@@ -5563,7 +7391,6 @@ class ProgressBar(Element):
             _error_popup_with_traceback('Error in ProgressBar.update - The window was closed')
             return
 
-
         if self.ParentForm.TKrootDestroyed:
             return False
 
@@ -5585,8 +7412,6 @@ class ProgressBar(Element):
         try:
             self.ParentForm.TKroot.update()
         except:
-            # Window._DecrementOpenCount()
-            # _my_windows.Decrement()
             return False
         return True
 
@@ -5607,7 +7432,28 @@ class Image(Element):
     Image Element - show an image in the window. Should be a GIF or a PNG only
     """
 
-    def __init__(self, source=None, filename=None, data=None, background_color=None, size=(None, None), s=(None, None), pad=None, p=None, key=None, k=None, tooltip=None, subsample=None, zoom=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, enable_events=False, metadata=None):
+    def __init__(
+        self,
+        source=None,
+        filename=None,
+        data=None,
+        background_color=None,
+        size=(None, None),
+        s=(None, None),
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        subsample=None,
+        zoom=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        enable_events=False,
+        metadata=None,
+    ):
         """
         :param source:           A filename or a base64 bytes. Will automatically detect the type and fill in filename or data for you.
         :type source:            str | bytes | None
@@ -5679,9 +7525,16 @@ class Image(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-
-        super().__init__(ELEM_TYPE_IMAGE, size=sz, background_color=background_color, pad=pad, key=key,
-                         tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_IMAGE,
+            size=sz,
+            background_color=background_color,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def update(self, source=None, filename=None, data=None, size=(None, None), subsample=None, zoom=None, visible=None):
@@ -5719,7 +7572,6 @@ class Image(Element):
             _error_popup_with_traceback('Error in Image.update - The window was closed')
             return
 
-
         if source is not None:
             if isinstance(source, bytes):
                 data = source
@@ -5747,16 +7599,19 @@ class Image(Element):
                     image = image.subsample(subsample)
                 if zoom is not None:
                     image = image.zoom(int(zoom))
-            except Exception as e:
+            except Exception:
                 image = data
                 # return  # an error likely means the window has closed so exit
 
         if image is not None:
-            self.tktext_label.configure(image='')           # clear previous image
+            self.tktext_label.configure(image='')  # clear previous image
             if self.tktext_label.image is not None:
                 del self.tktext_label.image
             if type(image) is not bytes:
-                width, height = size[0] if size[0] is not None else image.width(), size[1] if size[1] is not None else image.height()
+                width, height = (
+                    size[0] if size[0] is not None else image.width(),
+                    size[1] if size[1] is not None else image.height(),
+                )
             else:
                 width, height = size
             try:  # sometimes crashes if user closed with X
@@ -5803,12 +7658,12 @@ class Image(Element):
                 if type(source) is not bytes:
                     try:
                         self.AnimatedFrames.append(tk.PhotoImage(file=source, format='gif -index %i' % (i)))
-                    except Exception as e:
+                    except Exception:
                         break
                 else:
                     try:
                         self.AnimatedFrames.append(tk.PhotoImage(data=source, format='gif -index %i' % (i)))
-                    except Exception as e:
+                    except Exception:
                         break
             self.TotalAnimatedFrames = len(self.AnimatedFrames)
             self.LastFrameTime = time.time()
@@ -5830,7 +7685,6 @@ class Image(Element):
             self.tktext_label.configure(image=image, width=image.width(), heigh=image.height())
         except Exception as e:
             print('Exception in update_animation', e)
-
 
     def update_animation_no_buffering(self, source, time_between_frames=0):
         """
@@ -5890,9 +7744,24 @@ Im = Image
 #                           Canvas                                       #
 # ---------------------------------------------------------------------- #
 class Canvas(Element):
-
-    def __init__(self, canvas=None, background_color=None, size=(None, None), s=(None, None), pad=None, p=None, key=None, k=None, tooltip=None,
-                 right_click_menu=None, expand_x=False, expand_y=False, visible=True, border_width=0, metadata=None):
+    def __init__(
+        self,
+        canvas=None,
+        background_color=None,
+        size=(None, None),
+        s=(None, None),
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        border_width=0,
+        metadata=None,
+    ):
         """
         :param canvas:           Your own tk.Canvas if you already created it. Leave blank to create a Canvas
         :type canvas:            (tk.Canvas)
@@ -5926,7 +7795,6 @@ class Canvas(Element):
         :type metadata:          (Any)
         """
 
-
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self._TKCanvas = self.Widget = canvas
         self.RightClickMenu = right_click_menu
@@ -5937,12 +7805,19 @@ class Canvas(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_CANVAS, background_color=background_color, size=sz, pad=pad, key=key,
-                         tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_CANVAS,
+            background_color=background_color,
+            size=sz,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
-
-    def update(self,  background_color=None, visible=None):
+    def update(self, background_color=None, visible=None):
         """
 
         :param background_color: color of background
@@ -5966,7 +7841,6 @@ class Canvas(Element):
             self._pack_restore_settings()
         if visible is not None:
             self._visible = visible
-
 
     @property
     def tk_canvas(self):
@@ -6000,9 +7874,29 @@ class Graph(Element):
     Drawing primitives return an "id" that is referenced when you want to operation on that item (e.g. to erase it)
     """
 
-    def __init__(self, canvas_size, graph_bottom_left, graph_top_right, background_color=None, pad=None, p=None,
-                 change_submits=False, drag_submits=False, enable_events=False, motion_events=False, key=None, k=None, tooltip=None,
-                 right_click_menu=None, expand_x=False, expand_y=False, visible=True, float_values=False, border_width=0, metadata=None):
+    def __init__(
+        self,
+        canvas_size,
+        graph_bottom_left,
+        graph_top_right,
+        background_color=None,
+        pad=None,
+        p=None,
+        change_submits=False,
+        drag_submits=False,
+        enable_events=False,
+        motion_events=False,
+        key=None,
+        k=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        float_values=False,
+        border_width=0,
+        metadata=None,
+    ):
         """
         :param canvas_size:       size of the canvas area in pixels
         :type canvas_size:        (int, int)
@@ -6065,8 +7959,16 @@ class Graph(Element):
         self.expand_y = expand_y
         self.motion_events = motion_events
 
-        super().__init__(ELEM_TYPE_GRAPH, background_color=background_color, size=canvas_size, pad=pad, key=key,
-                         tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_GRAPH,
+            background_color=background_color,
+            size=canvas_size,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def _convert_xy_to_canvas_xy(self, x_in, y_in):
@@ -6190,11 +8092,9 @@ class Graph(Element):
         try:  # needed in case window was closed with an X
             point1 = converted_point[0] - size // 2, converted_point[1] - size // 2
             point2 = converted_point[0] + size // 2, converted_point[1] + size // 2
-            id = self._TKCanvas2.create_oval(point1[0], point1[1],
-                                             point2[0], point2[1],
-                                             width=0,
-                                             fill=color,
-                                             outline=color)
+            id = self._TKCanvas2.create_oval(
+                point1[0], point1[1], point2[0], point2[1], width=0, fill=color, outline=color
+            )
         except:
             id = None
         return id
@@ -6225,12 +8125,16 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        # print('Oval parms', int(converted_point[0]) - int(radius), int(converted_point[1]) - int(radius),
-        #                                      int(converted_point[0]) + int(radius), int(converted_point[1]) + int(radius))
         try:  # needed in case the window was closed with an X
-            id = self._TKCanvas2.create_oval(int(converted_point[0]) - int(radius), int(converted_point[1]) - int(radius),
-                                             int(converted_point[0]) + int(radius), int(converted_point[1]) + int(radius), fill=fill_color,
-                                             outline=line_color, width=line_width)
+            id = self._TKCanvas2.create_oval(
+                int(converted_point[0]) - int(radius),
+                int(converted_point[1]) - int(radius),
+                int(converted_point[0]) + int(radius),
+                int(converted_point[1]) + int(radius),
+                fill=fill_color,
+                outline=line_color,
+                width=line_width,
+            )
         except:
             id = None
         return id
@@ -6258,14 +8162,23 @@ class Graph(Element):
             print('Call Window.Finalize() prior to this operation')
             return None
         try:  # in case windows close with X
-            id = self._TKCanvas2.create_oval(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                             converted_bottom_right[1], fill=fill_color, outline=line_color, width=line_width)
+            id = self._TKCanvas2.create_oval(
+                converted_top_left[0],
+                converted_top_left[1],
+                converted_bottom_right[0],
+                converted_bottom_right[1],
+                fill=fill_color,
+                outline=line_color,
+                width=line_width,
+            )
         except:
             id = None
 
         return id
 
-    def draw_arc(self, top_left, bottom_right, extent, start_angle, style=None, arc_color='black', line_width=1, fill_color=None):
+    def draw_arc(
+        self, top_left, bottom_right, extent, start_angle, style=None, arc_color='black', line_width=1, fill_color=None
+    ):
         """
         Draws different types of arcs.  Uses a "bounding box" to define location
         :param top_left:     the top left point of bounding rectangle
@@ -6293,9 +8206,18 @@ class Graph(Element):
             print('Call Window.Finalize() prior to this operation')
             return None
         try:  # in case closed with X
-            id = self._TKCanvas2.create_arc(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                            converted_bottom_right[1], extent=extent, start=start_angle, style=tkstyle,
-                                            outline=arc_color, width=line_width, fill=fill_color)
+            id = self._TKCanvas2.create_arc(
+                converted_top_left[0],
+                converted_top_left[1],
+                converted_bottom_right[0],
+                converted_bottom_right[1],
+                extent=extent,
+                start=start_angle,
+                style=tkstyle,
+                outline=arc_color,
+                width=line_width,
+                fill=fill_color,
+            )
         except Exception as e:
             print('Error encountered drawing arc.', e)
             id = None
@@ -6328,9 +8250,15 @@ class Graph(Element):
         if line_width is None:
             line_width = 1
         try:  # in case closed with X
-            id = self._TKCanvas2.create_rectangle(converted_top_left[0], converted_top_left[1],
-                                                  converted_bottom_right[0],
-                                                  converted_bottom_right[1], fill=fill_color, outline=line_color, width=line_width)
+            id = self._TKCanvas2.create_rectangle(
+                converted_top_left[0],
+                converted_top_left[1],
+                converted_bottom_right[0],
+                converted_bottom_right[1],
+                fill=fill_color,
+                outline=line_color,
+                width=line_width,
+            )
         except:
             id = None
         return id
@@ -6390,7 +8318,15 @@ class Graph(Element):
             print('Call Window.Finalize() prior to this operation')
             return None
         try:  # in case closed with X
-            id = self._TKCanvas2.create_text(converted_point[0], converted_point[1], text=text, font=font, fill=color, angle=angle, anchor=text_location)
+            id = self._TKCanvas2.create_text(
+                converted_point[0],
+                converted_point[1],
+                text=text,
+                font=font,
+                fill=color,
+                angle=angle,
+                anchor=text_location,
+            )
         except:
             id = None
         return id
@@ -6543,9 +8479,9 @@ class Graph(Element):
         :type y:       int | float
         """
 
-        zero_converted = self._convert_xy_to_canvas_xy(0, 0)
+        # zero_converted = self._convert_xy_to_canvas_xy(0, 0)
         shift_converted = self._convert_xy_to_canvas_xy(x, y)
-        shift_amount = (shift_converted[0] - zero_converted[0], shift_converted[1] - zero_converted[1])
+        # shift_amount = (shift_converted[0] - zero_converted[0], shift_converted[1] - zero_converted[1])
         if figure is None:
             print('*** WARNING - Your figure is None. It most likely means your did not Finalize your Window ***')
             print('Call Window.Finalize() prior to all graph operations')
@@ -6647,7 +8583,6 @@ class Graph(Element):
             self.ParentForm.LastButtonClicked = (self.ParentForm.LastButtonClicked, '+UP')
         self.MouseButtonDown = False
 
-
     # button callback
     def button_press_call_back(self, event):
         """
@@ -6663,8 +8598,6 @@ class Graph(Element):
             self.ParentForm.LastButtonClicked = self.Key
         else:
             self.ParentForm.LastButtonClicked = '__GRAPH__'  # need to put something rather than None
-        # if self.ParentForm.CurrentlyRunningMainloop:
-        #     self.ParentForm.TKroot.quit()  # kick out of loop if read was called
         _exit_mainloop(self.ParentForm)
         self.MouseButtonDown = True
 
@@ -6705,8 +8638,6 @@ class Graph(Element):
             self.ParentForm.LastButtonClicked = self.Key
         else:
             self.ParentForm.LastButtonClicked = '__GRAPH__'  # need to put something rather than None
-        # if self.ParentForm.CurrentlyRunningMainloop:
-        #     self.ParentForm.TKroot.quit()  # kick out of loop if read was called
         if self.motion_events and not self.MouseButtonDown:
             if isinstance(self.ParentForm.LastButtonClicked, str):
                 self.ParentForm.LastButtonClicked = self.ParentForm.LastButtonClicked + '+MOVE'
@@ -6751,9 +8682,32 @@ class Frame(Element):
     A Frame Element that contains other Elements. Encloses with a line around elements and a text label.
     """
 
-    def __init__(self, title, layout, title_color=None, background_color=None, title_location=None,
-                 relief=DEFAULT_FRAME_RELIEF, size=(None, None), s=(None, None), font=None, pad=None, p=None, border_width=None, key=None, k=None,
-                 tooltip=None, right_click_menu=None, expand_x=False, expand_y=False, grab=None, visible=True, element_justification='left', vertical_alignment=None, metadata=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        background_color=None,
+        title_location=None,
+        relief=DEFAULT_FRAME_RELIEF,
+        size=(None, None),
+        s=(None, None),
+        font=None,
+        pad=None,
+        p=None,
+        border_width=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        grab=None,
+        visible=True,
+        element_justification='left',
+        vertical_alignment=None,
+        metadata=None,
+    ):
         """
         :param title:                 text that is displayed as the Frame's "label" or title
         :type title:                  (str)
@@ -6803,7 +8757,6 @@ class Frame(Element):
         :type metadata:               (Any)
         """
 
-
         self.UseDictionary = False
         self.ReturnValues = None
         self.ReturnValuesList = []
@@ -6831,10 +8784,19 @@ class Frame(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_FRAME, background_color=background_color, text_color=title_color, size=sz,
-                         font=font, pad=pad, key=key, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_FRAME,
+            background_color=background_color,
+            text_color=title_color,
+            size=sz,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
-
 
     def add_row(self, *args):
         """
@@ -6848,38 +8810,44 @@ class Frame(Element):
         CurrentRow = []  # start with a blank row and build up
         # -------------------------  Add the elements to a row  ------------------------- #
         for i, element in enumerate(args):  # Loop through list of elements and add them to the row
-            if type(element) == list:
-                PopupError('Error creating Frame layout',
-                           'Layout has a LIST instead of an ELEMENT',
-                           'This sometimes means you have a badly placed ]',
-                           'The offensive list is:',
-                           element,
-                           'This list will be stripped from your layout',
-                           keep_on_top=True
-                           )
+            if type(element) is list:
+                PopupError(
+                    'Error creating Frame layout',
+                    'Layout has a LIST instead of an ELEMENT',
+                    'This sometimes means you have a badly placed ]',
+                    'The offensive list is:',
+                    element,
+                    'This list will be stripped from your layout',
+                    keep_on_top=True,
+                )
                 continue
             elif callable(element) and not isinstance(element, Element):
-                PopupError('Error creating Frame layout',
-                           'Layout has a FUNCTION instead of an ELEMENT',
-                           'This likely means you are missing () from your layout',
-                           'The offensive list is:',
-                           element,
-                           'This item will be stripped from your layout',
-                           keep_on_top=True)
+                PopupError(
+                    'Error creating Frame layout',
+                    'Layout has a FUNCTION instead of an ELEMENT',
+                    'This likely means you are missing () from your layout',
+                    'The offensive list is:',
+                    element,
+                    'This item will be stripped from your layout',
+                    keep_on_top=True,
+                )
                 continue
             if element.ParentContainer is not None:
                 warnings.warn(
                     '*** YOU ARE ATTEMPTING TO REUSE AN ELEMENT IN YOUR LAYOUT! Once placed in a layout, an element cannot be used in another layout. ***',
-                    UserWarning)
-                _error_popup_with_traceback('Error creating Frame layout',
-                                            'The layout specified has already been used',
-                                            'You MUST start witha "clean", unused layout every time you create a window',
-                                            'The offensive Element = ',
-                                            element,
-                                            'and has a key = ', element.Key,
-                                            'This item will be stripped from your layout',
-                                            'Hint - try printing your layout and matching the IDs "print(layout)"',
-                                            )
+                    UserWarning,
+                )
+                _error_popup_with_traceback(
+                    'Error creating Frame layout',
+                    'The layout specified has already been used',
+                    'You MUST start witha "clean", unused layout every time you create a window',
+                    'The offensive Element = ',
+                    element,
+                    'and has a key = ',
+                    element.Key,
+                    'This item will be stripped from your layout',
+                    'Hint - try printing your layout and matching the IDs "print(layout)"',
+                )
                 continue
             element.Position = (CurrentRowNumber, i)
             element.ParentContainer = self
@@ -6903,12 +8871,16 @@ class Frame(Element):
             try:
                 iter(row)
             except TypeError:
-                PopupError('Error creating Frame layout',
-                           'Your row is not an iterable (e.g. a list)',
-                           'Instead of a list, the type found was {}'.format(type(row)),
-                           'The offensive row = ',
-                           row,
-                           'This item will be stripped from your layout', keep_on_top=True, image=_random_error_emoji())
+                PopupError(
+                    'Error creating Frame layout',
+                    'Your row is not an iterable (e.g. a list)',
+                    'Instead of a list, the type found was {}'.format(type(row)),
+                    'The offensive row = ',
+                    row,
+                    'This item will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             self.AddRow(*row)
         return self
@@ -7046,12 +9018,12 @@ HSep = HorizontalSeparator
 # ---------------------------------------------------------------------- #
 class Sizegrip(Element):
     """
-        Sizegrip element will be added to the bottom right corner of your window.
-        It should be placed on the last row of your window along with any other elements on that row.
-        The color will match the theme's background color.
+    Sizegrip element will be added to the bottom right corner of your window.
+    It should be placed on the last row of your window along with any other elements on that row.
+    The color will match the theme's background color.
     """
 
-    def __init__(self, background_color=None, pad=None, p=(0,0), key=None, k=None):
+    def __init__(self, background_color=None, pad=None, p=(0, 0), key=None, k=None):
         """
         Sizegrip Element
         :param background_color: color to use for the background of the grip
@@ -7070,8 +9042,7 @@ class Sizegrip(Element):
         pad = pad if pad is not None else p
         key = key if key is not None else k
 
-
-        super().__init__(ELEM_TYPE_SIZEGRIP, background_color=bg,key=key, pad=pad)
+        super().__init__(ELEM_TYPE_SIZEGRIP, background_color=bg, key=key, pad=pad)
 
 
 SGrip = Sizegrip
@@ -7086,8 +9057,30 @@ class Tab(Element):
     Tabs are never placed directly into a layout.  They are always "Contained" in a TabGroup layout
     """
 
-    def __init__(self, title, layout, title_color=None, background_color=None, font=None, pad=None, p=None, disabled=False,
-                 border_width=None, key=None, k=None, tooltip=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, element_justification='left', image_source=None, image_subsample=None, image_zoom=None, metadata=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        background_color=None,
+        font=None,
+        pad=None,
+        p=None,
+        disabled=False,
+        border_width=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        element_justification='left',
+        image_source=None,
+        image_subsample=None,
+        image_zoom=None,
+        metadata=None,
+    ):
         """
         :param title:                 text to show on the tab
         :type title:                  (str)
@@ -7171,8 +9164,17 @@ class Tab(Element):
 
         self.Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB, background_color=background_color, text_color=title_color, font=font, pad=pad, key=key, tooltip=tooltip,
-                         visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TAB,
+            background_color=background_color,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def add_row(self, *args):
@@ -7187,34 +9189,42 @@ class Tab(Element):
         CurrentRow = []  # start with a blank row and build up
         # -------------------------  Add the elements to a row  ------------------------- #
         for i, element in enumerate(args):  # Loop through list of elements and add them to the row
-            if type(element) == list:
-                popup_error_with_traceback('Error creating Tab layout',
-                           'Layout has a LIST instead of an ELEMENT',
-                           'This sometimes means you have a badly placed ]',
-                           'The offensive list is:',
-                           element,
-                           'This list will be stripped from your layout')
+            if type(element) is list:
+                popup_error_with_traceback(
+                    'Error creating Tab layout',
+                    'Layout has a LIST instead of an ELEMENT',
+                    'This sometimes means you have a badly placed ]',
+                    'The offensive list is:',
+                    element,
+                    'This list will be stripped from your layout',
+                )
                 continue
             elif callable(element) and not isinstance(element, Element):
-                popup_error_with_traceback('Error creating Tab layout',
-                           'Layout has a FUNCTION instead of an ELEMENT',
-                           'This likely means you are missing () from your layout',
-                           'The offensive list is:',
-                           element,
-                           'This item will be stripped from your layout')
+                popup_error_with_traceback(
+                    'Error creating Tab layout',
+                    'Layout has a FUNCTION instead of an ELEMENT',
+                    'This likely means you are missing () from your layout',
+                    'The offensive list is:',
+                    element,
+                    'This item will be stripped from your layout',
+                )
                 continue
             if element.ParentContainer is not None:
                 warnings.warn(
                     '*** YOU ARE ATTEMPTING TO REUSE AN ELEMENT IN YOUR LAYOUT! Once placed in a layout, an element cannot be used in another layout. ***',
-                    UserWarning)
-                popup_error_with_traceback('Error creating Tab layout',
-                           'The layout specified has already been used',
-                           'You MUST start witha "clean", unused layout every time you create a window',
-                           'The offensive Element = ',
-                           element,
-                           'and has a key = ', element.Key,
-                           'This item will be stripped from your layout',
-                           'Hint - try printing your layout and matching the IDs "print(layout)"')
+                    UserWarning,
+                )
+                popup_error_with_traceback(
+                    'Error creating Tab layout',
+                    'The layout specified has already been used',
+                    'You MUST start witha "clean", unused layout every time you create a window',
+                    'The offensive Element = ',
+                    element,
+                    'and has a key = ',
+                    element.Key,
+                    'This item will be stripped from your layout',
+                    'Hint - try printing your layout and matching the IDs "print(layout)"',
+                )
                 continue
             element.Position = (CurrentRowNumber, i)
             element.ParentContainer = self
@@ -7238,12 +9248,16 @@ class Tab(Element):
             try:
                 iter(row)
             except TypeError:
-                PopupError('Error creating Tab layout',
-                           'Your row is not an iterable (e.g. a list)',
-                           'Instead of a list, the type found was {}'.format(type(row)),
-                           'The offensive row = ',
-                           row,
-                           'This item will be stripped from your layout', keep_on_top=True, image=_random_error_emoji())
+                PopupError(
+                    'Error creating Tab layout',
+                    'Your row is not an iterable (e.g. a list)',
+                    'Instead of a list, the type found was {}'.format(type(row)),
+                    'The offensive row = ',
+                    row,
+                    'This item will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             self.AddRow(*row)
         return self
@@ -7272,7 +9286,6 @@ class Tab(Element):
             _error_popup_with_traceback('Error in Tab.update - The window was closed')
             return
 
-
         state = 'normal'
         if disabled is not None:
             self.Disabled = disabled
@@ -7288,12 +9301,6 @@ class Tab(Element):
         if title is not None:
             self.Title = str(title)
             self.ParentNotebook.tab(self.TabID, text=self.Title)
-            # self.ParentNotebook.tab(self.ContainerElemementNumber-1, text=self.Title)
-
-        # if visible is False:
-        #     self.ParentNotebook.pack_forget()
-        # elif visible is True:
-        #     self.ParentNotebook.pack()
         return self
 
     def _GetElementAtLocation(self, location):
@@ -7336,9 +9343,35 @@ class TabGroup(Element):
     TabGroup Element groups together your tabs into the group of tabs you see displayed in your window
     """
 
-    def __init__(self, layout, tab_location=None, title_color=None, tab_background_color=None, selected_title_color=None, selected_background_color=None,
-                 background_color=None, focus_color=None, font=None, change_submits=False, enable_events=False, pad=None, p=None, border_width=None, tab_border_width=None, theme=None, key=None, k=None,
-                 size=(None, None), s=(None, None), tooltip=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        layout,
+        tab_location=None,
+        title_color=None,
+        tab_background_color=None,
+        selected_title_color=None,
+        selected_background_color=None,
+        background_color=None,
+        focus_color=None,
+        font=None,
+        change_submits=False,
+        enable_events=False,
+        pad=None,
+        p=None,
+        border_width=None,
+        tab_border_width=None,
+        theme=None,
+        key=None,
+        k=None,
+        size=(None, None),
+        s=(None, None),
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param layout:                    Layout of Tabs. Different than normal layouts. ALL Tabs should be on first row
         :type layout:                     List[List[Tab]]
@@ -7394,22 +9427,34 @@ class TabGroup(Element):
         :type metadata:                   (Any)
         """
 
-
         self.UseDictionary = False
         self.ReturnValues = None
         self.ReturnValuesList = []
         self.ReturnValuesDictionary = {}
         self.DictionaryKeyCounter = 0
         self.ParentWindow = None
-        self.SelectedTitleColor = selected_title_color if selected_title_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT']
-        self.SelectedBackgroundColor = selected_background_color if selected_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL][
-            'BACKGROUND']
-        title_color = title_color if title_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
-        self.TabBackgroundColor = tab_background_color if tab_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
+        self.SelectedTitleColor = (
+            selected_title_color
+            if selected_title_color is not None
+            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT']
+        )
+        self.SelectedBackgroundColor = (
+            selected_background_color
+            if selected_background_color is not None
+            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['BACKGROUND']
+        )
+        title_color = (
+            title_color if title_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
+        )
+        self.TabBackgroundColor = (
+            tab_background_color
+            if tab_background_color is not None
+            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
+        )
         self.Rows = []
         self.TKNotebook = None  # type: ttk.Notebook
         self.Widget = None  # type: ttk.Notebook
-        self.tab_index_to_key = {}      # has a list of the tabs in the notebook and their associated key
+        self.tab_index_to_key = {}  # has a list of the tabs in the notebook and their associated key
         self.TabCount = 0
         self.BorderWidth = border_width
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
@@ -7428,8 +9473,18 @@ class TabGroup(Element):
 
         self.Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB_GROUP, size=sz, background_color=background_color, text_color=title_color, font=font,
-                         pad=pad, key=key, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TAB_GROUP,
+            size=sz,
+            background_color=background_color,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def add_row(self, *args):
@@ -7445,35 +9500,48 @@ class TabGroup(Element):
         CurrentRow = []  # start with a blank row and build up
         # -------------------------  Add the elements to a row  ------------------------- #
         for i, element in enumerate(args):  # Loop through list of elements and add them to the row
-            if type(element) == list:
-                PopupError('Error creating Tab layout',
-                           'Layout has a LIST instead of an ELEMENT',
-                           'This sometimes means you have a badly placed ]',
-                           'The offensive list is:',
-                           element,
-                           'This list will be stripped from your layout', keep_on_top=True, image=_random_error_emoji()
-                           )
+            if type(element) is list:
+                PopupError(
+                    'Error creating Tab layout',
+                    'Layout has a LIST instead of an ELEMENT',
+                    'This sometimes means you have a badly placed ]',
+                    'The offensive list is:',
+                    element,
+                    'This list will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             elif callable(element) and not isinstance(element, Element):
-                PopupError('Error creating Tab layout',
-                           'Layout has a FUNCTION instead of an ELEMENT',
-                           'This likely means you are missing () from your layout',
-                           'The offensive list is:',
-                           element,
-                           'This item will be stripped from your layout', keep_on_top=True, image=_random_error_emoji())
+                PopupError(
+                    'Error creating Tab layout',
+                    'Layout has a FUNCTION instead of an ELEMENT',
+                    'This likely means you are missing () from your layout',
+                    'The offensive list is:',
+                    element,
+                    'This item will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             if element.ParentContainer is not None:
                 warnings.warn(
                     '*** YOU ARE ATTEMPTING TO REUSE AN ELEMENT IN YOUR LAYOUT! Once placed in a layout, an element cannot be used in another layout. ***',
-                    UserWarning)
-                PopupError('Error creating Tab layout',
-                           'The layout specified has already been used',
-                           'You MUST start witha "clean", unused layout every time you create a window',
-                           'The offensive Element = ',
-                           element,
-                           'and has a key = ', element.Key,
-                           'This item will be stripped from your layout',
-                           'Hint - try printing your layout and matching the IDs "print(layout)"', keep_on_top=True, image=_random_error_emoji())
+                    UserWarning,
+                )
+                PopupError(
+                    'Error creating Tab layout',
+                    'The layout specified has already been used',
+                    'You MUST start witha "clean", unused layout every time you create a window',
+                    'The offensive Element = ',
+                    element,
+                    'and has a key = ',
+                    element.Key,
+                    'This item will be stripped from your layout',
+                    'Hint - try printing your layout and matching the IDs "print(layout)"',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             element.Position = (CurrentRowNumber, i)
             element.ParentContainer = self
@@ -7496,12 +9564,16 @@ class TabGroup(Element):
             try:
                 iter(row)
             except TypeError:
-                PopupError('Error creating Tab layout',
-                           'Your row is not an iterable (e.g. a list)',
-                           'Instead of a list, the type found was {}'.format(type(row)),
-                           'The offensive row = ',
-                           row,
-                           'This item will be stripped from your layout', keep_on_top=True, image=_random_error_emoji())
+                PopupError(
+                    'Error creating Tab layout',
+                    'Your row is not an iterable (e.g. a list)',
+                    'Instead of a list, the type found was {}'.format(type(row)),
+                    'The offensive row = ',
+                    row,
+                    'This item will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             self.AddRow(*row)
         return self
@@ -7535,7 +9607,6 @@ class TabGroup(Element):
                 if element.Title == tab_name:
                     return element.Key
         return None
-
 
     def find_currently_active_tab_key(self):
         """
@@ -7604,16 +9675,21 @@ class TabGroup(Element):
                 # print('*ERROR laying out form.... Image Element has no image specified*')
         except Exception as e:
             photo = None
-            _error_popup_with_traceback('Your Window has an Tab Element with an IMAGE problem',
-                                        'The traceback will show you the Window with the problem layout',
-                                        'Look in this Window\'s layout for an Image tab_element that has a key of {}'.format(tab_element.Key),
-                                        'The error occuring is:', e)
+            _error_popup_with_traceback(
+                'Your Window has an Tab Element with an IMAGE problem',
+                'The traceback will show you the Window with the problem layout',
+                'Look in this Window\'s layout for an Image tab_element that has a key of {}'.format(tab_element.Key),
+                'The error occuring is:',
+                e,
+            )
 
         tab_element.photo = photo
         # add the label
         if photo is not None:
             width, height = photo.width(), photo.height()
-            tab_element.tktext_label = tk.Label(tab_element.ParentRowFrame, image=photo, width=width, height=height, bd=0)
+            tab_element.tktext_label = tk.Label(
+                tab_element.ParentRowFrame, image=photo, width=width, height=height, bd=0
+            )
         else:
             tab_element.tktext_label = tk.Label(tab_element.ParentRowFrame, bd=0)
         # ------------------- end of imagey-stuff -------------------
@@ -7632,14 +9708,18 @@ class TabGroup(Element):
         tab_element.ParentForm = self.ParentForm
         self.TabCount += 1
         if tab_element.BackgroundColor != COLOR_SYSTEM_DEFAULT and tab_element.BackgroundColor is not None:
-            tab_element.TKFrame.configure(background=tab_element.BackgroundColor, highlightbackground=tab_element.BackgroundColor,
-                                          highlightcolor=tab_element.BackgroundColor)
+            tab_element.TKFrame.configure(
+                background=tab_element.BackgroundColor,
+                highlightbackground=tab_element.BackgroundColor,
+                highlightcolor=tab_element.BackgroundColor,
+            )
         if tab_element.BorderWidth is not None:
             tab_element.TKFrame.configure(borderwidth=tab_element.BorderWidth)
         if tab_element.Tooltip is not None:
-            tab_element.TooltipObject = ToolTip(tab_element.TKFrame, text=tab_element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
+            tab_element.TooltipObject = ToolTip(
+                tab_element.TKFrame, text=tab_element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+            )
         _add_right_click_menu(tab_element, form)
-
 
     def update(self, visible=None):
         """
@@ -7663,9 +9743,6 @@ class TabGroup(Element):
         if visible is not None:
             self._visible = visible
 
-
-
-
     AddRow = add_row
     FindKeyFromTabName = find_key_from_tab_name
     Get = get
@@ -7680,10 +9757,35 @@ class Slider(Element):
     A slider, horizontal or vertical
     """
 
-    def __init__(self, range=(None, None), default_value=None, resolution=None, tick_interval=None, orientation=None,
-                 disable_number_display=False, border_width=None, relief=None, change_submits=False,
-                 enable_events=False, disabled=False, size=(None, None), s=(None, None), font=None, background_color=None,
-                 text_color=None, trough_color=None, key=None, k=None, pad=None, p=None, expand_x=False, expand_y=False, tooltip=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        range=(None, None),
+        default_value=None,
+        resolution=None,
+        tick_interval=None,
+        orientation=None,
+        disable_number_display=False,
+        border_width=None,
+        relief=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        size=(None, None),
+        s=(None, None),
+        font=None,
+        background_color=None,
+        text_color=None,
+        trough_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        p=None,
+        expand_x=False,
+        expand_y=False,
+        tooltip=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param range:                  slider's range (min value, max value)
         :type range:                   (int, int) | Tuple[float, float]
@@ -7760,8 +9862,18 @@ class Slider(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_INPUT_SLIDER, size=temp_size, font=font, background_color=background_color,
-                         text_color=text_color, key=key, pad=pad, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_SLIDER,
+            size=temp_size,
+            font=font,
+            background_color=background_color,
+            text_color=text_color,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def update(self, value=None, range=(None, None), disabled=None, visible=None):
@@ -7790,7 +9902,6 @@ class Slider(Element):
             _error_popup_with_traceback('Error in Slider.update - The window was closed')
             return
 
-
         if range != (None, None):
             self.TKScale.config(from_=range[0], to_=range[1])
         if value is not None:
@@ -7813,7 +9924,6 @@ class Slider(Element):
         if visible is not None:
             self._visible = visible
 
-
     def _SliderChangedHandler(self, event):
         """
         Not user callable.  Callback function for when slider is moved.
@@ -7827,8 +9937,6 @@ class Slider(Element):
         else:
             self.ParentForm.LastButtonClicked = ''
         self.ParentForm.FormRemainedOpen = True
-        # if self.ParentForm.CurrentlyRunningMainloop:
-        #     self.ParentForm.TKroot.quit()  # kick the users out of the mainloop
         _exit_mainloop(self.ParentForm)
 
     Update = update
@@ -7903,9 +10011,6 @@ class TkScrollableFrame(tk.Frame):
             # self.hscrollbar = tk.Scrollbar(self, orient=tk.HORIZONTAL)
             element.hsb.pack(side='bottom', fill='x', expand='false')
             self.canvas.config(xscrollcommand=element.hsb.set)
-            # self.canvas = tk.Canvas(self, )
-        # else:
-        #     self.canvas = tk.Canvas(self)
 
         self.canvas.config(yscrollcommand=element.vsb.set)
         self.canvas.pack(side='left', fill='both', expand=True)
@@ -7926,21 +10031,11 @@ class TkScrollableFrame(tk.Frame):
 
         # Canvas can be: master, canvas, TKFrame
 
-        # Chr0nic
-
-        # self.unhookMouseWheel(None)
-        # self.TKFrame.bind("<Enter>", self.hookMouseWheel)
-        # self.TKFrame.bind("<Leave>", self.unhookMouseWheel)
-        # self.bind('<Configure>', self.set_scrollregion)
-
-
         self.unhookMouseWheel(None)
         self.canvas.bind('<Enter>', self.hookMouseWheel)
         self.canvas.bind('<Leave>', self.unhookMouseWheel)
         self.bind('<Configure>', self.set_scrollregion)
 
-
-    # Chr0nic
     def hookMouseWheel(self, e):
         # print("enter")
         VarHolder.canvas_holder = self.canvas
@@ -7983,7 +10078,7 @@ class TkScrollableFrame(tk.Frame):
         parent.bind('<Button-5>', mode)
 
     def set_scrollregion(self, event=None):
-        """ Set the scroll region on the canvas """
+        """Set the scroll region on the canvas"""
         self.canvas.configure(scrollregion=self.canvas.bbox('all'))
 
 
@@ -7995,11 +10090,37 @@ class Column(Element):
     A container element that is used to create a layout within your window's layout
     """
 
-    def __init__(self, layout, background_color=None, size=(None, None), s=(None, None), size_subsample_width=1, size_subsample_height=2, pad=None, p=None, scrollable=False,
-                 vertical_scroll_only=False, right_click_menu=None, key=None, k=None, visible=True, justification=None, element_justification=None,
-                 vertical_alignment=None, grab=None, expand_x=None, expand_y=None, metadata=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None,
-                 sbar_frame_color=None, sbar_relief=None):
+    def __init__(
+        self,
+        layout,
+        background_color=None,
+        size=(None, None),
+        s=(None, None),
+        size_subsample_width=1,
+        size_subsample_height=2,
+        pad=None,
+        p=None,
+        scrollable=False,
+        vertical_scroll_only=False,
+        right_click_menu=None,
+        key=None,
+        k=None,
+        visible=True,
+        justification=None,
+        element_justification=None,
+        vertical_alignment=None,
+        grab=None,
+        expand_x=None,
+        expand_y=None,
+        metadata=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+    ):
         """
         :param layout:                      Layout that will be shown in the Column container
         :type layout:                       List[List[Element]]
@@ -8059,7 +10180,6 @@ class Column(Element):
         :type sbar_relief:                  (str)
         """
 
-
         self.UseDictionary = False
         self.ReturnValues = None
         self.ReturnValuesList = []
@@ -8089,8 +10209,22 @@ class Column(Element):
         self.size_subsample_width = size_subsample_width
         self.size_subsample_height = size_subsample_height
 
-        super().__init__(ELEM_TYPE_COLUMN, background_color=bg, size=sz, pad=pad, key=key, visible=visible, metadata=metadata,
-                         sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
+        super().__init__(
+            ELEM_TYPE_COLUMN,
+            background_color=bg,
+            size=sz,
+            pad=pad,
+            key=key,
+            visible=visible,
+            metadata=metadata,
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
         return
 
     def add_row(self, *args):
@@ -8106,35 +10240,48 @@ class Column(Element):
         CurrentRow = []  # start with a blank row and build up
         # -------------------------  Add the elements to a row  ------------------------- #
         for i, element in enumerate(args):  # Loop through list of elements and add them to the row
-            if type(element) == list:
-                PopupError('Error creating Column layout',
-                           'Layout has a LIST instead of an ELEMENT',
-                           'This sometimes means you have a badly placed ]',
-                           'The offensive list is:',
-                           element,
-                           'This list will be stripped from your layout', keep_on_top=True, image=_random_error_emoji()
-                           )
+            if type(element) is list:
+                PopupError(
+                    'Error creating Column layout',
+                    'Layout has a LIST instead of an ELEMENT',
+                    'This sometimes means you have a badly placed ]',
+                    'The offensive list is:',
+                    element,
+                    'This list will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             elif callable(element) and not isinstance(element, Element):
-                PopupError('Error creating Column layout',
-                           'Layout has a FUNCTION instead of an ELEMENT',
-                           'This likely means you are missing () from your layout',
-                           'The offensive list is:',
-                           element,
-                           'This item will be stripped from your layout', keep_on_top=True, image=_random_error_emoji())
+                PopupError(
+                    'Error creating Column layout',
+                    'Layout has a FUNCTION instead of an ELEMENT',
+                    'This likely means you are missing () from your layout',
+                    'The offensive list is:',
+                    element,
+                    'This item will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             if element.ParentContainer is not None:
                 warnings.warn(
                     '*** YOU ARE ATTEMPTING TO REUSE AN ELEMENT IN YOUR LAYOUT! Once placed in a layout, an element cannot be used in another layout. ***',
-                    UserWarning)
-                PopupError('Error creating Column layout',
-                           'The layout specified has already been used',
-                           'You MUST start witha "clean", unused layout every time you create a window',
-                           'The offensive Element = ',
-                           element,
-                           'and has a key = ', element.Key,
-                           'This item will be stripped from your layout',
-                           'Hint - try printing your layout and matching the IDs "print(layout)"', keep_on_top=True, image=_random_error_emoji())
+                    UserWarning,
+                )
+                PopupError(
+                    'Error creating Column layout',
+                    'The layout specified has already been used',
+                    'You MUST start witha "clean", unused layout every time you create a window',
+                    'The offensive Element = ',
+                    element,
+                    'and has a key = ',
+                    element.Key,
+                    'This item will be stripped from your layout',
+                    'Hint - try printing your layout and matching the IDs "print(layout)"',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             element.Position = (CurrentRowNumber, i)
             element.ParentContainer = self
@@ -8158,12 +10305,16 @@ class Column(Element):
             try:
                 iter(row)
             except TypeError:
-                PopupError('Error creating Column layout',
-                           'Your row is not an iterable (e.g. a list)',
-                           'Instead of a list, the type found was {}'.format(type(row)),
-                           'The offensive row = ',
-                           row,
-                           'This item will be stripped from your layout', keep_on_top=True, image=_random_error_emoji())
+                PopupError(
+                    'Error creating Column layout',
+                    'Your row is not an iterable (e.g. a list)',
+                    'Instead of a list, the type found was {}'.format(type(row)),
+                    'The offensive row = ',
+                    row,
+                    'This item will be stripped from your layout',
+                    keep_on_top=True,
+                    image=_random_error_emoji(),
+                )
                 continue
             self.AddRow(*row)
         return self
@@ -8203,25 +10354,14 @@ class Column(Element):
             _error_popup_with_traceback('Error in Column.update - The window was closed')
             return
 
-        if self.expand_x and self.expand_y:
-            expand = tk.BOTH
-        elif self.expand_x:
-            expand = tk.X
-        elif self.expand_y:
-            expand = tk.Y
-        else:
-            expand = None
-
         if visible is False:
             if self.TKColFrame:
                 self._pack_forget_save_settings()
-                # self.TKColFrame.pack_forget()
             if self.ParentPanedWindow:
                 self.ParentPanedWindow.remove(self.TKColFrame)
         elif visible is True:
             if self.TKColFrame:
                 self._pack_restore_settings()
-                # self.TKColFrame.pack(padx=self.pad_used[0], pady=self.pad_used[1], fill=expand)
             if self.ParentPanedWindow:
                 self.ParentPanedWindow.add(self.TKColFrame)
         if visible is not None:
@@ -8251,8 +10391,26 @@ class Pane(Element):
     A sliding Pane that is unique to tkinter.  Uses Columns to create individual panes
     """
 
-    def __init__(self, pane_list, background_color=None, size=(None, None), s=(None, None), pad=None, p=None, orientation='vertical',
-                 show_handle=True, relief=RELIEF_RAISED, handle_size=None, border_width=None, key=None, k=None,  expand_x=None, expand_y=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        pane_list,
+        background_color=None,
+        size=(None, None),
+        s=(None, None),
+        pad=None,
+        p=None,
+        orientation='vertical',
+        show_handle=True,
+        relief=RELIEF_RAISED,
+        handle_size=None,
+        border_width=None,
+        key=None,
+        k=None,
+        expand_x=None,
+        expand_y=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param pane_list:        Must be a list of Column Elements. Each Column supplied becomes one pane that's shown
         :type pane_list:         List[Column] | Tuple[Column]
@@ -8290,7 +10448,6 @@ class Pane(Element):
         :type metadata:          (Any)
         """
 
-
         self.UseDictionary = False
         self.ReturnValues = None
         self.ReturnValuesList = []
@@ -8315,7 +10472,9 @@ class Pane(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_PANE, background_color=bg, size=sz, pad=pad, key=key, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_PANE, background_color=bg, size=sz, pad=pad, key=key, visible=visible, metadata=metadata
+        )
         return
 
     def update(self, visible=None):
@@ -8357,13 +10516,14 @@ class TKCalendar(ttk.Frame):
     This code was shamelessly lifted from moshekaplan's repository - moshekaplan/tkinter_components
     NONE of this code is user callable.  Stay away!
     """
+
     # XXX ToDo: cget and configure
 
     datetime = calendar.datetime.datetime
     timedelta = calendar.datetime.timedelta
 
     def __init__(self, master=None, target_element=None, close_when_chosen=True, default_date=(None, None, None), **kw):
-        """WIDGET-SPECIFIC OPTIONS: locale, firstweekday, year, month, selectbackground, selectforeground """
+        """WIDGET-SPECIFIC OPTIONS: locale, firstweekday, year, month, selectbackground, selectforeground"""
         self._TargetElement = target_element
         default_mon, default_day, default_year = default_date
         # remove custom options from kw before initializating ttk.Frame
@@ -8396,8 +10556,7 @@ class TKCalendar(ttk.Frame):
         self.__setup_selection(sel_bg, sel_fg)
 
         # store items ids, used for insertion later
-        self._items = [self._calendar.insert('', 'end', values='')
-                       for _ in range(6)]
+        self._items = [self._calendar.insert('', 'end', values='') for _ in range(6)]
         # insert dates in the currently empty calendar
         self._build_calendar()
 
@@ -8425,9 +10584,10 @@ class TKCalendar(ttk.Frame):
     def __setup_styles(self):
         # custom ttk styles
         style = ttk.Style(self.master)
-        arrow_layout = lambda dir: (
-            [('Button.focus', {'children': [('Button.%sarrow' % dir, None)]})]
-        )
+
+        def arrow_layout(dir):
+            return [('Button.focus', {'children': [('Button.%sarrow' % dir, None)]})]
+
         style.layout('L.TButton', arrow_layout('left'))
         style.layout('R.TButton', arrow_layout('right'))
 
@@ -8456,13 +10616,11 @@ class TKCalendar(ttk.Frame):
         font = tkinter.font.Font()
         maxwidth = max(font.measure(col) for col in cols)
         for col in cols:
-            self._calendar.column(col, width=maxwidth, minwidth=maxwidth,
-                                  anchor='e')
+            self._calendar.column(col, width=maxwidth, minwidth=maxwidth, anchor='e')
 
     def __setup_selection(self, sel_bg, sel_fg):
         self._font = tkinter.font.Font()
-        self._canvas = canvas = tk.Canvas(self._calendar,
-                                          background=sel_bg, borderwidth=0, highlightthickness=0)
+        self._canvas = canvas = tk.Canvas(self._calendar, background=sel_bg, borderwidth=0, highlightthickness=0)
         canvas.text = canvas.create_text(0, 0, fill=sel_fg, anchor='w')
 
         canvas.bind('<ButtonPress-1>', lambda evt: canvas.place_forget())
@@ -8471,7 +10629,7 @@ class TKCalendar(ttk.Frame):
 
     def __minsize(self, evt):
         width, height = self._calendar.master.geometry().split('x')
-        height = height[:height.index('+')]
+        height = height[: height.index('+')]
         self._calendar.master.minsize(width, height)
 
     def _build_calendar(self):
@@ -8489,7 +10647,7 @@ class TKCalendar(ttk.Frame):
             self._calendar.item(item, values=fmt_week)
 
     def _show_selection(self, text, bbox):
-        """ Configure canvas for a new selection. """
+        """Configure canvas for a new selection."""
         x, y, width, height = bbox
 
         textw = self._font.measure(text)
@@ -8503,12 +10661,12 @@ class TKCalendar(ttk.Frame):
     # Callbacks
 
     def _pressed(self, evt):
-        """ Clicked somewhere in the calendar. """
+        """Clicked somewhere in the calendar."""
         x, y, widget = evt.x, evt.y, evt.widget
         item = widget.identify_row(y)
         column = widget.identify_column(x)
 
-        if not column or not item in self._items:
+        if not column or item not in self._items:
             # clicked in the weekdays row or just outside the columns
             return
 
@@ -8533,7 +10691,9 @@ class TKCalendar(ttk.Frame):
         try:
             self._TargetElement.Update(
                 self.datetime(year, month, int(self._selection[0]), now.hour, now.minute, now.second).strftime(
-                    self.format))
+                    self.format
+                )
+            )
             if self._TargetElement.ChangeSubmits:
                 self._TargetElement.ParentForm.LastButtonClicked = self._TargetElement.Key
                 self._TargetElement.ParentForm.FormRemainedOpen = True
@@ -8556,8 +10716,7 @@ class TKCalendar(ttk.Frame):
         self._canvas.place_forget()
 
         year, month = self._date.year, self._date.month
-        self._date = self._date + self.timedelta(
-            days=calendar.monthrange(year, month)[1] + 1)
+        self._date = self._date + self.timedelta(days=calendar.monthrange(year, month)[1] + 1)
         self._date = self.datetime(self._date.year, self._date.month, 1)
         self._build_calendar()  # reconstruct calendar
 
@@ -8595,8 +10754,23 @@ class Menu(Element):
     menu is shown.  The key portion is returned as part of the event.
     """
 
-    def __init__(self, menu_definition, background_color=None, text_color=None, disabled_text_color=None, size=(None, None), s=(None, None), tearoff=False,
-                 font=None, pad=None, p=None, key=None, k=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        menu_definition,
+        background_color=None,
+        text_color=None,
+        disabled_text_color=None,
+        size=(None, None),
+        s=(None, None),
+        tearoff=False,
+        font=None,
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param menu_definition:           The Menu definition specified using lists (docs explain the format)
         :type menu_definition:            List[List[Tuple[str, List[str]]]
@@ -8639,8 +10813,17 @@ class Menu(Element):
         sz = size if size != (None, None) else s
         pad = pad if pad is not None else p
 
-        super().__init__(ELEM_TYPE_MENUBAR, background_color=self.BackgroundColor, text_color=self.TextColor, size=sz, pad=pad, key=key, visible=visible,
-                         font=font, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_MENUBAR,
+            background_color=self.BackgroundColor,
+            text_color=self.TextColor,
+            size=sz,
+            pad=pad,
+            key=key,
+            visible=visible,
+            font=font,
+            metadata=metadata,
+        )
         # super().__init__(ELEM_TYPE_MENUBAR, background_color=COLOR_SYSTEM_DEFAULT, text_color=COLOR_SYSTEM_DEFAULT, size=sz, pad=pad, key=key, visible=visible, font=None, metadata=metadata)
 
         self.Tearoff = tearoff
@@ -8658,8 +10841,6 @@ class Menu(Element):
         self.MenuItemChosen = item_chosen
         self.ParentForm.LastButtonClicked = item_chosen
         self.ParentForm.FormRemainedOpen = True
-        # if self.ParentForm.CurrentlyRunningMainloop:
-        #     self.ParentForm.TKroot.quit()  # kick the users out of the mainloop
         _exit_mainloop(self.ParentForm)
 
     def update(self, menu_definition=None, visible=None):
@@ -8686,12 +10867,14 @@ class Menu(Element):
 
         if menu_definition is not None:
             self.MenuDefinition = copy.deepcopy(menu_definition)
-            if self.TKMenu is None:     # if no menu exists, make one
-                self.TKMenu = tk.Menu(self.ParentForm.TKroot, tearoff=self.Tearoff, tearoffcommand=self._tearoff_menu_callback)  # create the menubar
+            if self.TKMenu is None:  # if no menu exists, make one
+                self.TKMenu = tk.Menu(
+                    self.ParentForm.TKroot, tearoff=self.Tearoff, tearoffcommand=self._tearoff_menu_callback
+                )  # create the menubar
             menubar = self.TKMenu
             # Delete all the menu items (assuming 10000 should be a high enough number to cover them all)
             menubar.delete(0, 10000)
-            self.Widget = self.TKMenu   # same the new menu so user can access to extend PySimpleGUI
+            self.Widget = self.TKMenu  # same the new menu so user can access to extend PySimpleGUI
             for menu_entry in self.MenuDefinition:
                 baritem = tk.Menu(menubar, tearoff=self.Tearoff, tearoffcommand=self._tearoff_menu_callback)
 
@@ -8710,10 +10893,12 @@ class Menu(Element):
                 # print(pos)
                 if pos != -1:
                     if pos == 0 or menu_entry[0][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                        menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + len(MENU_SHORTCUT_CHARACTER):]
+                        menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + len(MENU_SHORTCUT_CHARACTER) :]
                 if menu_entry[0][0] == MENU_DISABLED_CHARACTER:
-                    menubar.add_cascade(label=menu_entry[0][len(MENU_DISABLED_CHARACTER):], menu=baritem, underline=pos)
-                    menubar.entryconfig(menu_entry[0][len(MENU_DISABLED_CHARACTER):], state='disabled')
+                    menubar.add_cascade(
+                        label=menu_entry[0][len(MENU_DISABLED_CHARACTER) :], menu=baritem, underline=pos
+                    )
+                    menubar.entryconfig(menu_entry[0][len(MENU_DISABLED_CHARACTER) :], state='disabled')
                 else:
                     menubar.add_cascade(label=menu_entry[0], menu=baritem, underline=pos)
 
@@ -8738,15 +10923,61 @@ Menubar = Menu  # another name for Menu to make it clear it's the Menu Bar
 #                           Table                                        #
 # ---------------------------------------------------------------------- #
 class Table(Element):
-
-    def __init__(self, values, headings=None, visible_column_map=None, col_widths=None, cols_justification=None, def_col_width=10,
-                 auto_size_columns=True, max_col_width=20, select_mode=None, display_row_numbers=False, starting_row_number=0, num_rows=None,
-                 row_height=None, font=None, justification='right', text_color=None, background_color=None,
-                 alternating_row_color=None, selected_row_colors=(None, None), header_text_color=None, header_background_color=None, header_font=None, header_border_width=None, header_relief=None,
-                 row_colors=None, vertical_scroll_only=True, hide_vertical_scroll=False, border_width=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None,
-                 size=(None, None), s=(None, None), change_submits=False, enable_events=False, enable_click_events=False, right_click_selects=False, bind_return_key=False, pad=None, p=None,
-                 key=None, k=None, tooltip=None, right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        values,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        cols_justification=None,
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        display_row_numbers=False,
+        starting_row_number=0,
+        num_rows=None,
+        row_height=None,
+        font=None,
+        justification='right',
+        text_color=None,
+        background_color=None,
+        alternating_row_color=None,
+        selected_row_colors=(None, None),
+        header_text_color=None,
+        header_background_color=None,
+        header_font=None,
+        header_border_width=None,
+        header_relief=None,
+        row_colors=None,
+        vertical_scroll_only=True,
+        hide_vertical_scroll=False,
+        border_width=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+        size=(None, None),
+        s=(None, None),
+        change_submits=False,
+        enable_events=False,
+        enable_click_events=False,
+        right_click_selects=False,
+        bind_return_key=False,
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param values:                  Your table data represented as a 2-dimensions table... a list of rows, with each row representing a row in your table.
         :type values:                   List[List[str | int | float]]
@@ -8852,7 +11083,6 @@ class Table(Element):
         :type metadata:                 (Any)
         """
 
-
         self.Values = values
         self.ColumnHeadings = headings
         self.ColumnsToDisplay = visible_column_map
@@ -8863,8 +11093,16 @@ class Table(Element):
         self.AutoSizeColumns = auto_size_columns
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
-        self.HeaderTextColor = header_text_color if header_text_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
-        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
+        self.HeaderTextColor = (
+            header_text_color
+            if header_text_color is not None
+            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
+        )
+        self.HeaderBackgroundColor = (
+            header_background_color
+            if header_background_color is not None
+            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
+        )
         self.HeaderFont = header_font
         self.Justification = justification
         self.InitialState = None
@@ -8887,7 +11125,7 @@ class Table(Element):
         self.HeaderBorderWidth = header_border_width
         self.BorderWidth = border_width
         self.HeaderRelief = header_relief
-        self.table_ttk_style_name = None        # the ttk style name for the Table itself
+        self.table_ttk_style_name = None  # the ttk style name for the Table itself
         if selected_row_colors == (None, None):
             # selected_row_colors = DEFAULT_TABLE_AND_TREE_SELECTED_ROW_COLORS
             selected_row_colors = theme_button_color()
@@ -8908,12 +11146,30 @@ class Table(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_TABLE, text_color=text_color, background_color=background_color, font=font,
-                         size=sz, pad=pad, key=key, tooltip=tooltip, visible=visible, metadata=metadata,
-                         sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
+        super().__init__(
+            ELEM_TYPE_TABLE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            size=sz,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
         return
 
-    def update(self, values=None, num_rows=None, visible=None, select_rows=None, alternating_row_color=None, row_colors=None):
+    def update(
+        self, values=None, num_rows=None, visible=None, select_rows=None, alternating_row_color=None, row_colors=None
+    ):
         """
         Changes some of the settings for the Table Element. Must call `Window.Read` or `Window.Finalize` prior
 
@@ -9017,8 +11273,6 @@ class Table(Element):
             else:
                 self.ParentForm.LastButtonClicked = ''
             self.ParentForm.FormRemainedOpen = True
-            # if self.ParentForm.CurrentlyRunningMainloop:
-            #     self.ParentForm.TKroot.quit()
             _exit_mainloop(self.ParentForm)
 
     def _treeview_double_click(self, event):
@@ -9037,10 +11291,7 @@ class Table(Element):
             else:
                 self.ParentForm.LastButtonClicked = ''
             self.ParentForm.FormRemainedOpen = True
-            # if self.ParentForm.CurrentlyRunningMainloop:
-            #     self.ParentForm.TKroot.quit()
             _exit_mainloop(self.ParentForm)
-
 
     def _table_clicked(self, event):
         """
@@ -9058,20 +11309,28 @@ class Table(Element):
             if region == 'heading':
                 row = -1
             elif region == 'cell':
-                row = int(self.Widget.identify_row(event.y))-1
+                row = int(self.Widget.identify_row(event.y)) - 1
             elif region == 'separator':
                 row = None
             else:
                 row = None
             col_identified = self.Widget.identify_column(event.x)
-            if col_identified:      # Sometimes tkinter returns a value of '' which would cause an error if cast to an int
-                column = int(self.Widget.identify_column(event.x)[1:])-1-int(self.DisplayRowNumbers is True)
+            if col_identified:  # Sometimes tkinter returns a value of '' which would cause an error if cast to an int
+                column = int(self.Widget.identify_column(event.x)[1:]) - 1 - int(self.DisplayRowNumbers is True)
             else:
                 column = None
         except Exception as e:
-            warnings.warn('Error getting table click data for table with key= {}\nError: {}'.format(self.Key, e), UserWarning)
+            warnings.warn(
+                'Error getting table click data for table with key= {}\nError: {}'.format(self.Key, e), UserWarning
+            )
             if not SUPPRESS_ERROR_POPUPS:
-                _error_popup_with_traceback('Unable to complete operation getting the clicked event for table with key {}'.format(self.Key), _create_error_message(), e, 'Event data:', obj_to_string_single_obj(event))
+                _error_popup_with_traceback(
+                    'Unable to complete operation getting the clicked event for table with key {}'.format(self.Key),
+                    _create_error_message(),
+                    e,
+                    'Event data:',
+                    obj_to_string_single_obj(event),
+                )
             row = column = None
 
         self.last_clicked_position = (row, column)
@@ -9083,7 +11342,7 @@ class Table(Element):
         if self.right_click_selects and len(selections) <= 1:
             if (event.num == 3 and not running_mac()) or (event.num == 2 and running_mac()):
                 if row != -1 and row is not None:
-                    selections = [row+1]
+                    selections = [row + 1]
                     self.TKTreeview.selection_set(selections)
         # print(selections)
         self.SelectedRows = [int(x) - 1 for x in selections]
@@ -9095,8 +11354,6 @@ class Table(Element):
                 self.ParentForm.LastButtonClicked = ''
             self.ParentForm.FormRemainedOpen = True
             _exit_mainloop(self.ParentForm)
-
-
 
     def get(self):
         """
@@ -9119,9 +11376,6 @@ class Table(Element):
         """
         return self.last_clicked_position
 
-
-
-
     Update = update
     Get = get
 
@@ -9135,13 +11389,55 @@ class Tree(Element):
     to hold the user's data and pass to the element for display.
     """
 
-    def __init__(self, data=None, headings=None, visible_column_map=None, col_widths=None, col0_width=10, col0_heading='',
-                 def_col_width=10, auto_size_columns=True, max_col_width=20, select_mode=None, show_expanded=False,
-                 change_submits=False, enable_events=False, click_toggles_select=None, font=None, justification='right', text_color=None, border_width=None,
-                 background_color=None, selected_row_colors=(None, None), header_text_color=None, header_background_color=None, header_font=None, header_border_width=None, header_relief=None, num_rows=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None,
-                 row_height=None, vertical_scroll_only=True, hide_vertical_scroll=False, pad=None, p=None, key=None, k=None, tooltip=None,
-                 right_click_menu=None, expand_x=False, expand_y=False, visible=True, metadata=None):
+    def __init__(
+        self,
+        data=None,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        col0_width=10,
+        col0_heading='',
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        show_expanded=False,
+        change_submits=False,
+        enable_events=False,
+        click_toggles_select=None,
+        font=None,
+        justification='right',
+        text_color=None,
+        border_width=None,
+        background_color=None,
+        selected_row_colors=(None, None),
+        header_text_color=None,
+        header_background_color=None,
+        header_font=None,
+        header_border_width=None,
+        header_relief=None,
+        num_rows=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+        row_height=None,
+        vertical_scroll_only=True,
+        hide_vertical_scroll=False,
+        pad=None,
+        p=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        right_click_menu=None,
+        expand_x=False,
+        expand_y=False,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param data:                    The data represented using a PySimpleGUI provided TreeData class
         :type data:                     (TreeData)
@@ -9248,8 +11544,16 @@ class Tree(Element):
         self.AutoSizeColumns = auto_size_columns
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
-        self.HeaderTextColor = header_text_color if header_text_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
-        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
+        self.HeaderTextColor = (
+            header_text_color
+            if header_text_color is not None
+            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['TEXT_INPUT']
+        )
+        self.HeaderBackgroundColor = (
+            header_background_color
+            if header_background_color is not None
+            else LOOK_AND_FEEL_TABLE[CURRENT_LOOK_AND_FEEL]['INPUT']
+        )
         self.HeaderBorderWidth = header_border_width
         self.BorderWidth = border_width
         self.HeaderRelief = header_relief
@@ -9289,9 +11593,24 @@ class Tree(Element):
         self.expand_x = expand_x
         self.expand_y = expand_y
 
-        super().__init__(ELEM_TYPE_TREE, text_color=text_color, background_color=background_color, font=font, pad=pad, key=key, tooltip=tooltip,
-                         visible=visible, metadata=metadata,
-                         sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
+        super().__init__(
+            ELEM_TYPE_TREE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
         return
 
     def _treeview_selected(self, event):
@@ -9313,16 +11632,12 @@ class Tree(Element):
         self.SelectedRows = [self.IdToKey[x] for x in selections]
 
         if self.ChangeSubmits:
-            MyForm = self.ParentForm
             if self.Key is not None:
                 self.ParentForm.LastButtonClicked = self.Key
             else:
                 self.ParentForm.LastButtonClicked = ''
             self.ParentForm.FormRemainedOpen = True
-            # if self.ParentForm.CurrentlyRunningMainloop:
-            #     self.ParentForm.TKroot.quit()
             _exit_mainloop(self.ParentForm)
-
 
     def add_treeview_data(self, node):
         """
@@ -9344,15 +11659,28 @@ class Tree(Element):
                         photo = self.image_dict.get(node.icon)
 
                     node.photo = photo
-                    id = self.TKTreeview.insert(self.KeyToID[node.parent], 'end', iid=None, text=node.text,
-                                                values=node.values, open=self.ShowExpanded, image=node.photo)
+                    id = self.TKTreeview.insert(
+                        self.KeyToID[node.parent],
+                        'end',
+                        iid=None,
+                        text=node.text,
+                        values=node.values,
+                        open=self.ShowExpanded,
+                        image=node.photo,
+                    )
                     self.IdToKey[id] = node.key
                     self.KeyToID[node.key] = id
                 except:
                     self.photo = None
             else:
-                id = self.TKTreeview.insert(self.KeyToID[node.parent], 'end', iid=None, text=node.text,
-                                            values=node.values, open=self.ShowExpanded)
+                id = self.TKTreeview.insert(
+                    self.KeyToID[node.parent],
+                    'end',
+                    iid=None,
+                    text=node.text,
+                    values=node.values,
+                    open=self.ShowExpanded,
+                )
                 self.IdToKey[id] = node.key
                 self.KeyToID[node.key] = id
 
@@ -9537,8 +11865,9 @@ class TreeData(object):
         :type level:  (int)
         """
         return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text) + ' [ ' +  ', '.join([str(v) for v in node.values])  +' ]'] +
-            [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
+            [str(node.key) + ' : ' + str(node.text) + ' [ ' + ', '.join([str(v) for v in node.values]) + ' ]']
+            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
+        )
 
     Insert = insert
 
@@ -9602,10 +11931,12 @@ def Push(background_color=None):
     :type background_color:  (str)
     :return:                 (Text)
     """
-    return Text(font='_ 1', background_color=background_color, pad=(0,0), expand_x=True)
+    return Text(font='_ 1', background_color=background_color, pad=(0, 0), expand_x=True)
+
 
 P = Push
 Stretch = Push
+
 
 def VPush(background_color=None):
     """
@@ -9615,23 +11946,22 @@ def VPush(background_color=None):
     :type background_color:  (str)
     :return:                 (Text)
     """
-    return Text(font='_ 1', background_color=background_color, pad=(0,0), expand_y=True)
+    return Text(font='_ 1', background_color=background_color, pad=(0, 0), expand_y=True)
 
 
 VStretch = VPush
 VP = VPush
 
 
-
-
 # ------------------------------------------------------------------------- #
 #                       _TimerPeriodic CLASS                                #
 # ------------------------------------------------------------------------- #
 
+
 class _TimerPeriodic:
     id_counter = 1
     # Dictionary containing the active timers.  Format is {id : _TimerPeriodic object}
-    active_timers = {}         #type: dict[int:_TimerPeriodic]
+    active_timers = {}  # type: dict[int:_TimerPeriodic]
 
     def __init__(self, window, frequency_ms, key=EVENT_TIMER, repeating=True):
         """
@@ -9650,7 +11980,6 @@ class _TimerPeriodic:
         _TimerPeriodic.id_counter += 1
         self.start()
 
-
     @classmethod
     def stop_timer_with_id(cls, timer_id):
         """
@@ -9661,7 +11990,6 @@ class _TimerPeriodic:
         timer = cls.active_timers.get(timer_id, None)
         if timer is not None:
             timer.stop()
-
 
     @classmethod
     def stop_all_timers_for_window(cls, window):
@@ -9690,27 +12018,24 @@ class _TimerPeriodic:
 
         return timers
 
-
-
     def timer_thread(self):
         """
         The thread that sends events to the window.  Runs either once or in a loop until timer is stopped
         """
 
-        if not self.running:            # if timer has been cancelled, abort
+        if not self.running:  # if timer has been cancelled, abort
             del _TimerPeriodic.active_timers[self.id]
             return
         while True:
-            time.sleep(self.frequency_ms/1000)
-            if not self.running:        # if timer has been cancelled, abort
+            time.sleep(self.frequency_ms / 1000)
+            if not self.running:  # if timer has been cancelled, abort
                 del _TimerPeriodic.active_timers[self.id]
                 return
             self.window.write_event_value(self.key, self.id)
 
-            if not self.repeating:      # if timer does not repeat, then exit thread
+            if not self.repeating:  # if timer does not repeat, then exit thread
                 del _TimerPeriodic.active_timers[self.id]
                 return
-
 
     def start(self):
         """
@@ -9722,15 +12047,11 @@ class _TimerPeriodic:
         self.thread.start()
         _TimerPeriodic.active_timers[self.id] = self
 
-
     def stop(self):
         """
         Stops a timer
         """
         self.running = False
-
-
-
 
 
 # ------------------------------------------------------------------------- #
@@ -9740,6 +12061,7 @@ class Window:
     """
     Represents a single Window
     """
+
     NumOpenWindows = 0
     _user_defined_icon = None
     hidden_master_root = None  # type: tk.Tk
@@ -9758,30 +12080,79 @@ class Window:
     _floating_debug_window_build_needed = False
     _main_debug_window_build_needed = False
     # rereouted stdout info. List of tuples (window, element, previous destination)
-    _rerouted_stdout_stack = []             # type: List[Tuple[Window, Element]]
-    _rerouted_stderr_stack = []             # type: List[Tuple[Window, Element]]
+    _rerouted_stdout_stack = []  # type: List[Tuple[Window, Element]]
+    _rerouted_stderr_stack = []  # type: List[Tuple[Window, Element]]
     _original_stdout = None
     _original_stderr = None
     _watermark = None
     _watermark_temp_forced = False
     _watermark_user_text = ''
 
-    def __init__(self, title, layout=None, default_element_size=None,
-                 default_button_element_size=(None, None),
-                 auto_size_text=None, auto_size_buttons=None, location=(None, None), relative_location=(None, None), size=(None, None),
-                 element_padding=None, margins=(None, None), button_color=None, font=None,
-                 progress_bar_color=(None, None), background_color=None, border_depth=None, auto_close=False,
-                 auto_close_duration=DEFAULT_AUTOCLOSE_TIME, icon=None, force_toplevel=False,
-                 alpha_channel=None, return_keyboard_events=False, use_default_focus=True, text_justification=None,
-                 no_titlebar=False, grab_anywhere=False, grab_anywhere_using_control=True, keep_on_top=None, resizable=False, disable_close=False,
-                 disable_minimize=False, right_click_menu=None, transparent_color=None, debugger_enabled=True,
-                 right_click_menu_background_color=None, right_click_menu_text_color=None, right_click_menu_disabled_text_color=None, right_click_menu_selected_colors=(None, None),
-                 right_click_menu_font=None, right_click_menu_tearoff=False,
-                 finalize=False, element_justification='left', ttk_theme=None, use_ttk_buttons=None, modal=False, enable_close_attempted_event=False, enable_window_config_events=False,
-                 titlebar_background_color=None, titlebar_text_color=None, titlebar_font=None, titlebar_icon=None,
-                 use_custom_titlebar=None, scaling=None,
-                 sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None, watermark=None,
-                 metadata=None):
+    def __init__(
+        self,
+        title,
+        layout=None,
+        default_element_size=None,
+        default_button_element_size=(None, None),
+        auto_size_text=None,
+        auto_size_buttons=None,
+        location=(None, None),
+        relative_location=(None, None),
+        size=(None, None),
+        element_padding=None,
+        margins=(None, None),
+        button_color=None,
+        font=None,
+        progress_bar_color=(None, None),
+        background_color=None,
+        border_depth=None,
+        auto_close=False,
+        auto_close_duration=DEFAULT_AUTOCLOSE_TIME,
+        icon=None,
+        force_toplevel=False,
+        alpha_channel=None,
+        return_keyboard_events=False,
+        use_default_focus=True,
+        text_justification=None,
+        no_titlebar=False,
+        grab_anywhere=False,
+        grab_anywhere_using_control=True,
+        keep_on_top=None,
+        resizable=False,
+        disable_close=False,
+        disable_minimize=False,
+        right_click_menu=None,
+        transparent_color=None,
+        debugger_enabled=True,
+        right_click_menu_background_color=None,
+        right_click_menu_text_color=None,
+        right_click_menu_disabled_text_color=None,
+        right_click_menu_selected_colors=(None, None),
+        right_click_menu_font=None,
+        right_click_menu_tearoff=False,
+        finalize=False,
+        element_justification='left',
+        ttk_theme=None,
+        use_ttk_buttons=None,
+        modal=False,
+        enable_close_attempted_event=False,
+        enable_window_config_events=False,
+        titlebar_background_color=None,
+        titlebar_text_color=None,
+        titlebar_font=None,
+        titlebar_icon=None,
+        use_custom_titlebar=None,
+        scaling=None,
+        sbar_trough_color=None,
+        sbar_background_color=None,
+        sbar_arrow_color=None,
+        sbar_width=None,
+        sbar_arrow_width=None,
+        sbar_frame_color=None,
+        sbar_relief=None,
+        watermark=None,
+        metadata=None,
+    ):
         """
         :param title:                                The title that will be displayed in the Titlebar and on the Taskbar
         :type title:                                 (str)
@@ -9909,15 +12280,15 @@ class Window:
         :type metadata:                              (Any)
         """
 
-
         self._metadata = None  # type: Any
         self.AutoSizeText = auto_size_text if auto_size_text is not None else DEFAULT_AUTOSIZE_TEXT
         self.AutoSizeButtons = auto_size_buttons if auto_size_buttons is not None else DEFAULT_AUTOSIZE_BUTTONS
         self.Title = str(title)
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = default_element_size if default_element_size is not None else DEFAULT_ELEMENT_SIZE
-        self.DefaultButtonElementSize = default_button_element_size if default_button_element_size != (
-            None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
+        self.DefaultButtonElementSize = (
+            default_button_element_size if default_button_element_size != (None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
+        )
         if DEFAULT_WINDOW_LOCATION != (None, None) and location == (None, None):
             self.Location = DEFAULT_WINDOW_LOCATION
         else:
@@ -10000,8 +12371,12 @@ class Window:
         self.metadata = metadata
         self.TtkTheme = ttk_theme or DEFAULT_TTK_THEME
         self.UseTtkButtons = use_ttk_buttons if use_ttk_buttons is not None else USE_TTK_BUTTONS
-        self.user_bind_dict = {}  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
-        self.user_bind_event = None  # Used when user defines a tkinter binding using bind method - event data from tkinter
+        self.user_bind_dict = (
+            {}
+        )  # Used when user defines a tkinter binding using bind method - convert bind string to key modifier
+        self.user_bind_event = (
+            None  # Used when user defines a tkinter binding using bind method - event data from tkinter
+        )
         self.modal = modal
         self.thread_queue = None  # type: queue.Queue
         self.thread_lock = None  # type: threading.Lock
@@ -10015,14 +12390,26 @@ class Window:
         self.config_count = 0
         self.saw_00 = False
         self.maximized = False
-        self.right_click_menu_background_color = right_click_menu_background_color if right_click_menu_background_color is not None else theme_input_background_color()
-        self.right_click_menu_text_color = right_click_menu_text_color if right_click_menu_text_color is not None else theme_input_text_color()
-        self.right_click_menu_disabled_text_color = right_click_menu_disabled_text_color if right_click_menu_disabled_text_color is not None else COLOR_SYSTEM_DEFAULT
+        self.right_click_menu_background_color = (
+            right_click_menu_background_color
+            if right_click_menu_background_color is not None
+            else theme_input_background_color()
+        )
+        self.right_click_menu_text_color = (
+            right_click_menu_text_color if right_click_menu_text_color is not None else theme_input_text_color()
+        )
+        self.right_click_menu_disabled_text_color = (
+            right_click_menu_disabled_text_color
+            if right_click_menu_disabled_text_color is not None
+            else COLOR_SYSTEM_DEFAULT
+        )
         self.right_click_menu_font = right_click_menu_font if right_click_menu_font is not None else self.Font
         self.right_click_menu_tearoff = right_click_menu_tearoff
         self.auto_close_timer_needs_starting = False
         self.finalize_in_progress = False
-        self.close_destroys_window = not enable_close_attempted_event if enable_close_attempted_event is not None else None
+        self.close_destroys_window = (
+            not enable_close_attempted_event if enable_close_attempted_event is not None else None
+        )
         self.enable_window_config_events = enable_window_config_events
         self.override_custom_titlebar = False
         self.use_custom_titlebar = use_custom_titlebar or theme_use_custom_titlebar()
@@ -10030,8 +12417,9 @@ class Window:
         self.titlebar_text_color = titlebar_text_color
         self.titlebar_font = titlebar_font
         self.titlebar_icon = titlebar_icon
-        self.right_click_menu_selected_colors = _simplified_dual_color_to_tuple(right_click_menu_selected_colors,
-                                                                                (self.right_click_menu_background_color, self.right_click_menu_text_color))
+        self.right_click_menu_selected_colors = _simplified_dual_color_to_tuple(
+            right_click_menu_selected_colors, (self.right_click_menu_background_color, self.right_click_menu_text_color)
+        )
         self.TKRightClickMenu = None
         self._grab_anywhere_ignore_these_list = []
         self._grab_anywhere_include_these_list = []
@@ -10051,8 +12439,15 @@ class Window:
             Window._watermark = None
             Window._watermark_temp_forced = False
 
-
-        self.ttk_part_overrides = TTKPartOverrides(sbar_trough_color=sbar_trough_color, sbar_background_color=sbar_background_color, sbar_arrow_color=sbar_arrow_color, sbar_width=sbar_width, sbar_arrow_width=sbar_arrow_width, sbar_frame_color=sbar_frame_color, sbar_relief=sbar_relief)
+        self.ttk_part_overrides = TTKPartOverrides(
+            sbar_trough_color=sbar_trough_color,
+            sbar_background_color=sbar_background_color,
+            sbar_arrow_color=sbar_arrow_color,
+            sbar_width=sbar_width,
+            sbar_arrow_width=sbar_arrow_width,
+            sbar_frame_color=sbar_frame_color,
+            sbar_relief=sbar_relief,
+        )
 
         if no_titlebar is True:
             self.override_custom_titlebar = True
@@ -10066,10 +12461,11 @@ class Window:
                 self.Finalize()
 
         if CURRENT_LOOK_AND_FEEL == 'Default':
-            print('Window will be a boring gray. Try removing the theme call entirely\n',
-                  'You will get the default theme or the one set in global settings\n'
-                  "If you seriously want this gray window and no more nagging, add  theme('DefaultNoMoreNagging')  or theme('Gray Gray Gray') for completely gray/System Defaults")
-
+            print(
+                'Window will be a boring gray. Try removing the theme call entirely\n',
+                'You will get the default theme or the one set in global settings\n'
+                "If you seriously want this gray window and no more nagging, add  theme('DefaultNoMoreNagging')  or theme('Gray Gray Gray') for completely gray/System Defaults",
+            )
 
     @classmethod
     def _GetAContainerNumber(cls):
@@ -10149,35 +12545,42 @@ class Window:
             if isinstance(element, tuple) or isinstance(element, list):
                 self.add_row(*element)
                 continue
-                _error_popup_with_traceback('Error creating Window layout',
-                                            'Layout has a LIST instead of an ELEMENT',
-                                            'This sometimes means you have a badly placed ]',
-                                            'The offensive list is:',
-                                            element,
-                                            'This list will be stripped from your layout'
-                                            )
+                _error_popup_with_traceback(
+                    'Error creating Window layout',
+                    'Layout has a LIST instead of an ELEMENT',
+                    'This sometimes means you have a badly placed ]',
+                    'The offensive list is:',
+                    element,
+                    'This list will be stripped from your layout',
+                )
                 continue
             elif callable(element) and not isinstance(element, Element):
-                _error_popup_with_traceback('Error creating Window layout',
-                                            'Layout has a FUNCTION instead of an ELEMENT',
-                                            'This likely means you are missing () from your layout',
-                                            'The offensive list is:',
-                                            element,
-                                            'This item will be stripped from your layout')
+                _error_popup_with_traceback(
+                    'Error creating Window layout',
+                    'Layout has a FUNCTION instead of an ELEMENT',
+                    'This likely means you are missing () from your layout',
+                    'The offensive list is:',
+                    element,
+                    'This item will be stripped from your layout',
+                )
                 continue
             if element.ParentContainer is not None:
                 warnings.warn(
                     '*** YOU ARE ATTEMPTING TO REUSE AN ELEMENT IN YOUR LAYOUT! Once placed in a layout, an element cannot be used in another layout. ***',
-                    UserWarning)
-                _error_popup_with_traceback('Error detected in layout - Contains an element that has already been used.',
-                                            'You have attempted to reuse an element in your layout.',
-                                            "The layout specified has an element that's already been used.",
-                                            'You MUST start with a "clean", unused layout every time you create a window',
-                                            'The offensive Element = ',
-                                            element,
-                                            'and has a key = ', element.Key,
-                                            'This item will be stripped from your layout',
-                                            'Hint - try printing your layout and matching the IDs "print(layout)"')
+                    UserWarning,
+                )
+                _error_popup_with_traceback(
+                    'Error detected in layout - Contains an element that has already been used.',
+                    'You have attempted to reuse an element in your layout.',
+                    "The layout specified has an element that's already been used.",
+                    'You MUST start with a "clean", unused layout every time you create a window',
+                    'The offensive Element = ',
+                    element,
+                    'and has a key = ',
+                    element.Key,
+                    'This item will be stripped from your layout',
+                    'Hint - try printing your layout and matching the IDs "print(layout)"',
+                )
                 continue
             element.Position = (CurrentRowNumber, i)
             element.ParentContainer = self
@@ -10203,20 +12606,19 @@ class Window:
             try:
                 iter(row)
             except TypeError:
-                _error_popup_with_traceback('Error Creating Window Layout', 'Error creating Window layout',
-                           'Your row is not an iterable (e.g. a list)',
-                           'Instead of a list, the type found was {}'.format(type(row)),
-                           'The offensive row = ',
-                           row,
-                           'This item will be stripped from your layout')
+                _error_popup_with_traceback(
+                    'Error Creating Window Layout',
+                    'Error creating Window layout',
+                    'Your row is not an iterable (e.g. a list)',
+                    'Instead of a list, the type found was {}'.format(type(row)),
+                    'The offensive row = ',
+                    row,
+                    'This item will be stripped from your layout',
+                )
                 continue
             self.add_row(*row)
-        # if _optional_window_data(self) is not None:
-        #     self.add_row(_optional_window_data(self))
         if Window._watermark is not None:
             self.add_row(Window._watermark(self))
-
-
 
     def layout(self, rows):
         """
@@ -10242,8 +12644,17 @@ class Window:
             else:
                 icon = None
 
-            new_rows = [[Titlebar(title=self.Title, icon=icon, text_color=self.titlebar_text_color, background_color=self.titlebar_background_color,
-                                  font=self.titlebar_font)]] + rows
+            new_rows = [
+                [
+                    Titlebar(
+                        title=self.Title,
+                        icon=icon,
+                        text_color=self.titlebar_text_color,
+                        background_color=self.titlebar_background_color,
+                        font=self.titlebar_font,
+                    )
+                ]
+            ] + rows
         else:
             new_rows = rows
         self.add_rows(new_rows)
@@ -10289,14 +12700,15 @@ class Window:
         :param non_blocking: if True the Read call will not block
         :type non_blocking:  (bool)
         """
-        _error_popup_with_traceback('LayoutAndRead Depricated', 'Wow!  You have been using PySimpleGUI for a very long time.',
-                                                                'The Window.LayoutAndRead call is no longer supported')
+        _error_popup_with_traceback(
+            'LayoutAndRead Depricated',
+            'Wow!  You have been using PySimpleGUI for a very long time.',
+            'The Window.LayoutAndRead call is no longer supported',
+        )
 
         raise DeprecationWarning(
-            'LayoutAndRead is no longer supported... change your call window.Layout(layout).Read()\nor window(title, layout).Read()')
-        # self.AddRows(rows)
-        # self._Show(non_blocking=non_blocking)
-        # return self.ReturnValues
+            'LayoutAndRead is no longer supported... change your call window.Layout(layout).Read()\nor window(title, layout).Read()'
+        )
 
     def LayoutAndShow(self, rows):
         """
@@ -10465,16 +12877,27 @@ class Window:
         else:
             cur_month, cur_day, cur_year = elem.calendar_default_date_M_D_Y
 
-        date_chosen = popup_get_date(start_mon=cur_month, start_day=cur_day, start_year=cur_year, close_when_chosen=elem.calendar_close_when_chosen,
-                                     no_titlebar=elem.calendar_no_titlebar, begin_at_sunday_plus=elem.calendar_begin_at_sunday_plus,
-                                     locale=elem.calendar_locale, location=elem.calendar_location, month_names=elem.calendar_month_names,
-                                     day_abbreviations=elem.calendar_day_abbreviations, title=elem.calendar_title)
+        date_chosen = popup_get_date(
+            start_mon=cur_month,
+            start_day=cur_day,
+            start_year=cur_year,
+            close_when_chosen=elem.calendar_close_when_chosen,
+            no_titlebar=elem.calendar_no_titlebar,
+            begin_at_sunday_plus=elem.calendar_begin_at_sunday_plus,
+            locale=elem.calendar_locale,
+            location=elem.calendar_location,
+            month_names=elem.calendar_month_names,
+            day_abbreviations=elem.calendar_day_abbreviations,
+            title=elem.calendar_title,
+        )
         if date_chosen is not None:
             month, day, year = date_chosen
             now = datetime.datetime.now()
             hour, minute, second = now.hour, now.minute, now.second
             try:
-                date_string = calendar.datetime.datetime(year, month, day, hour, minute, second).strftime(elem.calendar_format)
+                date_string = calendar.datetime.datetime(year, month, day, hour, minute, second).strftime(
+                    elem.calendar_format
+                )
             except Exception as e:
                 print('Bad format string in calendar chooser button', e)
                 date_string = 'Bad format string'
@@ -10488,7 +12911,7 @@ class Window:
             elem.TKStringVar.set(date_string)
             if should_submit_window:
                 self.LastButtonClicked = target_element.Key
-                results = _BuildResults(self, False, self)
+                _BuildResults(self, False, self)
         else:
             should_submit_window = False
         return should_submit_window
@@ -10527,14 +12950,19 @@ class Window:
             if timeout is None or timeout > 3000:
                 timeout = 200
 
-
         while True:
             Window._root_running_mainloop = self.TKroot
             results = self._read(timeout=timeout, timeout_key=timeout_key)
             if results is not None:
                 if results[0] == DEFAULT_WINDOW_SNAPSHOT_KEY:
                     self.save_window_screenshot_to_disk()
-                    popup_quick_message('Saved window screenshot to disk', background_color='#1c1e23', text_color='white', keep_on_top=True, font='_ 30')
+                    popup_quick_message(
+                        'Saved window screenshot to disk',
+                        background_color='#1c1e23',
+                        text_color='white',
+                        keep_on_top=True,
+                        font='_ 30',
+                    )
                     continue
             # Post processing for Calendar Chooser Button
             try:
@@ -10544,7 +12972,6 @@ class Window:
                 if elem.Type == ELEM_TYPE_BUTTON:
                     if elem.BType == BUTTON_TYPE_CALENDAR_CHOOSER:
                         if self._calendar_chooser_button_clicked(elem):  # returns True if should break out
-                            # results[0] = self.LastButtonClicked
                             results = self.ReturnValues
                             break
                         else:
@@ -10552,7 +12979,6 @@ class Window:
                 break
             except:
                 break  # wasn't a calendar button for sure
-
 
         if close:
             self.close()
@@ -10598,7 +13024,11 @@ class Window:
         if self.TKrootDestroyed:
             self.read_closed_window_count += 1
             if self.read_closed_window_count > 100:
-                popup_error_with_traceback('Trying to read a closed window', 'You have tried 100 times to read a closed window.', 'You need to add a check for event == WIN_CLOSED',)
+                popup_error_with_traceback(
+                    'Trying to read a closed window',
+                    'You have tried 100 times to read a closed window.',
+                    'You need to add a check for event == WIN_CLOSED',
+                )
             return None, None
         if not self.Shown:
             self._Show()
@@ -10620,28 +13050,23 @@ class Window:
                 # clear the realtime flag if the element is not a button element (for example a graph element that is dragging)
                 if self.AllKeysDict.get(self.LastButtonClicked, None):
                     if self.AllKeysDict.get(self.LastButtonClicked).Type != ELEM_TYPE_BUTTON:
-                        self.LastButtonClickedWasRealtime = False  # stops from generating events until something changes
+                        self.LastButtonClickedWasRealtime = (
+                            False  # stops from generating events until something changes
+                        )
                 else:  # it is possible for the key to not be in the dicitonary because it has a modifier. If so, then clear the realtime button flag
                     self.LastButtonClickedWasRealtime = False  # stops from generating events until something changes
 
                 try:
-                    rc = self.TKroot.update()
+                    self.TKroot.update()
                 except:
                     self.TKrootDestroyed = True
                     Window._DecrementOpenCount()
-                    # _my_windows.Decrement()
-                    # print('ROOT Destroyed')
                 results = _BuildResults(self, False, self)
-                if results[0] != None and results[0] != timeout_key:
+                if results[0] is not None and results[0] != timeout_key:
                     return results
                 else:
                     pass
-
-                # else:
-                #     print("** REALTIME PROBLEM FOUND **", results)
-
             if self.RootNeedsDestroying:
-                # print('*** DESTROYING really late***')
                 try:
                     self.TKroot.destroy()
                 except:
@@ -10651,12 +13076,10 @@ class Window:
                 return None, None
 
             # normal read blocking code....
-            if timeout != None:
+            if timeout is not None:
                 self.TimerCancelled = False
                 self.TKAfterID = self.TKroot.after(timeout, self._TimeoutAlarmCallback)
             self.CurrentlyRunningMainloop = True
-            # self.TKroot.protocol("WM_DESTROY_WINDOW", self._OnClosingCallback)
-            # self.TKroot.protocol("WM_DELETE_WINDOW", self._OnClosingCallback)
             Window._window_running_mainloop = self
             try:
                 Window._root_running_mainloop.mainloop()
@@ -10686,7 +13109,6 @@ class Window:
             # if form was closed with X
             if self.LastButtonClicked is None and self.LastKeyboardEvent is None and self.ReturnValues[0] is None:
                 Window._DecrementOpenCount()
-                # _my_windows.Decrement()
         # Determine return values
         if self.LastKeyboardEvent is not None or self.LastButtonClicked is not None:
             results = _BuildResults(self, False, self)
@@ -10697,11 +13119,13 @@ class Window:
             if self._queued_thread_event_available():
                 self.ReturnValues = results = _BuildResults(self, False, self)
                 return results
-            if not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[
-                0] is None:  # Special Qt case because returning for no reason so fake timeout
+            if (
+                not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None
+            ):  # Special Qt case because returning for no reason so fake timeout
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
-            elif not self.XFound and self.ReturnValues[0] is None:  # Return a timeout event... can happen when autoclose used on another window
-                # print("*** Faking timeout ***")
+            elif (
+                not self.XFound and self.ReturnValues[0] is None
+            ):  # Return a timeout event... can happen when autoclose used on another window
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
             return self.ReturnValues
 
@@ -10723,18 +13147,13 @@ class Window:
         if not self.Shown:
             self._Show(non_blocking=True)
         try:
-            rc = self.TKroot.update()
+            self.TKroot.update()
         except:
             self.TKrootDestroyed = True
             Window._DecrementOpenCount()
-            # _my_windows.Decrement()
-            # print("read failed")
-            # return None, None
         if self.RootNeedsDestroying:
-            # print('*** DESTROYING LATE ***', self.ReturnValues)
             self.TKroot.destroy()
             Window._DecrementOpenCount()
-            # _my_windows.Decrement()
             self.Values = None
             self.LastButtonClicked = None
             return None, None
@@ -10769,13 +13188,11 @@ class Window:
         if not self.Shown:
             self._Show(non_blocking=True)
         try:
-            rc = self.TKroot.update()
+            self.TKroot.update()
         except:
             self.TKrootDestroyed = True
             Window._DecrementOpenCount()
             print('** Finalize failed **')
-            # _my_windows.Decrement()
-            # return None, None
         return self
 
     def refresh(self):
@@ -10792,7 +13209,7 @@ class Window:
         if self.TKrootDestroyed:
             return self
         try:
-            rc = self.TKroot.update()
+            self.TKroot.update()
         except:
             pass
         return self
@@ -10837,9 +13254,13 @@ class Window:
         :rtype:                 Element | Error Element | None
         """
 
-        warnings.warn('Use of FindElement is not recommended.\nEither switch to the recommended window[key] format\nor the PEP8 compliant find_element',
-                      UserWarning)
-        print('** Warning - FindElement should not be used to look up elements. window[key] or window.find_element are recommended. **')
+        warnings.warn(
+            'Use of FindElement is not recommended.\nEither switch to the recommended window[key] format\nor the PEP8 compliant find_element',
+            UserWarning,
+        )
+        print(
+            '** Warning - FindElement should not be used to look up elements. window[key] or window.find_element are recommended. **'
+        )
 
         return self.find_element(key, silent_on_error=silent_on_error)
 
@@ -10891,8 +13312,15 @@ class Window:
             key_error = True
             closest_key = self._find_closest_key(key)
             if not silent_on_error:
-                print('** Error looking up your element using the key: ', key, 'The closest matching key: ', closest_key)
-                _error_popup_with_traceback('Key Error', 'Problem finding your key ' + str(key), 'Closest match = ' + str(closest_key), emoji=EMOJI_BASE64_KEY)
+                print(
+                    '** Error looking up your element using the key: ', key, 'The closest matching key: ', closest_key
+                )
+                _error_popup_with_traceback(
+                    'Key Error',
+                    'Problem finding your key ' + str(key),
+                    'Closest match = ' + str(closest_key),
+                    emoji=EMOJI_BASE64_KEY,
+                )
                 element = ErrorElement(key=key)
             else:
                 element = None
@@ -10918,7 +13346,6 @@ class Window:
         element = _FindElementWithFocusInSubForm(self)
         return element
 
-
     def widget_to_element(self, widget):
         """
         Returns the element that matches a supplied tkinter widget.
@@ -10934,7 +13361,6 @@ class Window:
             if element.Widget == widget:
                 return element
         return None
-
 
     def _BuildKeyDict(self):
         """
@@ -10975,25 +13401,47 @@ class Window:
                         element.Key = element.ButtonText
                     elif element.Type == ELEM_TYPE_TAB:
                         element.Key = element.Title
-                    if element.Type in (ELEM_TYPE_MENUBAR, ELEM_TYPE_BUTTONMENU,
-                                        ELEM_TYPE_INPUT_SLIDER, ELEM_TYPE_GRAPH, ELEM_TYPE_IMAGE,
-                                        ELEM_TYPE_INPUT_CHECKBOX, ELEM_TYPE_INPUT_LISTBOX, ELEM_TYPE_INPUT_COMBO,
-                                        ELEM_TYPE_INPUT_MULTILINE, ELEM_TYPE_INPUT_OPTION_MENU, ELEM_TYPE_INPUT_SPIN,
-                                        ELEM_TYPE_INPUT_RADIO, ELEM_TYPE_INPUT_TEXT, ELEM_TYPE_PROGRESS_BAR,
-                                        ELEM_TYPE_TABLE, ELEM_TYPE_TREE,
-                                        ELEM_TYPE_TAB_GROUP, ELEM_TYPE_SEPARATOR):
+                    if element.Type in (
+                        ELEM_TYPE_MENUBAR,
+                        ELEM_TYPE_BUTTONMENU,
+                        ELEM_TYPE_INPUT_SLIDER,
+                        ELEM_TYPE_GRAPH,
+                        ELEM_TYPE_IMAGE,
+                        ELEM_TYPE_INPUT_CHECKBOX,
+                        ELEM_TYPE_INPUT_LISTBOX,
+                        ELEM_TYPE_INPUT_COMBO,
+                        ELEM_TYPE_INPUT_MULTILINE,
+                        ELEM_TYPE_INPUT_OPTION_MENU,
+                        ELEM_TYPE_INPUT_SPIN,
+                        ELEM_TYPE_INPUT_RADIO,
+                        ELEM_TYPE_INPUT_TEXT,
+                        ELEM_TYPE_PROGRESS_BAR,
+                        ELEM_TYPE_TABLE,
+                        ELEM_TYPE_TREE,
+                        ELEM_TYPE_TAB_GROUP,
+                        ELEM_TYPE_SEPARATOR,
+                    ):
                         element.Key = top_window.DictionaryKeyCounter
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        if element.Type == ELEM_TYPE_BUTTON and WARN_DUPLICATE_BUTTON_KEY_ERRORS:  # for Buttons see if should complain
-                            warnings.warn('*** Duplicate key found in your layout {} ***'.format(element.Key), UserWarning)
-                            warnings.warn('*** Replaced new key with {} ***'.format(str(element.Key) + str(self.UniqueKeyCounter)))
+                        if (
+                            element.Type == ELEM_TYPE_BUTTON and WARN_DUPLICATE_BUTTON_KEY_ERRORS
+                        ):  # for Buttons see if should complain
+                            warnings.warn(
+                                '*** Duplicate key found in your layout {} ***'.format(element.Key), UserWarning
+                            )
+                            warnings.warn(
+                                '*** Replaced new key with {} ***'.format(str(element.Key) + str(self.UniqueKeyCounter))
+                            )
                             if not SUPPRESS_ERROR_POPUPS:
-                                _error_popup_with_traceback('Duplicate key found in your layout', 'Dupliate key: {}'.format(element.Key),
-                                                            'Is being replaced with: {}'.format(str(element.Key) + str(self.UniqueKeyCounter)),
-                                                            'The line of code above shows you which layout, but does not tell you exactly where the element was defined',
-                                                            'The element type is {}'.format(element.Type))
+                                _error_popup_with_traceback(
+                                    'Duplicate key found in your layout',
+                                    'Dupliate key: {}'.format(element.Key),
+                                    'Is being replaced with: {}'.format(str(element.Key) + str(self.UniqueKeyCounter)),
+                                    'The line of code above shows you which layout, but does not tell you exactly where the element was defined',
+                                    'The element type is {}'.format(element.Type),
+                                )
                         element.Key = str(element.Key) + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
                     key_dict[element.Key] = element
@@ -11034,7 +13482,13 @@ class Window:
         for row_num, row in enumerate(window.Rows):
             for col_num, element in enumerate(row):
                 elem_list.append(element)
-                if element.Type in (ELEM_TYPE_COLUMN, ELEM_TYPE_FRAME, ELEM_TYPE_TAB_GROUP, ELEM_TYPE_PANE, ELEM_TYPE_TAB):
+                if element.Type in (
+                    ELEM_TYPE_COLUMN,
+                    ELEM_TYPE_FRAME,
+                    ELEM_TYPE_TAB_GROUP,
+                    ELEM_TYPE_PANE,
+                    ELEM_TYPE_TAB,
+                ):
                     elem_list = self._build_element_list_for_form(top_window, element, elem_list)
         return elem_list
 
@@ -11101,7 +13555,6 @@ class Window:
         except:
             pass
 
-
     def move_to_center(self):
         """
         Recenter your window after it's been moved or the size changed.
@@ -11112,10 +13565,8 @@ class Window:
             return
         screen_width, screen_height = self.get_screen_dimensions()
         win_width, win_height = self.size
-        x, y = (screen_width - win_width)//2, (screen_height - win_height)//2
+        x, y = (screen_width - win_width) // 2, (screen_height - win_height) // 2
         self.move(x, y)
-
-
 
     def minimize(self):
         """
@@ -11128,7 +13579,6 @@ class Window:
         else:
             self.TKroot.iconify()
         self.maximized = False
-
 
     def maximize(self):
         """
@@ -11143,8 +13593,6 @@ class Window:
             self.TKroot.state('zoomed')
         else:
             self.TKroot.attributes('-fullscreen', True)
-        # this method removes the titlebar too
-        # self.TKroot.attributes('-fullscreen', True)
         self.maximized = True
 
     def normal(self):
@@ -11165,7 +13613,6 @@ class Window:
                     self.TKroot.attributes('-fullscreen', False)
             self.maximized = False
 
-
     def _StartMoveUsingControlKey(self, event):
         """
         Used by "Grab Anywhere" style windows. This function is bound to mouse-down. It marks the beginning of a drag.
@@ -11175,16 +13622,16 @@ class Window:
         self._start_move_save_offset(event)
         return
 
-
     def _StartMoveGrabAnywhere(self, event):
-
-
         """
         Used by "Grab Anywhere" style windows. This function is bound to mouse-down. It marks the beginning of a drag.
         :param event: event information passed in by tkinter. Contains x,y position of mouse
         :type event:  (event)
         """
-        if (isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS) or event.widget in self._grab_anywhere_ignore_these_list) and event.widget not in self._grab_anywhere_include_these_list:
+        if (
+            isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS)
+            or event.widget in self._grab_anywhere_ignore_these_list
+        ) and event.widget not in self._grab_anywhere_include_these_list:
             # print('Found widget to ignore in grab anywhere...')
             return
         self._start_move_save_offset(event)
@@ -11206,7 +13653,7 @@ class Window:
         self._mousex = event.x + event.widget.winfo_rootx()
         self._mousey = event.y + event.widget.winfo_rooty()
         geometry = self.TKroot.geometry()
-        location = geometry[geometry.find('+') + 1:].split('+')
+        location = geometry[geometry.find('+') + 1 :].split('+')
         self._startx = int(location[0])
         self._starty = int(location[1])
         self._mouse_offset_x = self._mousex - self._startx
@@ -11218,35 +13665,33 @@ class Window:
                 if win == self:
                     continue
                 geometry = win.TKroot.geometry()
-                location = geometry[geometry.find('+') + 1:].split('+')
+                location = geometry[geometry.find('+') + 1 :].split('+')
                 _startx = int(location[0])
                 _starty = int(location[1])
                 win._mouse_offset_x = event.x_root - _startx
                 win._mouse_offset_y = event.y_root - _starty
 
-
     def _OnMotionUsingControlKey(self, event):
         self._OnMotion(event)
 
-
     def _OnMotionGrabAnywhere(self, event):
-
         """
         Used by "Grab Anywhere" style windows. This function is bound to mouse motion. It actually moves the window
         :param event: event information passed in by tkinter. Contains x,y position of mouse
         :type event:  (event)
         """
-        if (isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS) or event.widget in self._grab_anywhere_ignore_these_list) and event.widget not in self._grab_anywhere_include_these_list:
+        if (
+            isinstance(event.widget, GRAB_ANYWHERE_IGNORE_THESE_WIDGETS)
+            or event.widget in self._grab_anywhere_ignore_these_list
+        ) and event.widget not in self._grab_anywhere_include_these_list:
             # print('Found widget to ignore in grab anywhere...')
             return
 
         self._OnMotion(event)
 
-
     def _OnMotion(self, event):
 
         self.TKroot.geometry(f'+{event.x_root-self._mouse_offset_x}+{event.y_root-self._mouse_offset_y}')
-        # print(f"+{event.x_root}+{event.y_root}")
         # ------ Move All Windows code ------
         try:
             if Window._move_all_windows:
@@ -11272,7 +13717,6 @@ class Window:
         self.user_bind_event = event
         _exit_mainloop(self)
 
-
     def _move_callback(self, event):
         """
         Called when a control + arrow key is pressed.
@@ -11283,15 +13727,15 @@ class Window:
         """
         if not self._is_window_created('Tried to move window using arrow keys'):
             return
-        x,y = self.current_location()
+        x, y = self.current_location()
         if event.keysym == 'Up':
-            self.move(x, y-1)
+            self.move(x, y - 1)
         elif event.keysym == 'Down':
-            self.move(x, y+1)
+            self.move(x, y + 1)
         elif event.keysym == 'Left':
-            self.move(x-1, y)
+            self.move(x - 1, y)
         elif event.keysym == 'Right':
-            self.move(x+1, y)
+            self.move(x + 1, y)
 
     """
     def _config_callback(self, event):
@@ -11368,8 +13812,6 @@ class Window:
         self.LastButtonClicked = None
         self.FormRemainedOpen = True
         self.LastKeyboardEvent = 'MouseWheel:Down' if event.delta < 0 or event.num == 5 else 'MouseWheel:Up'
-        # if not self.NonBlocking:
-        #     _BuildResults(self, False, self)
         _exit_mainloop(self)
 
     def _Close(self, without_event=False):
@@ -11423,21 +13865,11 @@ class Window:
             Window._DecrementOpenCount()
         except:
             pass
-        # if down to 1 window, try and destroy the hidden window, if there is one
-        # if Window.NumOpenWindows == 1:
-        #     try:
-        #         Window.hidden_master_root.destroy()
-        #         Window.NumOpenWindows = 0  # if no hidden window, then this won't execute
-        #     except:
-        #         pass
         self.TKrootDestroyed = True
 
         # Free up anything that was held in the layout and the root variables
         self.Rows = None
         self.TKroot = None
-
-
-
 
     def is_closed(self, quick_check=None):
         """
@@ -11458,19 +13890,16 @@ class Window:
 
         # see if can do an update... if not, then it's been destroyed
         try:
-            rc = self.TKroot.update()
+            self.TKroot.update()
         except:
             return True
         return False
-
 
     # IT FINALLY WORKED! 29-Oct-2018 was the first time this damned thing got called
     def _OnClosingCallback(self):
         """
         Internally used method ONLY. Not sure callable.  tkinter calls this when the window is closed by clicking X
         """
-        # global _my_windows
-        # print('Got closing callback', self.DisableClose)
         if self.DisableClose:
             return
         if self.CurrentlyRunningMainloop:  # quit if this is the current mainloop, otherwise don't quit!
@@ -11623,7 +14052,6 @@ class Window:
         except:
             pass
 
-
     def keep_on_top_set(self):
         """
         Sets keep_on_top after a window has been created.  Effect is the same
@@ -11639,7 +14067,6 @@ class Window:
         except Exception as e:
             warnings.warn('Problem in Window.keep_on_top_set trying to set wm_attributes topmost' + str(e), UserWarning)
 
-
     def keep_on_top_clear(self):
         """
         Clears keep_on_top after a window has been created.  Effect is the same
@@ -11651,9 +14078,9 @@ class Window:
         try:
             self.TKroot.wm_attributes('-topmost', 0)
         except Exception as e:
-            warnings.warn('Problem in Window.keep_on_top_clear trying to clear wm_attributes topmost' + str(e), UserWarning)
-
-
+            warnings.warn(
+                'Problem in Window.keep_on_top_clear trying to clear wm_attributes topmost' + str(e), UserWarning
+            )
 
     def current_location(self, more_accurate=False, without_titlebar=False):
         """
@@ -11673,7 +14100,6 @@ class Window:
         :rtype:                  Tuple[(int | None), (int | None)]
         """
 
-
         if not self._is_window_created('tried Window.current_location'):
             return (None, None)
         try:
@@ -11681,15 +14107,14 @@ class Window:
                 x, y = self.TKroot.winfo_rootx(), self.TKroot.winfo_rooty()
             elif more_accurate:
                 geometry = self.TKroot.geometry()
-                location = geometry[geometry.find('+') + 1:].split('+')
+                location = geometry[geometry.find('+') + 1 :].split('+')
                 x, y = int(location[0]), int(location[1])
             else:
-                x, y =  int(self.TKroot.winfo_x()), int(self.TKroot.winfo_y())
+                x, y = int(self.TKroot.winfo_x()), int(self.TKroot.winfo_y())
         except Exception as e:
             warnings.warn('Error in Window.current_location. Trouble getting x,y location\n' + str(e), UserWarning)
             x, y = (None, None)
-        return (x,y)
-
+        return (x, y)
 
     def current_size_accurate(self):
         """
@@ -11707,9 +14132,15 @@ class Window:
             window_size = geometry_tuple[0].split('x')
             x, y = int(window_size[0]), int(window_size[1])
         except Exception as e:
-            warnings.warn('Error in Window.current_size_accurate. Trouble getting x,y size\n{} {}'.format(geometry, geometry_tuple) + str(e), UserWarning)
+            warnings.warn(
+                'Error in Window.current_size_accurate. Trouble getting x,y size\n{} {}'.format(
+                    geometry, geometry_tuple
+                )
+                + str(e),
+                UserWarning,
+            )
             x, y = (None, None)
-        return (x,y)
+        return (x, y)
 
     @property
     def size(self):
@@ -11739,7 +14170,6 @@ class Window:
         except:
             pass
 
-
     def set_size(self, size):
         """
         Changes the size of the window, if possible. You can also use the Window.size prooerty
@@ -11756,8 +14186,6 @@ class Window:
         except:
             pass
 
-
-
     def set_min_size(self, size):
         """
         Changes the minimum size of the window. Note Window must be read or finalized first.
@@ -11769,7 +14197,6 @@ class Window:
             return
         self.TKroot.minsize(size[0], size[1])
         self.TKroot.update_idletasks()
-
 
     def set_resizable(self, x_axis_enable, y_axis_enable):
         """
@@ -11820,7 +14247,7 @@ class Window:
         :rtype:     (int, int)
         """
         if not self._is_window_created('tried Window.mouse_location'):
-            return (0,0)
+            return (0, 0)
 
         return (self.TKroot.winfo_pointerx(), self.TKroot.winfo_pointery())
 
@@ -11865,11 +14292,8 @@ class Window:
         else:
             self.LastButtonClicked = bind_string
         self.FormRemainedOpen = True
-        # if self.CurrentlyRunningMainloop:
-        #     self.TKroot.quit()
         _exit_mainloop(self)
         return 'break' if propagate is not True else None
-
 
     def bind(self, bind_string, key, propagate=True):
         """
@@ -11886,12 +14310,11 @@ class Window:
             return
         try:
             self.TKroot.bind(bind_string, lambda evt: self._user_bind_callback(bind_string, evt, propagate))
-        except Exception as e:
+        except Exception:
             self.TKroot.unbind_all(bind_string)
             return
             # _error_popup_with_traceback('Window.bind error', e)
         self.user_bind_dict[bind_string] = key
-
 
     def unbind(self, bind_string):
         """
@@ -11905,8 +14328,6 @@ class Window:
         if not self._is_window_created('tried Window.unbind'):
             return
         self.TKroot.unbind(bind_string)
-
-
 
     def _callback_main_debugger_window_create_keystroke(self, event):
         """
@@ -11964,7 +14385,7 @@ class Window:
         if not self._is_window_created('tried Window.set_title'):
             return
         if self._has_custom_titlebar:
-            try:    # just in case something goes badly, don't crash
+            try:  # just in case something goes badly, don't crash
                 self.find_element(TITLEBAR_TEXT_KEY).update(title)
             except:
                 pass
@@ -11986,7 +14407,7 @@ class Window:
 
         # if modal windows have been disabled globally
         if not DEFAULT_MODAL_WINDOWS_ENABLED and not DEFAULT_MODAL_WINDOWS_FORCED:
-        # if not DEFAULT_MODAL_WINDOWS_ENABLED:
+            # if not DEFAULT_MODAL_WINDOWS_ENABLED:
             return
 
         try:
@@ -12053,16 +14474,6 @@ class Window:
         :type event:
 
         """
-        # print('Thread callback info', threading.current_thread())
-        # print(event)
-        # trace_details = traceback.format_stack()
-        # print(''.join(trace_details))
-        # self.thread_lock.acquire()
-        # if self.thread_timer:
-        # self.TKroot.after_cancel(id=self.thread_timer)
-        # self.thread_timer = None
-        # self.thread_lock.release()
-
         if self._queued_thread_event_available():
             self.FormRemainedOpen = True
             _exit_mainloop(self)
@@ -12100,15 +14511,6 @@ class Window:
         self.TKroot.tk.willdispatch()  # brilliant bit of code provided by Giuliano who I owe a million thank yous!
         self.thread_strvar.set('new item')
 
-        # self.thread_queue.put(item=(key, value))
-        # self.thread_strvar.set('new item')
-        # March 28 2021 - finally found a solution!  It needs a little more work and a lock
-        # if no timer is running, then one should be started
-        # if self.thread_timer is None:
-        #     print('Starting a timer')
-        #     self.thread_timer = self.TKroot.after(1, self._window_tkvar_changed_callback)
-        # self.thread_lock.release()
-
     def _queued_thread_event_read(self):
         if self.thread_queue is None:
             return None
@@ -12130,8 +14532,6 @@ class Window:
             self.thread_timer = None
         # self.thread_lock.release()
         return qsize != 0
-
-
 
     def _RightClickMenuCallback(self, event):
         """
@@ -12155,7 +14555,6 @@ class Window:
         self.TKRightClickMenu.tk_popup(event.x_root, event.y_root, 0)
         self.TKRightClickMenu.grab_release()
 
-
     def save_window_screenshot_to_disk(self, filename=None):
         """
         Saves an image of the PySimpleGUI window provided into the filename provided
@@ -12171,6 +14570,7 @@ class Window:
                 import PIL as PIL
                 from PIL import ImageGrab
                 from PIL import Image
+
                 pil_imported = True
                 pil_import_attempted = True
             except:
@@ -12183,7 +14583,7 @@ class Window:
             pos = self.current_location()
             # Add a little to the X direction if window has a titlebar
             if not self.NoTitleBar:
-                pos = (pos[0]+7, pos[1])
+                pos = (pos[0] + 7, pos[1])
             # Get size of wiondow
             size = self.current_size_accurate()
             # Get size of the titlebar
@@ -12191,11 +14591,11 @@ class Window:
             # Add titlebar to size of window so that titlebar and window will be saved
             size = (size[0], size[1] + titlebar_height)
             if not self.NoTitleBar:
-                size_adjustment = (2,1)
+                size_adjustment = (2, 1)
             else:
-                size_adjustment = (0,0)
+                size_adjustment = (0, 0)
             # Make the "Bounding rectangle" used by PLK to do the screen grap "operation
-            rect = (pos[0], pos[1], pos[0] + size[0]+size_adjustment[0], pos[1] + size[1]+size_adjustment[1])
+            rect = (pos[0], pos[1], pos[0] + size[0] + size_adjustment[0], pos[1] + size[1] + size_adjustment[1])
             # Grab the image
             grab = ImageGrab.grab(bbox=rect)
             # Save the grabbed image to disk
@@ -12215,11 +14615,15 @@ class Window:
             try:
                 grab.save(full_filename)
             except Exception as e:
-                popup_error_with_traceback('Screen capture failure', 'Error happened while trying to save screencapture', e)
+                popup_error_with_traceback(
+                    'Screen capture failure', 'Error happened while trying to save screencapture', e
+                )
         else:
-            popup_error_with_traceback('Screen capture failure', 'You have attempted a screen capture but have not set up a good filename to save to')
+            popup_error_with_traceback(
+                'Screen capture failure',
+                'You have attempted a screen capture but have not set up a good filename to save to',
+            )
         return grab
-
 
     def perform_long_operation(self, func, end_key=None):
         """
@@ -12258,7 +14662,6 @@ class Window:
         """
         return self.AllKeysDict
 
-
     def key_is_good(self, key):
         """
         Checks to see if this is a good key for this window
@@ -12291,16 +14694,11 @@ class Window:
 
         return scaling
 
-
     def _custom_titlebar_restore_callback(self, event):
         self._custom_titlebar_restore()
 
-
     def _custom_titlebar_restore(self):
         if running_linux():
-            # if self._skip_first_restore_callback:
-            #     self._skip_first_restore_callback = False
-            #     return
             self.TKroot.unbind('<Button-1>')
             self.TKroot.deiconify()
 
@@ -12319,24 +14717,16 @@ class Window:
                 self.TKroot.attributes('-fullscreen', False)
         self.maximized = False
 
-
     def _custom_titlebar_minimize(self):
         if running_linux():
             self.TKroot.wm_attributes('-type', 'normal')
-            # self.ParentForm.TKroot.state('icon')
-            # return
-            # self.ParentForm.maximize()
             self.TKroot.wm_overrideredirect(False)
-            # self.ParentForm.minimize()
-            # self.ParentForm.TKroot.wm_overrideredirect(False)
             self.TKroot.iconify()
-            # self._skip_first_restore_callback = True
             self.TKroot.bind('<Button-1>', self._custom_titlebar_restore_callback)
         else:
             self.TKroot.wm_overrideredirect(False)
             self.TKroot.iconify()
             self.TKroot.bind('<Expose>', self._custom_titlebar_restore_callback)
-
 
     def _custom_titlebar_callback(self, key):
         """
@@ -12357,7 +14747,6 @@ class Window:
             if not self.DisableClose:
                 self._OnClosingCallback()
 
-
     def timer_start(self, frequency_ms, key=EVENT_TIMER, repeating=True):
         """
         Starts a timer that gnerates Timer Events.  The default is to repeat the timer events until timer is stopped.
@@ -12377,7 +14766,6 @@ class Window:
         timer = _TimerPeriodic(self, frequency_ms=frequency_ms, key=key, repeating=repeating)
         return timer.id
 
-
     def timer_stop(self, timer_id):
         """
         Stops a timer with a given ID
@@ -12388,13 +14776,11 @@ class Window:
         """
         _TimerPeriodic.stop_timer_with_id(timer_id)
 
-
     def timer_stop_all(self):
         """
         Stops all timers for THIS window
         """
         _TimerPeriodic.stop_all_timers_for_window(self)
-
 
     def timer_get_active_timers(self):
         """
@@ -12404,11 +14790,10 @@ class Window:
         """
         return _TimerPeriodic.get_all_timers_for_window(self)
 
-
     @classmethod
     def _restore_stdout(cls):
         for item in cls._rerouted_stdout_stack:
-            (window, element) = item   # type: (Window, Element)
+            (window, element) = item  # type: (Window, Element)
             if not window.is_closed():
                 sys.stdout = element
                 break
@@ -12417,31 +14802,16 @@ class Window:
             sys.stdout = cls._original_stdout
         # print('Restored stdout... new stack:',  [item[0].Title for item in cls._rerouted_stdout_stack ])
 
-
     @classmethod
     def _restore_stderr(cls):
         for item in cls._rerouted_stderr_stack:
-            (window, element) = item   # type: (Window, Element)
+            (window, element) = item  # type: (Window, Element)
             if not window.is_closed():
                 sys.stderr = element
                 break
         cls._rerouted_stderr_stack = [item for item in cls._rerouted_stderr_stack if not item[0].is_closed()]
         if len(cls._rerouted_stderr_stack) == 0 and cls._original_stderr is not None:
             sys.stderr = cls._original_stderr
-        # print('Restored stderr... new stack:',  [item[0].Title for item in cls._rerouted_stderr_stack ])
-
-
-
-
-
-    # def __enter__(self):
-    #     """
-    #     WAS used with context managers which are no longer needed nor advised.  It is here for legacy support and
-    #     am afraid of removing right now
-    #     :return: (window)
-    #      :rtype:
-    #     """
-    #     return self
 
     def __getitem__(self, key):
         """
@@ -12472,11 +14842,16 @@ class Window:
         msg = str(additional_message)
         if self.TKroot is None:
             warnings.warn(
-                'You cannot perform operations on a Window until it is read or finalized. Adding a "finalize=True" parameter to your Window creation will fix this. ' + msg,
-                UserWarning)
+                'You cannot perform operations on a Window until it is read or finalized. Adding a "finalize=True" parameter to your Window creation will fix this. '
+                + msg,
+                UserWarning,
+            )
             if not SUPPRESS_ERROR_POPUPS:
-                _error_popup_with_traceback('You cannot perform operations on a Window until it is read or finalized.',
-                                            'Adding a "finalize=True" parameter to your Window creation will likely fix this', msg)
+                _error_popup_with_traceback(
+                    'You cannot perform operations on a Window until it is read or finalized.',
+                    'Adding a "finalize=True" parameter to your Window creation will likely fix this',
+                    msg,
+                )
             return False
         return True
 
@@ -12527,24 +14902,6 @@ class Window:
     CloseNonBlocking = close
     CloseNonBlockingForm = close
     start_thread = perform_long_operation
-    #
-    # def __exit__(self, *a):
-    #     """
-    #     WAS used with context managers which are no longer needed nor advised.  It is here for legacy support and
-    #     am afraid of removing right now
-    #     :param *a: (?) Not sure what's passed in.
-    #      :type *a:
-    #     :return:   Always returns False which was needed for context manager to work
-    #      :rtype:
-    #     """
-    #     self.__del__()
-    #     return False
-    #
-    # def __del__(self):
-    #     # print('DELETING WINDOW')
-    #     for row in self.Rows:
-    #         for element in row:
-    #             element.__del__()
 
 
 # -------------------------------- PEP8-ify the Window Class USER Interfaces -------------------------------- #
@@ -12639,7 +14996,7 @@ def read_all_windows(timeout=None, timeout_key=TIMEOUT_KEY):
     Window._timeout_0_counter = 0  # reset value if not reading with timeout 0 so ready next time needed
 
     # setup timeout timer
-    if timeout != None:
+    if timeout is not None:
         try:
             Window.hidden_master_root.after_cancel(Window._TKAfterID)
             del Window._TKAfterID
@@ -12678,6 +15035,7 @@ def read_all_windows(timeout=None, timeout_key=TIMEOUT_KEY):
         event, values = window.ReturnValues
 
     return window, event, values
+
 
 # MP""""""`MM                     dP
 # M  mmmmm..M                     88
@@ -12771,9 +15129,13 @@ class SystemTray:
         screen_size = Window.get_screen_size()
 
         if filename:
-            image_elem = Image(filename=filename, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-')
+            image_elem = Image(
+                filename=filename, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-'
+            )
         elif data_base64:
-            image_elem = Image(data=data_base64, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-')
+            image_elem = Image(
+                data=data_base64, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-'
+            )
         elif data:
             image_elem = Image(data=data, background_color='red', enable_events=True, tooltip=tooltip, key='-IMAGE-')
         else:
@@ -12781,8 +15143,19 @@ class SystemTray:
         layout = [
             [image_elem],
         ]
-        self.window = Window('Window Title', layout, element_padding=(0, 0), margins=(0, 0), grab_anywhere=True, no_titlebar=True, transparent_color='red',
-                             keep_on_top=True, right_click_menu=menu, location=(screen_size[0] - 100, screen_size[1] - 100), finalize=True)
+        self.window = Window(
+            'Window Title',
+            layout,
+            element_padding=(0, 0),
+            margins=(0, 0),
+            grab_anywhere=True,
+            no_titlebar=True,
+            transparent_color='red',
+            keep_on_top=True,
+            right_click_menu=menu,
+            location=(screen_size[0] - 100, screen_size[1] - 100),
+            finalize=True,
+        )
 
         self.window['-IMAGE-'].bind('<Double-Button-1>', '+DOUBLE_CLICK')
 
@@ -12836,8 +15209,16 @@ class SystemTray:
         """
         self.window.un_hide()
 
-    def show_message(self, title, message, filename=None, data=None, data_base64=None, messageicon=None,
-                     time=(SYSTEM_TRAY_MESSAGE_FADE_IN_DURATION, SYSTEM_TRAY_MESSAGE_DISPLAY_DURATION_IN_MILLISECONDS)):
+    def show_message(
+        self,
+        title,
+        message,
+        filename=None,
+        data=None,
+        data_base64=None,
+        messageicon=None,
+        time=(SYSTEM_TRAY_MESSAGE_FADE_IN_DURATION, SYSTEM_TRAY_MESSAGE_DISPLAY_DURATION_IN_MILLISECONDS),
+    ):
         """
         Shows a balloon above icon in system tray
         :param title:       Title shown in balloon
@@ -12864,7 +15245,9 @@ class SystemTray:
 
         user_icon = data_base64 or filename or data or messageicon
 
-        event = self.notify(title, message, icon=user_icon, fade_in_duration=fade_duration, display_duration_in_ms=display_duration)
+        event = self.notify(
+            title, message, icon=user_icon, fade_in_duration=fade_duration, display_duration_in_ms=display_duration
+        )
         self.last_message_event = event
         return event
 
@@ -12874,7 +15257,14 @@ class SystemTray:
         """
         self.window.close()
 
-    def update(self, menu=None, tooltip=None, filename=None, data=None, data_base64=None, ):
+    def update(
+        self,
+        menu=None,
+        tooltip=None,
+        filename=None,
+        data=None,
+        data_base64=None,
+    ):
         """
         Updates the menu, tooltip or icon
         :param menu:        menu defintion
@@ -12905,8 +15295,16 @@ class SystemTray:
             self.window['-IMAGE-'].set_tooltip(tooltip)
 
     @classmethod
-    def notify(cls, title, message, icon=_tray_icon_success, display_duration_in_ms=SYSTEM_TRAY_MESSAGE_DISPLAY_DURATION_IN_MILLISECONDS,
-               fade_in_duration=SYSTEM_TRAY_MESSAGE_FADE_IN_DURATION, alpha=0.9, location=None):
+    def notify(
+        cls,
+        title,
+        message,
+        icon=_tray_icon_success,
+        display_duration_in_ms=SYSTEM_TRAY_MESSAGE_DISPLAY_DURATION_IN_MILLISECONDS,
+        fade_in_duration=SYSTEM_TRAY_MESSAGE_FADE_IN_DURATION,
+        alpha=0.9,
+        location=None,
+    ):
         """
         Displays a "notification window", usually in the bottom right corner of your display.  Has an icon, a title, and a message
         The window will slowly fade in and out if desired.  Clicking on the window will cause it to move through the end the current "phase". For example, if the window was fading in and it was clicked, then it would immediately stop fading in and instead be fully visible.  It's a way for the user to quickly dismiss the window.
@@ -12936,29 +15334,67 @@ class SystemTray:
         message = full_msg[:-1]
 
         win_msg_lines = message.count('\n') + 1
-        max_line = max(message.split('\n'))
 
         screen_res_x, screen_res_y = Window.get_screen_size()
         win_margin = SYSTEM_TRAY_WIN_MARGINS  # distance from screen edges
         win_width, win_height = 364, 66 + (14.8 * win_msg_lines)
 
-        layout = [[Graph(canvas_size=(win_width, win_height), graph_bottom_left=(0, win_height), graph_top_right=(win_width, 0), key='-GRAPH-',
-                         background_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR, enable_events=True)]]
+        layout = [
+            [
+                Graph(
+                    canvas_size=(win_width, win_height),
+                    graph_bottom_left=(0, win_height),
+                    graph_top_right=(win_width, 0),
+                    key='-GRAPH-',
+                    background_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR,
+                    enable_events=True,
+                )
+            ]
+        ]
 
-        win_location = location if location is not None else (screen_res_x - win_width - win_margin[0], screen_res_y - win_height - win_margin[1])
-        window = Window(title, layout, background_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR, no_titlebar=True,
-                        location=win_location, keep_on_top=True, alpha_channel=0, margins=(0, 0), element_padding=(0, 0), grab_anywhere=True, finalize=True)
+        win_location = (
+            location
+            if location is not None
+            else (screen_res_x - win_width - win_margin[0], screen_res_y - win_height - win_margin[1])
+        )
+        window = Window(
+            title,
+            layout,
+            background_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR,
+            no_titlebar=True,
+            location=win_location,
+            keep_on_top=True,
+            alpha_channel=0,
+            margins=(0, 0),
+            element_padding=(0, 0),
+            grab_anywhere=True,
+            finalize=True,
+        )
 
-        window['-GRAPH-'].draw_rectangle((win_width, win_height), (-win_width, -win_height), fill_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR,
-                                         line_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR)
+        window['-GRAPH-'].draw_rectangle(
+            (win_width, win_height),
+            (-win_width, -win_height),
+            fill_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR,
+            line_color=SYSTEM_TRAY_MESSAGE_WIN_COLOR,
+        )
         if type(icon) is bytes:
             window['-GRAPH-'].draw_image(data=icon, location=(20, 20))
         elif icon is not None:
             window['-GRAPH-'].draw_image(filename=icon, location=(20, 20))
-        window['-GRAPH-'].draw_text(title, location=(64, 20), color=SYSTEM_TRAY_MESSAGE_TEXT_COLOR, font=('Helvetica', 12, 'bold'),
-                                    text_location=TEXT_LOCATION_TOP_LEFT)
-        window['-GRAPH-'].draw_text(message, location=(64, 44), color=SYSTEM_TRAY_MESSAGE_TEXT_COLOR, font=('Helvetica', 9),
-                                    text_location=TEXT_LOCATION_TOP_LEFT)
+        window['-GRAPH-'].draw_text(
+            title,
+            location=(64, 20),
+            color=SYSTEM_TRAY_MESSAGE_TEXT_COLOR,
+            font=('Helvetica', 12, 'bold'),
+            text_location=TEXT_LOCATION_TOP_LEFT,
+        )
+        window['-GRAPH-'].draw_text(
+            message,
+            location=(64, 44),
+            color=SYSTEM_TRAY_MESSAGE_TEXT_COLOR,
+            font=('Helvetica', 9),
+            text_location=TEXT_LOCATION_TOP_LEFT,
+        )
         window['-GRAPH-'].set_cursor('hand2')
 
         if fade_in_duration:
@@ -13004,6 +15440,7 @@ class SystemTray:
 # Button Lazy Functions so the caller doesn't have to define a bunch of stuff #
 # =========================================================================== #
 
+
 # ------------------------- A fake Element... the Pad Element ------------------------- #
 def Sizer(h_pixels=0, v_pixels=0):
     """
@@ -13018,6 +15455,7 @@ def Sizer(h_pixels=0, v_pixels=0):
     """
 
     return Canvas(size=(0, 0), pad=((h_pixels, 0), (v_pixels, 0)))
+
 
 def pin(elem, vertical_alignment=None, shrink=True, expand_x=None, expand_y=None):
     """
@@ -13044,7 +15482,13 @@ def pin(elem, vertical_alignment=None, shrink=True, expand_x=None, expand_y=None
     """
     if shrink:
         # return Column([[elem, Canvas(size=(0, 0),background_color=elem.BackgroundColor, pad=(0, 0))]], pad=(0, 0), vertical_alignment=vertical_alignment, expand_x=expand_x, expand_y=expand_y)
-        return Column([[elem, Column([[]],pad=(0,0))]], pad=(0, 0), vertical_alignment=vertical_alignment, expand_x=expand_x, expand_y=expand_y)
+        return Column(
+            [[elem, Column([[]], pad=(0, 0))]],
+            pad=(0, 0),
+            vertical_alignment=vertical_alignment,
+            expand_x=expand_x,
+            expand_y=expand_y,
+        )
     else:
         return Column([[elem]], pad=(0, 0), vertical_alignment=vertical_alignment, expand_x=expand_x, expand_y=expand_y)
 
@@ -13065,11 +15509,27 @@ def vtop(elem_or_row, expand_x=None, expand_y=None, background_color=None):
     :rtype:                  Column | List[Column]
     """
 
-
     if isinstance(elem_or_row, list) or isinstance(elem_or_row, tuple):
-        return [Column([[e]], pad=(0, 0), vertical_alignment='top', expand_x=expand_x, expand_y=expand_y, background_color=background_color) for e in elem_or_row]
+        return [
+            Column(
+                [[e]],
+                pad=(0, 0),
+                vertical_alignment='top',
+                expand_x=expand_x,
+                expand_y=expand_y,
+                background_color=background_color,
+            )
+            for e in elem_or_row
+        ]
 
-    return Column([[elem_or_row]], pad=(0, 0), vertical_alignment='top', expand_x=expand_x, expand_y=expand_y, background_color=background_color)
+    return Column(
+        [[elem_or_row]],
+        pad=(0, 0),
+        vertical_alignment='top',
+        expand_x=expand_x,
+        expand_y=expand_y,
+        background_color=background_color,
+    )
 
 
 def vcenter(elem_or_row, expand_x=None, expand_y=None, background_color=None):
@@ -13089,9 +15549,26 @@ def vcenter(elem_or_row, expand_x=None, expand_y=None, background_color=None):
     """
 
     if isinstance(elem_or_row, list) or isinstance(elem_or_row, tuple):
-        return [Column([[e]], pad=(0, 0), vertical_alignment='center',expand_x=expand_x, expand_y=expand_y, background_color=background_color) for e in elem_or_row]
+        return [
+            Column(
+                [[e]],
+                pad=(0, 0),
+                vertical_alignment='center',
+                expand_x=expand_x,
+                expand_y=expand_y,
+                background_color=background_color,
+            )
+            for e in elem_or_row
+        ]
 
-    return Column([[elem_or_row]], pad=(0, 0), vertical_alignment='center', expand_x=expand_x, expand_y=expand_y,background_color=background_color)
+    return Column(
+        [[elem_or_row]],
+        pad=(0, 0),
+        vertical_alignment='center',
+        expand_x=expand_x,
+        expand_y=expand_y,
+        background_color=background_color,
+    )
 
 
 def vbottom(elem_or_row, expand_x=None, expand_y=None, background_color=None):
@@ -13110,11 +15587,27 @@ def vbottom(elem_or_row, expand_x=None, expand_y=None, background_color=None):
     :rtype:                  Column | List[Column]
     """
 
-
     if isinstance(elem_or_row, list) or isinstance(elem_or_row, tuple):
-        return [Column([[e]], pad=(0, 0), vertical_alignment='bottom', expand_x=expand_x, expand_y=expand_y, background_color=background_color) for e in elem_or_row]
+        return [
+            Column(
+                [[e]],
+                pad=(0, 0),
+                vertical_alignment='bottom',
+                expand_x=expand_x,
+                expand_y=expand_y,
+                background_color=background_color,
+            )
+            for e in elem_or_row
+        ]
 
-    return Column([[elem_or_row]], pad=(0, 0), vertical_alignment='bottom', expand_x=expand_x, expand_y=expand_y,background_color=background_color)
+    return Column(
+        [[elem_or_row]],
+        pad=(0, 0),
+        vertical_alignment='bottom',
+        expand_x=expand_x,
+        expand_y=expand_y,
+        background_color=background_color,
+    )
 
 
 def Titlebar(title='', icon=None, text_color=None, background_color=None, font=None, key=None, k=None):
@@ -13173,16 +15666,71 @@ def Titlebar(title='', icon=None, text_color=None, background_color=None, font=N
 
     icon_and_text_portion += [T(title, text_color=tc, background_color=bc, font=font, grab=True, key=TITLEBAR_TEXT_KEY)]
 
-    return Column([[Column([icon_and_text_portion], pad=(0, 0), background_color=bc),
-                    Column([[T(SYMBOL_TITLEBAR_MINIMIZE, text_color=tc, background_color=bc, enable_events=True, font=font, key=TITLEBAR_MINIMIZE_KEY),
-                             Text(SYMBOL_TITLEBAR_MAXIMIZE, text_color=tc, background_color=bc, enable_events=True, font=font, key=TITLEBAR_MAXIMIZE_KEY),
-                             Text(SYMBOL_TITLEBAR_CLOSE, text_color=tc, background_color=bc, font=font, enable_events=True, key=TITLEBAR_CLOSE_KEY), ]],
-                           element_justification='r', expand_x=True, grab=True, pad=(0, 0), background_color=bc)]], expand_x=True, grab=True,
-                  background_color=bc, pad=(0, 0), metadata=TITLEBAR_METADATA_MARKER, key=key)
+    return Column(
+        [
+            [
+                Column([icon_and_text_portion], pad=(0, 0), background_color=bc),
+                Column(
+                    [
+                        [
+                            T(
+                                SYMBOL_TITLEBAR_MINIMIZE,
+                                text_color=tc,
+                                background_color=bc,
+                                enable_events=True,
+                                font=font,
+                                key=TITLEBAR_MINIMIZE_KEY,
+                            ),
+                            Text(
+                                SYMBOL_TITLEBAR_MAXIMIZE,
+                                text_color=tc,
+                                background_color=bc,
+                                enable_events=True,
+                                font=font,
+                                key=TITLEBAR_MAXIMIZE_KEY,
+                            ),
+                            Text(
+                                SYMBOL_TITLEBAR_CLOSE,
+                                text_color=tc,
+                                background_color=bc,
+                                font=font,
+                                enable_events=True,
+                                key=TITLEBAR_CLOSE_KEY,
+                            ),
+                        ]
+                    ],
+                    element_justification='r',
+                    expand_x=True,
+                    grab=True,
+                    pad=(0, 0),
+                    background_color=bc,
+                ),
+            ]
+        ],
+        expand_x=True,
+        grab=True,
+        background_color=bc,
+        pad=(0, 0),
+        metadata=TITLEBAR_METADATA_MARKER,
+        key=key,
+    )
 
 
-def MenubarCustom(menu_definition, disabled_text_color=None, bar_font=None, font=None, tearoff=False, pad=0, p=None, background_color=None, text_color=None,
-                  bar_background_color=None, bar_text_color=None, key=None, k=None):
+def MenubarCustom(
+    menu_definition,
+    disabled_text_color=None,
+    bar_font=None,
+    font=None,
+    tearoff=False,
+    pad=0,
+    p=None,
+    background_color=None,
+    text_color=None,
+    bar_background_color=None,
+    bar_text_color=None,
+    key=None,
+    k=None,
+):
     """
     A custom Menubar that replaces the OS provided Menubar
 
@@ -13232,12 +15780,25 @@ def MenubarCustom(menu_definition, disabled_text_color=None, bar_font=None, font
             text = text.replace(MENU_SHORTCUT_CHARACTER, '')
         if text.startswith(MENU_DISABLED_CHARACTER):
             disabled = True
-            text = text[len(MENU_DISABLED_CHARACTER):]
+            text = text[len(MENU_DISABLED_CHARACTER) :]
         else:
             disabled = False
 
-        button_menu = ButtonMenu(text, menu, border_width=0, button_color=(bar_text, bar_bg), key=text, pad=(0, 0), disabled=disabled, font=bar_font,
-                                 item_font=font, disabled_text_color=disabled_text_color, text_color=menu_text, background_color=menu_bg, tearoff=tearoff)
+        button_menu = ButtonMenu(
+            text,
+            menu,
+            border_width=0,
+            button_color=(bar_text, bar_bg),
+            key=text,
+            pad=(0, 0),
+            disabled=disabled,
+            font=bar_font,
+            item_font=font,
+            disabled_text_color=disabled_text_color,
+            text_color=menu_text,
+            background_color=menu_bg,
+            tearoff=tearoff,
+        )
         button_menu.part_of_custom_menubar = True
         button_menu.custom_menubar_key = key if key is not None else k
         row += [button_menu]
@@ -13245,9 +15806,28 @@ def MenubarCustom(menu_definition, disabled_text_color=None, bar_font=None, font
 
 
 # -------------------------  FOLDER BROWSE Element lazy function  ------------------------- #
-def FolderBrowse(button_text='Browse', target=(ThisRow, -1), initial_folder=None, tooltip=None, size=(None, None), s=(None, None),
-                 auto_size_button=None, button_color=None, disabled=False, change_submits=False, enable_events=False,
-                 font=None, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def FolderBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     :param button_text:      text in the button (Default value = 'Browse')
     :type button_text:       (str)
@@ -13293,17 +15873,55 @@ def FolderBrowse(button_text='Browse', target=(ThisRow, -1), initial_folder=None
     :rtype:                  (Button)
     """
 
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FOLDER, target=target,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, s=s, auto_size_button=auto_size_button,
-                  disabled=disabled, button_color=button_color, change_submits=change_submits,
-                  enable_events=enable_events, font=font, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FOLDER,
+        target=target,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        font=font,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileBrowse(button_text='Browse', target=(ThisRow, -1), file_types=FILE_TYPES_ALL_FILES, initial_folder=None,
-               tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None, change_submits=False,
-               enable_events=False, font=None, disabled=False,
-               pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def FileBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=FILE_TYPES_ALL_FILES,
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    disabled=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Browse')
@@ -13351,17 +15969,57 @@ def FileBrowse(button_text='Browse', target=(ThisRow, -1), file_types=FILE_TYPES
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, s=s, auto_size_button=auto_size_button,
-                  change_submits=change_submits, enable_events=enable_events, disabled=disabled,
-                  button_color=button_color, font=font, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  FILES BROWSE Element (Multiple file selection) lazy function  ------------------------- #
-def FilesBrowse(button_text='Browse', target=(ThisRow, -1), file_types=FILE_TYPES_ALL_FILES, disabled=False,
-                initial_folder=None, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None,
-                change_submits=False, enable_events=False,
-                font=None, pad=None, p=None, key=None, k=None, visible=True, files_delimiter=BROWSE_FILES_DELIMITER, metadata=None, expand_x=False, expand_y=False):
+def FilesBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=FILE_TYPES_ALL_FILES,
+    disabled=False,
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    files_delimiter=BROWSE_FILES_DELIMITER,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     Allows browsing of multiple files. File list is returned as a single list with the delimiter defined using the files_delimiter parameter.
 
@@ -13412,19 +16070,59 @@ def FilesBrowse(button_text='Browse', target=(ThisRow, -1), file_types=FILE_TYPE
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    button = Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILES, target=target, file_types=file_types,
-                    initial_folder=initial_folder, change_submits=change_submits, enable_events=enable_events,
-                    tooltip=tooltip, size=size, s=s, auto_size_button=auto_size_button,
-                    disabled=disabled, button_color=button_color, font=font, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    button = Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILES,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
     button._files_delimiter = files_delimiter
     return button
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileSaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=FILE_TYPES_ALL_FILES, initial_folder=None,
-               default_extension='', disabled=False, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None,
-               change_submits=False, enable_events=False, font=None,
-               pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def FileSaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=FILE_TYPES_ALL_FILES,
+    initial_folder=None,
+    default_extension='',
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:       text in the button (Default value = 'Save As...')
@@ -13473,17 +16171,58 @@ def FileSaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=FILE_T
     :type expand_y:           (bool)        :return:                  returns a button
     :rtype:                   (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, default_extension=default_extension, tooltip=tooltip, size=size, s=s, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits,
-                  enable_events=enable_events, font=font, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        default_extension=default_extension,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        font=font,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  SAVE AS Element lazy function  ------------------------- #
-def SaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=FILE_TYPES_ALL_FILES, initial_folder=None, default_extension='',
-           disabled=False, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None,
-           change_submits=False, enable_events=False, font=None,
-           pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def SaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=FILE_TYPES_ALL_FILES,
+    initial_folder=None,
+    default_extension='',
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:       text in the button (Default value = 'Save As...')
@@ -13532,15 +16271,54 @@ def SaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=FILE_TYPES
     :return:                  returns a button
     :rtype:                   (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, default_extension=default_extension, tooltip=tooltip, size=size, s=s, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits,
-                  enable_events=enable_events, font=font, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        default_extension=default_extension,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        font=font,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  SAVE BUTTON Element lazy function  ------------------------- #
-def Save(button_text='Save', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, bind_return_key=True,
-         disabled=False, tooltip=None, font=None, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Save(
+    button_text='Save',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    bind_return_key=True,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Save')
@@ -13582,14 +16360,50 @@ def Save(button_text='Save', size=(None, None), s=(None, None), auto_size_button
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  SUBMIT BUTTON Element lazy function  ------------------------- #
-def Submit(button_text='Submit', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Submit(
+    button_text='Submit',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Submit')
@@ -13631,15 +16445,51 @@ def Submit(button_text='Submit', size=(None, None), s=(None, None), auto_size_bu
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  OPEN BUTTON Element lazy function  ------------------------- #
 # -------------------------  OPEN BUTTON Element lazy function  ------------------------- #
-def Open(button_text='Open', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False,
-         bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Open(
+    button_text='Open',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Open')
@@ -13681,14 +16531,50 @@ def Open(button_text='Open', size=(None, None), s=(None, None), auto_size_button
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  OK BUTTON Element lazy function  ------------------------- #
-def OK(button_text='OK', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def OK(
+    button_text='OK',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'OK')
@@ -13730,14 +16616,50 @@ def OK(button_text='OK', size=(None, None), s=(None, None), auto_size_button=Non
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  YES BUTTON Element lazy function  ------------------------- #
-def Ok(button_text='Ok', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Ok(
+    button_text='Ok',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Ok')
@@ -13779,14 +16701,50 @@ def Ok(button_text='Ok', size=(None, None), s=(None, None), auto_size_button=Non
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  CANCEL BUTTON Element lazy function  ------------------------- #
-def Cancel(button_text='Cancel', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           tooltip=None, font=None, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Cancel(
+    button_text='Cancel',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Cancel')
@@ -13828,14 +16786,50 @@ def Cancel(button_text='Cancel', size=(None, None), s=(None, None), auto_size_bu
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  QUIT BUTTON Element lazy function  ------------------------- #
-def Quit(button_text='Quit', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Quit(
+    button_text='Quit',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Quit')
@@ -13877,14 +16871,50 @@ def Quit(button_text='Quit', size=(None, None), s=(None, None), auto_size_button
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  Exit BUTTON Element lazy function  ------------------------- #
-def Exit(button_text='Exit', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Exit(
+    button_text='Exit',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Exit')
@@ -13926,14 +16956,50 @@ def Exit(button_text='Exit', size=(None, None), s=(None, None), auto_size_button
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  YES BUTTON Element lazy function  ------------------------- #
-def Yes(button_text='Yes', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Yes(
+    button_text='Yes',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Yes')
@@ -13975,14 +17041,50 @@ def Yes(button_text='Yes', size=(None, None), s=(None, None), auto_size_button=N
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  NO BUTTON Element lazy function  ------------------------- #
-def No(button_text='No', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-       font=None, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def No(
+    button_text='No',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'No')
@@ -14024,14 +17126,50 @@ def No(button_text='No', size=(None, None), s=(None, None), auto_size_button=Non
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  NO BUTTON Element lazy function  ------------------------- #
-def Help(button_text='Help', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False, font=None,
-         tooltip=None, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Help(
+    button_text='Help',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    tooltip=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button (Default value = 'Help')
@@ -14073,14 +17211,50 @@ def Help(button_text='Help', size=(None, None), s=(None, None), auto_size_button
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  NO BUTTON Element lazy function  ------------------------- #
-def Debug(button_text='', size=(None, None), s=(None, None), auto_size_button=None, button_color=None, disabled=False, font=None,
-          tooltip=None, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def Debug(
+    button_text='',
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    tooltip=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     This Button has been changed in how it works!!
     Your button has been replaced with a normal button that has the PySimpleGUI Debugger buggon logo on it.
@@ -14126,19 +17300,59 @@ def Debug(button_text='', size=(None, None), s=(None, None), auto_size_button=No
     :rtype:                  (Button)
     """
 
-
     user_key = key if key is not None else k if k is not None else button_text
 
-    return Button(button_text='', button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=theme_button_color(), font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=user_key, k=k, visible=visible, image_data=PSG_DEBUGGER_LOGO,
-                  image_subsample=2, border_width=0, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text='',
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=theme_button_color(),
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=user_key,
+        k=k,
+        visible=visible,
+        image_data=PSG_DEBUGGER_LOGO,
+        image_subsample=2,
+        border_width=0,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  GENERIC BUTTON Element lazy function  ------------------------- #
-def SimpleButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                 border_width=None, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None,
-                 font=None, bind_return_key=False, disabled=False, focus=False, pad=None, p=None, key=None, k=None, metadata=None, expand_x=False, expand_y=False):
+def SimpleButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     DEPIRCATED
 
@@ -14189,17 +17403,58 @@ def SimpleButton(button_text, image_filename=None, image_data=None, image_size=(
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  CLOSE BUTTON Element lazy function  ------------------------- #
-def CloseButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None, font=None,
-                bind_return_key=False, disabled=False, focus=False, pad=None, p=None, key=None, k=None, metadata=None, expand_x=False, expand_y=False):
+def CloseButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     DEPRICATED
 
@@ -14251,20 +17506,61 @@ def CloseButton(button_text, image_filename=None, image_data=None, image_size=(N
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 CButton = CloseButton
 
 
 # -------------------------  GENERIC BUTTON Element lazy function  ------------------------- #
-def ReadButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-               border_width=None, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None, font=None,
-               bind_return_key=False, disabled=False, focus=False, pad=None, p=None, key=None, k=None, metadata=None, expand_x=False, expand_y=False):
+def ReadButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     :param button_text:      text in the button
     :type button_text:       (str)
@@ -14314,11 +17610,31 @@ def ReadButton(button_text, image_filename=None, image_data=None, image_size=(No
     :rtype:                  (Button)
     """
 
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, s=s, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 ReadFormButton = ReadButton
@@ -14326,9 +17642,31 @@ RButton = ReadFormButton
 
 
 # -------------------------  Realtime BUTTON Element lazy function  ------------------------- #
-def RealtimeButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                   border_width=None, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None,
-                   font=None, disabled=False, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def RealtimeButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button
@@ -14380,17 +17718,60 @@ def RealtimeButton(button_text, image_filename=None, image_data=None, image_size
     :return:                 Button created
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_REALTIME, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_REALTIME,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  Dummy BUTTON Element lazy function  ------------------------- #
-def DummyButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), s=(None, None), auto_size_button=None, button_color=None, font=None,
-                disabled=False, bind_return_key=False, focus=False, pad=None, p=None, key=None, k=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def DummyButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     This is a special type of Button.
 
@@ -14448,21 +17829,72 @@ def DummyButton(button_text, image_filename=None, image_data=None, image_size=(N
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN_ONLY, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, s=s, auto_size_button=auto_size_button,
-                  button_color=button_color, font=font, disabled=disabled, bind_return_key=bind_return_key, focus=focus,
-                  pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN_ONLY,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def CalendarButton(button_text, target=(ThisRow, -1), close_when_date_chosen=True, default_date_m_d_y=(None, None, None),
-                   image_filename=None, image_data=None, image_size=(None, None),
-                   image_subsample=None, tooltip=None, border_width=None, size=(None, None), s=(None, None), auto_size_button=None,
-                   button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None, p=None, enable_events=None,
-                   key=None, k=None, visible=True, locale=None, format='%Y-%m-%d %H:%M:%S', begin_at_sunday_plus=0, month_names=None, day_abbreviations=None,
-                   title='Choose Date',
-                   no_titlebar=True, location=(None, None), metadata=None, expand_x=False, expand_y=False):
+def CalendarButton(
+    button_text,
+    target=(ThisRow, -1),
+    close_when_date_chosen=True,
+    default_date_m_d_y=(None, None, None),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    enable_events=None,
+    key=None,
+    k=None,
+    visible=True,
+    locale=None,
+    format='%Y-%m-%d %H:%M:%S',
+    begin_at_sunday_plus=0,
+    month_names=None,
+    day_abbreviations=None,
+    title='Choose Date',
+    no_titlebar=True,
+    location=(None, None),
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
     Button that will show a calendar chooser window.  Fills in the target element with result
 
@@ -14537,11 +17969,34 @@ def CalendarButton(button_text, target=(ThisRow, -1), close_when_date_chosen=Tru
     :return:                       returns a button
     :rtype:                        (Button)
     """
-    button = Button(button_text=button_text, button_type=BUTTON_TYPE_CALENDAR_CHOOSER, target=target,
-                    image_filename=image_filename, image_data=image_data, image_size=image_size,
-                    image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size, s=s,
-                    auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled, enable_events=enable_events,
-                    bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    button = Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CALENDAR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        enable_events=enable_events,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
     button.calendar_close_when_chosen = close_when_date_chosen
     button.calendar_default_date_M_D_Y = default_date_m_d_y
     button.calendar_locale = locale
@@ -14557,10 +18012,33 @@ def CalendarButton(button_text, target=(ThisRow, -1), close_when_date_chosen=Tru
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def ColorChooserButton(button_text, target=(ThisRow, -1), image_filename=None, image_data=None, image_size=(None, None),
-                       image_subsample=None, tooltip=None, border_width=None, size=(None, None), s=(None, None), auto_size_button=None,
-                       button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None, p=None,
-                       key=None, k=None, default_color=None, visible=True, metadata=None, expand_x=False, expand_y=False):
+def ColorChooserButton(
+    button_text,
+    target=(ThisRow, -1),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    s=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    p=None,
+    key=None,
+    k=None,
+    default_color=None,
+    visible=True,
+    metadata=None,
+    expand_x=False,
+    expand_y=False,
+):
     """
 
     :param button_text:      text in the button
@@ -14617,15 +18095,39 @@ def ColorChooserButton(button_text, target=(ThisRow, -1), image_filename=None, i
     :return:                 returns a button
     :rtype:                  (Button)
     """
-    button = Button(button_text=button_text, button_type=BUTTON_TYPE_COLOR_CHOOSER, target=target,
-                  image_filename=image_filename, image_data=image_data, image_size=image_size,
-                  image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size, s=s,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, p=p, key=key, k=k, visible=visible, metadata=metadata, expand_x=expand_x, expand_y=expand_y)
+    button = Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_COLOR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        s=s,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        p=p,
+        key=key,
+        k=k,
+        visible=visible,
+        metadata=metadata,
+        expand_x=expand_x,
+        expand_y=expand_y,
+    )
     button.default_color = default_color
     return button
 
+
 #####################################  -----  BUTTON Functions   ------ ##################################################
+
 
 def button_color_to_tuple(color_tuple_or_string, default=(None, None)):
     """
@@ -14695,7 +18197,9 @@ def _simplified_dual_color_to_tuple(color_tuple_or_string, default=(None, None))
                 text_color, background_color = default
         else:
             if not SUPPRESS_ERROR_POPUPS:
-                _error_popup_with_traceback('** Badly formatted dual-color... not a tuple nor string **', color_tuple_or_string)
+                _error_popup_with_traceback(
+                    '** Badly formatted dual-color... not a tuple nor string **', color_tuple_or_string
+                )
             else:
                 print('** Badly formatted dual-color... not a tuple nor string **', color_tuple_or_string)
             text_color, background_color = default
@@ -14716,14 +18220,9 @@ def _simplified_dual_color_to_tuple(color_tuple_or_string, default=(None, None))
 
 #####################################  -----  RESULTS   ------ ##################################################
 
+
 def AddToReturnDictionary(form, element, value):
     form.ReturnValuesDictionary[element.Key] = value
-    # if element.Key is None:
-    #     form.ReturnValuesDictionary[form.DictionaryKeyCounter] = value
-    #     element.Key = form.DictionaryKeyCounter
-    #     form.DictionaryKeyCounter += 1
-    # else:
-    #     form.ReturnValuesDictionary[element.Key] = value
 
 
 def AddToReturnList(form, value):
@@ -14761,7 +18260,6 @@ def _BuildResults(form, initialize_only, top_level_form):
     #   Button - Button Text and position as a Tuple
 
     # Get the initialized results so we don't have to rebuild
-    # form.DictionaryKeyCounter = 0
     form.ReturnValuesDictionary = {}
     form.ReturnValuesList = []
     _BuildResultsForSubform(form, initialize_only, top_level_form)
@@ -14843,11 +18341,15 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                         value = element.TKStringVar.get()
                     except:
                         value = ''
-                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
+                    if (
+                        not top_level_form.NonBlocking
+                        and not element.do_not_clear
+                        and not top_level_form.ReturnKeyboardEvents
+                    ):
                         element.TKStringVar.set('')
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
                     value = element.TKIntVar.get()
-                    value = (value != 0)
+                    value = value != 0
                 elif element.Type == ELEM_TYPE_INPUT_RADIO:
                     RadVar = element.TKIntVar.get()
                     this_rowcol = EncodeRadioRowCol(form.ContainerElemementNumber, row_num, col_num)
@@ -14868,12 +18370,13 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                             value = None
                 elif element.Type == ELEM_TYPE_INPUT_COMBO:
                     element = element  # type: Combo
-                    # value = element.TKStringVar.get()
                     try:
                         if element.TKCombo.current() == -1:  # if the current value was not in the original list
                             value = element.TKCombo.get()
                         else:
-                            value = element.Values[element.TKCombo.current()]  # get value from original list given index
+                            value = element.Values[
+                                element.TKCombo.current()
+                            ]  # get value from original list given index
                     except:
                         value = '*Exception occurred*'
                 elif element.Type == ELEM_TYPE_INPUT_OPTION_MENU:
@@ -14882,7 +18385,7 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                     try:
                         items = element.TKListbox.curselection()
                         value = [element.Values[int(item)] for item in items]
-                    except Exception as e:
+                    except Exception:
                         value = ''
                 elif element.Type == ELEM_TYPE_INPUT_SPIN:
                     try:
@@ -14899,13 +18402,19 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                     except:
                         value = 0
                 elif element.Type == ELEM_TYPE_INPUT_MULTILINE:
-                    if element.WriteOnly:  # if marked as "write only" when created, then don't include with the values being returned
+                    if (
+                        element.WriteOnly
+                    ):  # if marked as "write only" when created, then don't include with the values being returned
                         continue
                     try:
                         value = element.TKText.get(1.0, tk.END)
                         if element.rstrip:
                             value = value.rstrip()
-                        if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
+                        if (
+                            not top_level_form.NonBlocking
+                            and not element.do_not_clear
+                            and not top_level_form.ReturnKeyboardEvents
+                        ):
                             element.TKText.delete('1.0', tk.END)
                     except:
                         value = None
@@ -14944,27 +18453,42 @@ def _BuildResultsForSubform(form, initialize_only, top_level_form):
                                 top_level_form.ReturnValuesDictionary[element.custom_menubar_key] = None
                             value = None
 
-                    # if element.MenuItemChosen is not None:
-                    #     button_pressed_text = top_level_form.LastButtonClicked = element.MenuItemChosen
-                    # value = element.MenuItemChosen
-                    # element.MenuItemChosen = None
             else:
                 value = None
 
             # if an input type element, update the results
             if element.Type not in (
-            ELEM_TYPE_BUTTON, ELEM_TYPE_TEXT, ELEM_TYPE_IMAGE, ELEM_TYPE_OUTPUT, ELEM_TYPE_PROGRESS_BAR, ELEM_TYPE_COLUMN, ELEM_TYPE_FRAME, ELEM_TYPE_SEPARATOR,
-            ELEM_TYPE_TAB):
+                ELEM_TYPE_BUTTON,
+                ELEM_TYPE_TEXT,
+                ELEM_TYPE_IMAGE,
+                ELEM_TYPE_OUTPUT,
+                ELEM_TYPE_PROGRESS_BAR,
+                ELEM_TYPE_COLUMN,
+                ELEM_TYPE_FRAME,
+                ELEM_TYPE_SEPARATOR,
+                ELEM_TYPE_TAB,
+            ):
                 if not (element.Type == ELEM_TYPE_BUTTONMENU and element.part_of_custom_menubar):
                     AddToReturnList(form, value)
                     AddToReturnDictionary(top_level_form, element, value)
-            elif (element.Type == ELEM_TYPE_BUTTON and
-                  element.BType == BUTTON_TYPE_COLOR_CHOOSER and
-                  element.Target == (None, None)) or \
-                    (element.Type == ELEM_TYPE_BUTTON
-                     and element.Key is not None and
-                     (element.BType in (BUTTON_TYPE_SAVEAS_FILE, BUTTON_TYPE_BROWSE_FILE, BUTTON_TYPE_BROWSE_FILES,
-                                        BUTTON_TYPE_BROWSE_FOLDER, BUTTON_TYPE_CALENDAR_CHOOSER))):
+            elif (
+                element.Type == ELEM_TYPE_BUTTON
+                and element.BType == BUTTON_TYPE_COLOR_CHOOSER
+                and element.Target == (None, None)
+            ) or (
+                element.Type == ELEM_TYPE_BUTTON
+                and element.Key is not None
+                and (
+                    element.BType
+                    in (
+                        BUTTON_TYPE_SAVEAS_FILE,
+                        BUTTON_TYPE_BROWSE_FILE,
+                        BUTTON_TYPE_BROWSE_FILES,
+                        BUTTON_TYPE_BROWSE_FOLDER,
+                        BUTTON_TYPE_CALENDAR_CHOOSER,
+                    )
+                )
+            ):
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
 
@@ -15012,7 +18536,7 @@ def fill_form_with_values(window, values_dict):
     for element_key in values_dict:
         try:
             window.AllKeysDict[element_key].Update(values_dict[element_key])
-        except Exception as e:
+        except Exception:
             print('Problem filling form. Perhaps bad key?  This is a suspected bad key: {}'.format(element_key))
 
 
@@ -15091,28 +18615,34 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False,
             pos = sub_menu_info.find(MENU_SHORTCUT_CHARACTER)
             if pos != -1:
                 if pos < len(MENU_SHORTCUT_CHARACTER) or sub_menu_info[pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                    sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + len(MENU_SHORTCUT_CHARACTER):]
+                    sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + len(MENU_SHORTCUT_CHARACTER) :]
             if sub_menu_info == '---':
                 top_menu.add('separator')
             else:
                 try:
-                    item_without_key = sub_menu_info[:sub_menu_info.index(MENU_KEY_SEPARATOR)]
+                    item_without_key = sub_menu_info[: sub_menu_info.index(MENU_KEY_SEPARATOR)]
                 except:
                     item_without_key = sub_menu_info
 
                 if item_without_key[0] == MENU_DISABLED_CHARACTER:
-                    top_menu.add_command(label=item_without_key[len(MENU_DISABLED_CHARACTER):], underline=pos - 1,
-                                         command=lambda: element._MenuItemChosenCallback(sub_menu_info))
-                    top_menu.entryconfig(item_without_key[len(MENU_DISABLED_CHARACTER):], state='disabled')
+                    top_menu.add_command(
+                        label=item_without_key[len(MENU_DISABLED_CHARACTER) :],
+                        underline=pos - 1,
+                        command=lambda: element._MenuItemChosenCallback(sub_menu_info),
+                    )
+                    top_menu.entryconfig(item_without_key[len(MENU_DISABLED_CHARACTER) :], state='disabled')
                 else:
-                    top_menu.add_command(label=item_without_key, underline=pos,
-                                         command=lambda: element._MenuItemChosenCallback(sub_menu_info))
+                    top_menu.add_command(
+                        label=item_without_key,
+                        underline=pos,
+                        command=lambda: element._MenuItemChosenCallback(sub_menu_info),
+                    )
     else:
         i = 0
         while i < (len(sub_menu_info)):
             item = sub_menu_info[i]
             if i != len(sub_menu_info) - 1:
-                if type(sub_menu_info[i + 1]) == list:
+                if type(sub_menu_info[i + 1]) is list:
                     new_menu = tk.Menu(top_menu, tearoff=element.Tearoff)
                     # if a right click menu, then get styling from the top-level window
                     if right_click_menu:
@@ -15143,14 +18673,25 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False,
                     return_val = new_menu
                     pos = sub_menu_info[i].find(MENU_SHORTCUT_CHARACTER)
                     if pos != -1:
-                        if pos < len(MENU_SHORTCUT_CHARACTER) or sub_menu_info[i][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                            sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + len(MENU_SHORTCUT_CHARACTER):]
+                        if (
+                            pos < len(MENU_SHORTCUT_CHARACTER)
+                            or sub_menu_info[i][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\'
+                        ):
+                            sub_menu_info[i] = (
+                                sub_menu_info[i][:pos] + sub_menu_info[i][pos + len(MENU_SHORTCUT_CHARACTER) :]
+                            )
                     if sub_menu_info[i][0] == MENU_DISABLED_CHARACTER:
-                        top_menu.add_cascade(label=sub_menu_info[i][len(MENU_DISABLED_CHARACTER):], menu=new_menu,
-                                             underline=pos, state='disabled')
+                        top_menu.add_cascade(
+                            label=sub_menu_info[i][len(MENU_DISABLED_CHARACTER) :],
+                            menu=new_menu,
+                            underline=pos,
+                            state='disabled',
+                        )
                     else:
                         top_menu.add_cascade(label=sub_menu_info[i], menu=new_menu, underline=pos)
-                    AddMenuItem(new_menu, sub_menu_info[i + 1], element, is_sub_menu=True, right_click_menu=right_click_menu)
+                    AddMenuItem(
+                        new_menu, sub_menu_info[i + 1], element, is_sub_menu=True, right_click_menu=right_click_menu
+                    )
                     i += 1  # skip the next one
                 else:
                     AddMenuItem(top_menu, item, element, right_click_menu=right_click_menu)
@@ -15200,31 +18741,49 @@ def _fixed_map(style, style_name, option, highlight_colors=(None, None)):
 
     # default_map = [elm for elm in style.map("Treeview", query_opt=option) if '!' not in elm[0]]
     # custom_map = [elm for elm in style.map(style_name, query_opt=option) if '!' not in elm[0]]
-    default_map = [elm for elm in style.map('Treeview', query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]]
-    custom_map = [elm for elm in style.map(style_name, query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]]
+    default_map = [
+        elm for elm in style.map('Treeview', query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]
+    ]
+    custom_map = [
+        elm for elm in style.map(style_name, query_opt=option) if '!' not in elm[0] and 'selected' not in elm[0]
+    ]
     if option == 'background':
-        custom_map.append(('selected', highlight_colors[1] if highlight_colors[1] is not None else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[1]))
+        custom_map.append(
+            (
+                'selected',
+                (
+                    highlight_colors[1]
+                    if highlight_colors[1] is not None
+                    else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[1]
+                ),
+            )
+        )
     elif option == 'foreground':
-        custom_map.append(('selected', highlight_colors[0] if highlight_colors[0] is not None else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[0]))
+        custom_map.append(
+            (
+                'selected',
+                (
+                    highlight_colors[0]
+                    if highlight_colors[0] is not None
+                    else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[0]
+                ),
+            )
+        )
 
     new_map = custom_map + default_map
     return new_map
-    #
-    # new_map = [elm for elm in style.map(style_name, query_opt=option) if elm[:2] != ('!disabled', '!selected')]
-    #
-    # if option == 'background':
-    #     new_map.append(('selected', highlight_colors[1] if highlight_colors[1] is not None else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[1]))
-    # elif option == 'foreground':
-    #     new_map.append(('selected', highlight_colors[0] if highlight_colors[0] is not None else ALTERNATE_TABLE_AND_TREE_SELECTED_ROW_COLORS[0]))
-    # return new_map
-    #
+
 
 def _add_right_click_menu(element, toplevel_form):
     if element.RightClickMenu == MENU_RIGHT_CLICK_DISABLED:
         return
     if element.RightClickMenu or toplevel_form.RightClickMenu:
         menu = element.RightClickMenu or toplevel_form.RightClickMenu
-        top_menu = tk.Menu(toplevel_form.TKroot, tearoff=toplevel_form.right_click_menu_tearoff, tearoffcommand=element._tearoff_menu_callback)
+        top_menu = tk.Menu(
+            toplevel_form.TKroot,
+            tearoff=toplevel_form.right_click_menu_tearoff,
+            tearoffcommand=element._tearoff_menu_callback,
+        )
 
         if toplevel_form.right_click_menu_background_color not in (COLOR_SYSTEM_DEFAULT, None):
             top_menu.config(bg=toplevel_form.right_click_menu_background_color)
@@ -15241,7 +18800,7 @@ def _add_right_click_menu(element, toplevel_form):
             top_menu.config(activebackground=toplevel_form.right_click_menu_selected_colors[1])
         AddMenuItem(top_menu, menu[1], element, right_click_menu=True)
         element.TKRightClickMenu = top_menu
-        if (running_mac()):
+        if running_mac():
             element.Widget.bind('<ButtonRelease-2>', element._RightClickMenuCallback)
         else:
             element.Widget.bind('<ButtonRelease-3>', element._RightClickMenuCallback)
@@ -15250,14 +18809,17 @@ def _add_right_click_menu(element, toplevel_form):
 def _change_ttk_theme(style, theme_name):
     global ttk_theme_in_use
     if theme_name not in style.theme_names():
-        _error_popup_with_traceback('You are trying to use TTK theme "{}"'.format(theme_name),
-                                        'This is not legal for your system',
-                                        'The valid themes to choose from are: {}'.format(', '.join(style.theme_names())))
+        _error_popup_with_traceback(
+            'You are trying to use TTK theme "{}"'.format(theme_name),
+            'This is not legal for your system',
+            'The valid themes to choose from are: {}'.format(', '.join(style.theme_names())),
+        )
         return False
 
     style.theme_use(theme_name)
     ttk_theme_in_use = theme_name
     return True
+
 
 # class Stylist:
 #     """
@@ -15300,6 +18862,7 @@ def _change_ttk_theme(style, theme_name):
 #         style.configure(ttkstyle, **kwargs)
 #         return ttkstyle
 
+
 def _make_ttk_style_name(base_style, element, primary_style=False):
     Window._counter_for_ttk_widgets += 1
     style_name = str(Window._counter_for_ttk_widgets) + '___' + str(element.Key) + base_style
@@ -15327,15 +18890,18 @@ def _make_ttk_scrollbar(element, orientation, window):
         style_name = _make_ttk_style_name('.Vertical.TScrollbar', element)
         # style_name_thumb = _make_ttk_style_name('.Vertical.TScrollbar.thumb', element)
         element.vsb_style = style
-        element.vsb = ttk.Scrollbar(element.element_frame, orient=orient, command=element.Widget.yview, style=style_name)
+        element.vsb = ttk.Scrollbar(
+            element.element_frame, orient=orient, command=element.Widget.yview, style=style_name
+        )
         element.vsb_style_name = style_name
     else:
         orient = 'horizontal'
         style_name = _make_ttk_style_name('.Horizontal.TScrollbar', element)
         element.hsb_style = style
-        element.hsb = ttk.Scrollbar(element.element_frame, orient=orient, command=element.Widget.xview, style=style_name)
+        element.hsb = ttk.Scrollbar(
+            element.element_frame, orient=orient, command=element.Widget.xview, style=style_name
+        )
         element.hsb_style_name = style_name
-
 
     # ------------------ Get the colors using heirarchy of element, window, options, settings ------------------
     # Trough Color
@@ -15402,7 +18968,6 @@ def _make_ttk_scrollbar(element, orientation, window):
     else:
         scroll_width = element.scroll_width
 
-
     if trough_color not in (None, COLOR_SYSTEM_DEFAULT):
         style.configure(style_name, troughcolor=trough_color)
 
@@ -15411,12 +18976,26 @@ def _make_ttk_scrollbar(element, orientation, window):
     if frame_color not in (None, COLOR_SYSTEM_DEFAULT):
         style.configure(style_name, bordercolor=frame_color)
 
-    if (background_color not in (None, COLOR_SYSTEM_DEFAULT)) and \
-        (arrow_color not in (None, COLOR_SYSTEM_DEFAULT)):
-        style.map(style_name, background=[('selected', background_color), ('active', arrow_color), ('background', background_color), ('!focus', background_color)])
-    if (background_color not in (None, COLOR_SYSTEM_DEFAULT)) and \
-        (arrow_color not in (None, COLOR_SYSTEM_DEFAULT)):
-        style.map(style_name, arrowcolor=[('selected', arrow_color), ('active', background_color), ('background', background_color),('!focus', arrow_color)])
+    if (background_color not in (None, COLOR_SYSTEM_DEFAULT)) and (arrow_color not in (None, COLOR_SYSTEM_DEFAULT)):
+        style.map(
+            style_name,
+            background=[
+                ('selected', background_color),
+                ('active', arrow_color),
+                ('background', background_color),
+                ('!focus', background_color),
+            ],
+        )
+    if (background_color not in (None, COLOR_SYSTEM_DEFAULT)) and (arrow_color not in (None, COLOR_SYSTEM_DEFAULT)):
+        style.map(
+            style_name,
+            arrowcolor=[
+                ('selected', arrow_color),
+                ('active', background_color),
+                ('background', background_color),
+                ('!focus', arrow_color),
+            ],
+        )
 
     if scroll_width not in (None, COLOR_SYSTEM_DEFAULT):
         style.configure(style_name, width=scroll_width)
@@ -15425,6 +19004,7 @@ def _make_ttk_scrollbar(element, orientation, window):
 
     if scroll_relief not in (None, COLOR_SYSTEM_DEFAULT):
         style.configure(style_name, relief=scroll_relief)
+
 
 # if __name__ == '__main__':
 #     root = tk.Tk()
@@ -15440,6 +19020,7 @@ def _make_ttk_scrollbar(element, orientation, window):
 #     ttk.Frame(style=frame_style, width=100, height=100).pack(padx=10, pady=10)
 #
 #     root.mainloop()
+
 
 # @_timeit
 def PackFormIntoFrame(form, containing_frame, toplevel_form):
@@ -15514,25 +19095,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
     def _string_width_in_pixels(font, string):
         return tkinter.font.Font(font=font).measure(string)  # single character width
 
-
-
-
-    # def _valid_theme(style, theme_name):
-    #     if theme_name in style.theme_names():
-    #         return True
-    #     _error_popup_with_traceback('Your Window has an invalid ttk theme specified',
-    #                                 'The traceback will show you the Window with the problem layout',
-    #                                 '** Invalid ttk theme specified {} **'.format(theme_name),
-    #                                 '\nValid choices include: {}'.format(style.theme_names()))
-    #
-    #     # print('** Invalid ttk theme specified {} **'.format(theme_name),
-    #     #       '\nValid choices include: {}'.format(style.theme_names()))
-    #     return False
-
-
-
     def _add_grab(element):
-
         try:
             if form.Grab is True or element.Grab is True:
                 # if something already about to the button, then don't do the grab stuff
@@ -15547,14 +19110,16 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.TKColFrame.canvas.bind('<ButtonPress-1>', toplevel_form._StartMoveGrabAnywhere)
                     element.TKColFrame.canvas.bind('<ButtonRelease-1>', toplevel_form._StopMove)
                     element.TKColFrame.canvas.bind('<B1-Motion>', toplevel_form._OnMotionGrabAnywhere)
-        except Exception as e:
+        except Exception:
             pass
             # print(e)
 
     def _add_right_click_menu_and_grab(element):
         if element.RightClickMenu == MENU_RIGHT_CLICK_DISABLED:
             return
-        if element.Type == ELEM_TYPE_TAB_GROUP:   # unless everything disabled, then need to always set a right click menu for tabgroups
+        if (
+            element.Type == ELEM_TYPE_TAB_GROUP
+        ):  # unless everything disabled, then need to always set a right click menu for tabgroups
             if toplevel_form.RightClickMenu == MENU_RIGHT_CLICK_DISABLED:
                 return
             menu = _MENU_RIGHT_CLICK_TABGROUP_DEFAULT
@@ -15562,7 +19127,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             menu = element.RightClickMenu or form.RightClickMenu or toplevel_form.RightClickMenu
 
         if menu:
-            top_menu = tk.Menu(toplevel_form.TKroot, tearoff=toplevel_form.right_click_menu_tearoff, tearoffcommand=element._tearoff_menu_callback)
+            top_menu = tk.Menu(
+                toplevel_form.TKroot,
+                tearoff=toplevel_form.right_click_menu_tearoff,
+                tearoffcommand=element._tearoff_menu_callback,
+            )
 
             if toplevel_form.right_click_menu_background_color not in (COLOR_SYSTEM_DEFAULT, None):
                 top_menu.config(bg=toplevel_form.right_click_menu_background_color)
@@ -15579,14 +19148,16 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 top_menu.config(activebackground=toplevel_form.right_click_menu_selected_colors[1])
             AddMenuItem(top_menu, menu[1], element, right_click_menu=True)
             element.TKRightClickMenu = top_menu
-            if toplevel_form.RightClickMenu:            # if the top level has a right click menu, then setup a callback for the Window itself
+            if (
+                toplevel_form.RightClickMenu
+            ):  # if the top level has a right click menu, then setup a callback for the Window itself
                 if toplevel_form.TKRightClickMenu is None:
                     toplevel_form.TKRightClickMenu = top_menu
-                    if (running_mac()):
+                    if running_mac():
                         toplevel_form.TKroot.bind('<ButtonRelease-2>', toplevel_form._RightClickMenuCallback)
                     else:
                         toplevel_form.TKroot.bind('<ButtonRelease-3>', toplevel_form._RightClickMenuCallback)
-            if (running_mac()):
+            if running_mac():
                 element.Widget.bind('<ButtonRelease-2>', element._RightClickMenuCallback)
             else:
                 element.Widget.bind('<ButtonRelease-3>', element._RightClickMenuCallback)
@@ -15597,7 +19168,6 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     pass
         _add_grab(element)
 
-
     def _add_expansion(element, row_should_expand, row_fill_direction):
         expand = True
         if element.expand_x and element.expand_y:
@@ -15606,10 +19176,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             row_should_expand = True
         elif element.expand_x:
             fill = tk.X
-            row_fill_direction = tk.X if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.Y else tk.X
+            row_fill_direction = (
+                tk.X if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.Y else tk.X
+            )
         elif element.expand_y:
             fill = tk.Y
-            row_fill_direction = tk.Y if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.X else tk.Y
+            row_fill_direction = (
+                tk.Y if row_fill_direction == tk.NONE else tk.BOTH if row_fill_direction == tk.X else tk.Y
+            )
             row_should_expand = True
         else:
             fill = tk.NONE
@@ -15617,7 +19191,6 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
         return expand, fill, row_should_expand, row_fill_direction
 
     tclversion_detailed = tkinter.Tcl().eval('info patchlevel')
-
 
     # --------------------------------------------------------------------------- #
     # ****************  Use FlexForm to build the tkinter window ********** ----- #
@@ -15664,10 +19237,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             # element.pad_used = elementpad  # store the value used back into the element
             # Determine Element size
             element_size = element.Size
-            if (element_size == (None, None) and element_type not in (
-                    ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU)):  # user did not specify a size
+            if element_size == (None, None) and element_type not in (
+                ELEM_TYPE_BUTTON,
+                ELEM_TYPE_BUTTONMENU,
+            ):  # user did not specify a size
                 element_size = toplevel_form.DefaultElementSize
-            elif (element_size == (None, None) and element_type in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU)):
+            elif element_size == (None, None) and element_type in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU):
                 element_size = toplevel_form.DefaultButtonElementSize
             else:
                 auto_size_text = False  # if user has specified a size then it shouldn't autosize
@@ -15684,26 +19259,35 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element = element  # type: Column
                 # ----------------------- SCROLLABLE Column ----------------------
                 if element.Scrollable:
-                    element.Widget = element.TKColFrame = TkScrollableFrame(tk_row_frame, element.VerticalScrollOnly, element, toplevel_form)  # do not use yet!  not working
+                    element.Widget = element.TKColFrame = TkScrollableFrame(
+                        tk_row_frame, element.VerticalScrollOnly, element, toplevel_form
+                    )  # do not use yet!  not working
                     PackFormIntoFrame(element, element.TKColFrame.TKFrame, toplevel_form)
                     element.TKColFrame.TKFrame.update()
                     if element.Size == (None, None):  # if no size specified, use column width x column height/2
-                        element.TKColFrame.canvas.config(width=element.TKColFrame.TKFrame.winfo_reqwidth() // element.size_subsample_width,
-                                                         height=element.TKColFrame.TKFrame.winfo_reqheight() // element.size_subsample_height)
+                        element.TKColFrame.canvas.config(
+                            width=element.TKColFrame.TKFrame.winfo_reqwidth() // element.size_subsample_width,
+                            height=element.TKColFrame.TKFrame.winfo_reqheight() // element.size_subsample_height,
+                        )
                     else:
-                        element.TKColFrame.canvas.config(width=element.TKColFrame.TKFrame.winfo_reqwidth() // element.size_subsample_width,
-                                                         height=element.TKColFrame.TKFrame.winfo_reqheight() // element.size_subsample_height)
+                        element.TKColFrame.canvas.config(
+                            width=element.TKColFrame.TKFrame.winfo_reqwidth() // element.size_subsample_width,
+                            height=element.TKColFrame.TKFrame.winfo_reqheight() // element.size_subsample_height,
+                        )
                         if None not in (element.Size[0], element.Size[1]):
                             element.TKColFrame.canvas.config(width=element.Size[0], height=element.Size[1])
                         elif element.Size[1] is not None:
                             element.TKColFrame.canvas.config(height=element.Size[1])
                         elif element.Size[0] is not None:
                             element.TKColFrame.canvas.config(width=element.Size[0])
-                    if not element.BackgroundColor in (None, COLOR_SYSTEM_DEFAULT):
+                    if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                         element.TKColFrame.canvas.config(background=element.BackgroundColor)
-                        element.TKColFrame.TKFrame.config(background=element.BackgroundColor, borderwidth=0, highlightthickness=0)
-                        element.TKColFrame.config(background=element.BackgroundColor, borderwidth=0,
-                                                  highlightthickness=0)
+                        element.TKColFrame.TKFrame.config(
+                            background=element.BackgroundColor, borderwidth=0, highlightthickness=0
+                        )
+                        element.TKColFrame.config(
+                            background=element.BackgroundColor, borderwidth=0, highlightthickness=0
+                        )
                 # ----------------------- PLAIN Column ----------------------
                 else:
                     if element.Size != (None, None):
@@ -15716,14 +19300,18 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             element.TKColFrame.canvas.config(height=element.Size[1])
                         elif element.Size[0] is not None:
                             element.TKColFrame.canvas.config(width=element.Size[0])
-                        if not element.BackgroundColor in (None, COLOR_SYSTEM_DEFAULT):
+                        if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                             element.TKColFrame.canvas.config(background=element.BackgroundColor)
-                            element.TKColFrame.TKFrame.config(background=element.BackgroundColor, borderwidth=0, highlightthickness=0)
+                            element.TKColFrame.TKFrame.config(
+                                background=element.BackgroundColor, borderwidth=0, highlightthickness=0
+                            )
                     else:
                         element.Widget = element.TKColFrame = tk.Frame(tk_row_frame)
                         PackFormIntoFrame(element, element.TKColFrame, toplevel_form)
                         if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
-                            element.TKColFrame.config(background=element.BackgroundColor, borderwidth=0, highlightthickness=0)
+                            element.TKColFrame.config(
+                                background=element.BackgroundColor, borderwidth=0, highlightthickness=0
+                            )
 
                 if element.Justification is None:
                     pass
@@ -15765,9 +19353,13 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         anchor = tk.CENTER
                     if element.VerticalAlignment.lower().startswith('b'):
                         anchor = tk.S
-                    element.TKColFrame.pack(side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
+                    element.TKColFrame.pack(
+                        side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
+                    )
                 else:
-                    element.TKColFrame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
+                    element.TKColFrame.pack(
+                        side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
+                    )
 
                 # element.TKColFrame.pack(side=side, padx=elementpad[0], pady=elementpad[1], expand=True, fill='both')
                 if element.visible is False:
@@ -15781,12 +19373,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             # -------------------------  Pane placement element  ------------------------- #
             if element_type == ELEM_TYPE_PANE:
                 bd = element.BorderDepth if element.BorderDepth is not None else border_depth
-                element.PanedWindow = element.Widget = tk.PanedWindow(tk_row_frame,
-                                                                      orient=tk.VERTICAL if element.Orientation.startswith(
-                                                                          'v') else tk.HORIZONTAL,
-                                                                      borderwidth=bd,
-                                                                      bd=bd,
-                                                                      )
+                element.PanedWindow = element.Widget = tk.PanedWindow(
+                    tk_row_frame,
+                    orient=tk.VERTICAL if element.Orientation.startswith('v') else tk.HORIZONTAL,
+                    borderwidth=bd,
+                    bd=bd,
+                )
                 if element.Relief is not None:
                     element.PanedWindow.configure(relief=element.Relief)
                 element.PanedWindow.configure(handlesize=element.HandleSize)
@@ -15803,10 +19395,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     if pane.visible:
                         element.PanedWindow.add(pane.TKColFrame)
                     if pane.BackgroundColor != COLOR_SYSTEM_DEFAULT and pane.BackgroundColor is not None:
-                        pane.TKColFrame.configure(background=pane.BackgroundColor,
-                                                  highlightbackground=pane.BackgroundColor,
-                                                  highlightcolor=pane.BackgroundColor)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                        pane.TKColFrame.configure(
+                            background=pane.BackgroundColor,
+                            highlightbackground=pane.BackgroundColor,
+                            highlightcolor=pane.BackgroundColor,
+                        )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element.PanedWindow.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 # element.PanedWindow.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=True, fill='both')
                 if element.visible is False:
@@ -15821,14 +19417,6 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     width, height = element_size
                 else:
                     width, height = None, None
-                    # lines = display_text.split('\n')
-                    # max_line_len = max([len(l) for l in lines])
-                    # num_lines = len(lines)
-                    # if max_line_len > element_size[0]:  # if text exceeds element size, the will have to wrap
-                    #     width = element_size[0]
-                    # else:
-                    #     width = max_line_len
-                    # height = num_lines
                 # ---===--- LABEL widget create and place --- #
                 element = element  # type: Text
                 bd = element.BorderWidth if element.BorderWidth is not None else border_depth
@@ -15843,13 +19431,20 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = tk.LEFT if justification.startswith('l') else tk.CENTER if justification.startswith('c') else tk.RIGHT
+                justify = (
+                    tk.LEFT
+                    if justification.startswith('l')
+                    else tk.CENTER if justification.startswith('c') else tk.RIGHT
+                )
                 anchor = tk.NW if justification.startswith('l') else tk.N if justification.startswith('c') else tk.NE
-                tktext_label = element.Widget = tk.Label(tk_row_frame, textvariable=stringvar, width=width,
-                                                         height=height, justify=justify, bd=bd, font=font)
+                tktext_label = element.Widget = tk.Label(
+                    tk_row_frame, textvariable=stringvar, width=width, height=height, justify=justify, bd=bd, font=font
+                )
                 # Set wrap-length for text (in PIXELS) == PAIN IN THE ASS
                 wraplen = tktext_label.winfo_reqwidth()  # width of widget in Pixels
-                if auto_size_text or (not auto_size_text and height == 1):  # if just 1 line high, ensure no wrap happens
+                if auto_size_text or (
+                    not auto_size_text and height == 1
+                ):  # if just 1 line high, ensure no wrap happens
                     wraplen = 0
                 tktext_label.configure(anchor=anchor, wraplen=wraplen)  # set wrap to width of widget
                 if element.Relief is not None:
@@ -15858,7 +19453,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tktext_label.configure(background=element.BackgroundColor)
                 if element.TextColor != COLOR_SYSTEM_DEFAULT and element.TextColor is not None:
                     tktext_label.configure(fg=element.TextColor)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 tktext_label.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -15872,8 +19469,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Grab:
                     element._grab_anywhere_on()
             # -------------------------  BUTTON placement element non-ttk version  ------------------------- #
-            elif (element_type == ELEM_TYPE_BUTTON and element.UseTtkButtons is False) or \
-                    (element_type == ELEM_TYPE_BUTTON and element.UseTtkButtons is not True and toplevel_form.UseTtkButtons is not True):
+            elif (element_type == ELEM_TYPE_BUTTON and element.UseTtkButtons is False) or (
+                element_type == ELEM_TYPE_BUTTON
+                and element.UseTtkButtons is not True
+                and toplevel_form.UseTtkButtons is not True
+            ):
                 element = element  # type: Button
                 element.UseTtkButtons = False  # indicate that ttk button was not used
                 stringvar = tk.StringVar()
@@ -15903,16 +19503,18 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     pos = btext.find(MENU_SHORTCUT_CHARACTER)
                     if pos != -1:
                         if pos < len(MENU_SHORTCUT_CHARACTER) or btext[pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                            btext = btext[:pos] + btext[pos + len(MENU_SHORTCUT_CHARACTER):]
+                            btext = btext[:pos] + btext[pos + len(MENU_SHORTCUT_CHARACTER) :]
                         else:
-                            btext = btext.replace('\\'+MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
+                            btext = btext.replace('\\' + MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
                             pos = -1
-                tkbutton = element.Widget = tk.Button(tk_row_frame, text=btext, width=width, height=height, justify=tk.CENTER, bd=bd, font=font)
+                tkbutton = element.Widget = tk.Button(
+                    tk_row_frame, text=btext, width=width, height=height, justify=tk.CENTER, bd=bd, font=font
+                )
                 if pos != -1:
                     tkbutton.config(underline=pos)
                 try:
                     if btype != BUTTON_TYPE_REALTIME:
-                        tkbutton.config( command=element.ButtonCallBack)
+                        tkbutton.config(command=element.ButtonCallBack)
 
                     else:
                         tkbutton.bind('<ButtonRelease-1>', element.ButtonReleaseCallBack)
@@ -15925,13 +19527,15 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         if bc[1] != COLOR_SYSTEM_DEFAULT:
                             tkbutton.config(background=bc[1])
                 except Exception as e:
-                    _error_popup_with_traceback('Button has a problem....',
-                                                'The traceback information will not show the line in your layout with the problem, but it does tell you which window.',
-                                                'Error {}'.format(e),
-                                                # 'Button Text: {}'.format(btext),
-                                                # 'Button key: {}'.format(element.Key),
-                                                # 'Color string: {}'.format(bc),
-                                                "Parent Window's Title: {}".format(toplevel_form.Title))
+                    _error_popup_with_traceback(
+                        'Button has a problem....',
+                        'The traceback information will not show the line in your layout with the problem, but it does tell you which window.',
+                        'Error {}'.format(e),
+                        # 'Button Text: {}'.format(btext),
+                        # 'Button key: {}'.format(element.Key),
+                        # 'Color string: {}'.format(bc),
+                        "Parent Window's Title: {}".format(toplevel_form.Title),
+                    )
 
                 if bd == 0 and not running_mac():
                     tkbutton.config(relief=tk.FLAT)
@@ -15954,10 +19558,13 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         else:
                             width, height = photo.width(), photo.height()
                     except Exception as e:
-                        _error_popup_with_traceback('Button Element error {}'.format(e), 'Image filename: {}'.format(element.ImageFilename),
-                                                     'NOTE - file format must be PNG or GIF!',
-                                                    'Button element key: {}'.format(element.Key),
-                                                    "Parent Window's Title: {}".format(toplevel_form.Title))
+                        _error_popup_with_traceback(
+                            'Button Element error {}'.format(e),
+                            'Image filename: {}'.format(element.ImageFilename),
+                            'NOTE - file format must be PNG or GIF!',
+                            'Button element key: {}'.format(element.Key),
+                            "Parent Window's Title: {}".format(toplevel_form.Title),
+                        )
                     tkbutton.config(image=photo, compound=tk.CENTER, width=width, height=height)
                     tkbutton.image = photo
                 if element.ImageData:  # if button has an image on it
@@ -15975,15 +19582,19 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         tkbutton.config(image=photo, compound=tk.CENTER, width=width, height=height)
                         tkbutton.image = photo
                     except Exception as e:
-                        _error_popup_with_traceback('Button Element error {}'.format(e),
-                                                    'Problem using BASE64 Image data Image Susample',
-                                                    'Buton element key: {}'.format(element.Key),
-                                                    "Parent Window's Title: {}".format(toplevel_form.Title))
+                        _error_popup_with_traceback(
+                            'Button Element error {}'.format(e),
+                            'Problem using BASE64 Image data Image Susample',
+                            'Buton element key: {}'.format(element.Key),
+                            "Parent Window's Title: {}".format(toplevel_form.Title),
+                        )
 
                 if width != 0:
                     wraplen = width * _char_width_in_pixels(font)
                     tkbutton.configure(wraplength=wraplen)  # set wrap to width of widget
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
 
                 tkbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
@@ -15998,7 +19609,10 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     toplevel_form.TKroot.focus_force()
                 if element.Disabled is True:
                     element.TKButton['state'] = 'disabled'
-                if element.DisabledButtonColor != (None, None) and element.DisabledButtonColor != (COLOR_SYSTEM_DEFAULT, COLOR_SYSTEM_DEFAULT):
+                if element.DisabledButtonColor != (None, None) and element.DisabledButtonColor != (
+                    COLOR_SYSTEM_DEFAULT,
+                    COLOR_SYSTEM_DEFAULT,
+                ):
                     if element.DisabledButtonColor[0] not in (None, COLOR_SYSTEM_DEFAULT):
                         element.TKButton['disabledforeground'] = element.DisabledButtonColor[0]
                 if element.MouseOverColors[1] not in (COLOR_SYSTEM_DEFAULT, None):
@@ -16007,19 +19621,22 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkbutton.config(activeforeground=element.MouseOverColors[0])
 
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKButton, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 try:
                     if element.HighlightColors[1] != COLOR_SYSTEM_DEFAULT:
                         tkbutton.config(highlightbackground=element.HighlightColors[1])
                     if element.HighlightColors[0] != COLOR_SYSTEM_DEFAULT:
                         tkbutton.config(highlightcolor=element.HighlightColors[0])
                 except Exception as e:
-                    _error_popup_with_traceback('Button Element error {}'.format(e),
-                                                'Button element key: {}'.format(element.Key),
-                                                'Button text: {}'.format(btext),
-                                                'Has a bad highlight color {}'.format(element.HighlightColors),
-                                                "Parent Window's Title: {}".format(toplevel_form.Title))
+                    _error_popup_with_traceback(
+                        'Button Element error {}'.format(e),
+                        'Button element key: {}'.format(element.Key),
+                        'Button text: {}'.format(btext),
+                        'Has a bad highlight color {}'.format(element.HighlightColors),
+                        "Parent Window's Title: {}".format(toplevel_form.Title),
+                    )
                     # print('Button with text: ', btext, 'has a bad highlight color', element.HighlightColors)
                 _add_right_click_menu_and_grab(element)
 
@@ -16036,9 +19653,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     pos = btext.find(MENU_SHORTCUT_CHARACTER)
                     if pos != -1:
                         if pos < len(MENU_SHORTCUT_CHARACTER) or btext[pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                            btext = btext[:pos] + btext[pos + len(MENU_SHORTCUT_CHARACTER):]
+                            btext = btext[:pos] + btext[pos + len(MENU_SHORTCUT_CHARACTER) :]
                         else:
-                            btext = btext.replace('\\'+MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
+                            btext = btext.replace('\\' + MENU_SHORTCUT_CHARACTER, MENU_SHORTCUT_CHARACTER)
                             pos = -1
                 btype = element.BType
                 if element.AutoSizeButton is not None:
@@ -16096,9 +19713,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     button_style.map(style_name, background=[('disabled', element.DisabledButtonColor[1])])
 
                 if height > 1:
-                    button_style.configure(style_name, padding=height * _char_height_in_pixels(font))  # should this be height instead?
+                    button_style.configure(
+                        style_name, padding=height * _char_height_in_pixels(font)
+                    )  # should this be height instead?
                 if width != 0:
-                    wraplen = width * _char_width_in_pixels(font) # width of widget in Pixels
+                    wraplen = width * _char_width_in_pixels(font)  # width of widget in Pixels
                     button_style.configure(style_name, wraplength=wraplen)  # set wrap to width of widget
 
                 ## -------------- TTK Button With Image -------------- ##
@@ -16134,7 +19753,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkbutton.image = photo
 
                 element.TKButton = tkbutton  # not used yet but save the TK button in case
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 tkbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -16153,8 +19774,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 _add_right_click_menu_and_grab(element)
 
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKButton, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
             # -------------------------  BUTTONMENU placement element  ------------------------- #
             elif element_type == ELEM_TYPE_BUTTONMENU:
                 element = element  # type: ButtonMenu
@@ -16178,7 +19800,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 bd = element.BorderWidth
                 if element.ItemFont is None:
                     element.ItemFont = font
-                tkbutton = element.Widget = tk.Menubutton(tk_row_frame, text=btext, width=width, height=height, justify=tk.LEFT, bd=bd, font=font)
+                tkbutton = element.Widget = tk.Menubutton(
+                    tk_row_frame, text=btext, width=width, height=height, justify=tk.LEFT, bd=bd, font=font
+                )
                 element.TKButtonMenu = tkbutton
                 if bc != (None, None) and bc != COLOR_SYSTEM_DEFAULT and bc[1] != COLOR_SYSTEM_DEFAULT:
                     tkbutton.config(foreground=bc[0], background=bc[1])
@@ -16220,12 +19844,19 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkbutton.image = photo
                 if width != 0:
                     tkbutton.configure(wraplength=wraplen + 10)  # set wrap to width of widget
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 tkbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
 
                 menu_def = element.MenuDefinition
 
-                element.TKMenu = top_menu = tk.Menu(tkbutton, tearoff=element.Tearoff, font=element.ItemFont, tearoffcommand=element._tearoff_menu_callback)
+                element.TKMenu = top_menu = tk.Menu(
+                    tkbutton,
+                    tearoff=element.Tearoff,
+                    font=element.ItemFont,
+                    tearoffcommand=element._tearoff_menu_callback,
+                )
 
                 if element.BackgroundColor not in (COLOR_SYSTEM_DEFAULT, None):
                     top_menu.config(bg=element.BackgroundColor)
@@ -16246,10 +19877,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # tkbutton.pack_forget()
-                if element.Disabled == True:
+                if element.Disabled:
                     element.TKButton['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKButton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
 
             # -------------------------  INPUT placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_TEXT:
@@ -16263,18 +19896,29 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     justification = element.Justification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = tk.LEFT if justification.startswith('l') else tk.CENTER if justification.startswith('c') else tk.RIGHT
+                justify = (
+                    tk.LEFT
+                    if justification.startswith('l')
+                    else tk.CENTER if justification.startswith('c') else tk.RIGHT
+                )
                 # anchor = tk.NW if justification == 'left' else tk.N if justification == 'center' else tk.NE
-                element.TKEntry = element.Widget = tk.Entry(tk_row_frame, width=element_size[0],
-                                                            textvariable=element.TKStringVar, bd=bd,
-                                                            font=font, show=show, justify=justify)
+                element.TKEntry = element.Widget = tk.Entry(
+                    tk_row_frame,
+                    width=element_size[0],
+                    textvariable=element.TKStringVar,
+                    bd=bd,
+                    font=font,
+                    show=show,
+                    justify=justify,
+                )
                 if element.ChangeSubmits:
                     element.TKEntry.bind('<Key>', element._KeyboardHandler)
                 element.TKEntry.bind('<Return>', element._ReturnKeyHandler)
 
-
                 if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
-                    element.TKEntry.configure(background=element.BackgroundColor, selectforeground=element.BackgroundColor)
+                    element.TKEntry.configure(
+                        background=element.BackgroundColor, selectforeground=element.BackgroundColor
+                    )
 
                 if text_color not in (None, COLOR_SYSTEM_DEFAULT):
                     element.TKEntry.configure(fg=text_color, selectbackground=text_color)
@@ -16291,7 +19935,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.Widget.config(highlightthickness=0)
                 # element.pack_keywords = {'side':tk.LEFT, 'padx':elementpad[0], 'pady':elementpad[1], 'expand':False, 'fill':tk.NONE }
                 # element.TKEntry.pack(**element.pack_keywords)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element.TKEntry.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -16313,7 +19959,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             # -------------------------  COMBO placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_COMBO:
                 element = element  # type: Combo
-                max_line_len = max([len(str(l)) for l in element.Values]) if len(element.Values) else 0
+                max_line_len = max([len(str(line)) for line in element.Values]) if len(element.Values) else 0
                 if auto_size_text is False:
                     width = element_size[0]
                 else:
@@ -16326,7 +19972,6 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 # Creates a unique name for each field element(Sure there is a better way to do this)
                 # unique_field = _make_ttk_style_name('.TCombobox.field', element)
-
 
                 # Set individual widget options
                 try:
@@ -16350,27 +19995,39 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                             combostyle.configure(style_name, selectbackground=element.BackgroundColor)
 
-
                 except Exception as e:
-                    _error_popup_with_traceback('Combo Element error {}'.format(e),
-                                                'Combo element key: {}'.format(element.Key),
-                                                'One of your colors is bad. Check the text, background, button background and button arrow colors',
-                                                "Parent Window's Title: {}".format(toplevel_form.Title))
+                    _error_popup_with_traceback(
+                        'Combo Element error {}'.format(e),
+                        'Combo element key: {}'.format(element.Key),
+                        'One of your colors is bad. Check the text, background, button background and button arrow colors',
+                        "Parent Window's Title: {}".format(toplevel_form.Title),
+                    )
 
                 # Strange code that is needed to set the font for the drop-down list
                 element._dropdown_newfont = tkinter.font.Font(font=font)
                 tk_row_frame.option_add('*TCombobox*Listbox*Font', element._dropdown_newfont)
 
-                element.TKCombo = element.Widget = ttk.Combobox(tk_row_frame, width=width, textvariable=element.TKStringVar, font=font, style=style_name)
+                element.TKCombo = element.Widget = ttk.Combobox(
+                    tk_row_frame, width=width, textvariable=element.TKStringVar, font=font, style=style_name
+                )
 
                 # make tcl call to deal with colors for the drop-down formatting
                 try:
-                    if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT) and \
-                        element.TextColor not in (None, COLOR_SYSTEM_DEFAULT):
+                    if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT) and element.TextColor not in (
+                        None,
+                        COLOR_SYSTEM_DEFAULT,
+                    ):
                         element.Widget.tk.eval(
-                    '[ttk::combobox::PopdownWindow {}].f.l configure -foreground {} -background {} -selectforeground {} -selectbackground {}'.format(element.Widget, element.TextColor, element.BackgroundColor, element.BackgroundColor, element.TextColor))
-                except Exception as e:
-                    pass    # going to let this one slide
+                            '[ttk::combobox::PopdownWindow {}].f.l configure -foreground {} -background {} -selectforeground {} -selectbackground {}'.format(
+                                element.Widget,
+                                element.TextColor,
+                                element.BackgroundColor,
+                                element.BackgroundColor,
+                                element.TextColor,
+                            )
+                        )
+                except Exception:
+                    pass  # going to let this one slide
 
                 # Chr0nic
                 element.TKCombo.bind('<Enter>', lambda event, em=element: testMouseHook2(em))
@@ -16383,19 +20040,15 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Size[1] != 1 and element.Size[1] is not None:
                     element.TKCombo.configure(height=element.Size[1])
                 element.TKCombo['values'] = element.Values
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element.TKCombo.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element.TKCombo.pack_forget()
                 if element.DefaultValue is not None:
                     element.TKCombo.set(element.DefaultValue)
-                    # for i, v in enumerate(element.Values):
-                    #     if v == element.DefaultValue:
-                    #         element.TKCombo.current(i)
-                    #         break
-                # elif element.Values:
-                #     element.TKCombo.current(0)
                 if element.ChangeSubmits:
                     element.TKCombo.bind('<<ComboboxSelected>>', element._ComboboxSelectHandler)
                 if element.BindReturnKey:
@@ -16412,7 +20065,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
             # -------------------------  OPTIONMENU placement Element (Like ComboBox but different) element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_OPTION_MENU:
-                max_line_len = max([len(str(l)) for l in element.Values])
+                max_line_len = max([len(str(line)) for line in element.Values])
                 if auto_size_text is False:
                     width = element_size[0]
                 else:
@@ -16420,7 +20073,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.TKStringVar = tk.StringVar()
                 if element.DefaultValue:
                     element.TKStringVar.set(element.DefaultValue)
-                element.TKOptionMenu = element.Widget = tk.OptionMenu(tk_row_frame, element.TKStringVar, *element.Values)
+                element.TKOptionMenu = element.Widget = tk.OptionMenu(
+                    tk_row_frame, element.TKStringVar, *element.Values
+                )
                 element.TKOptionMenu.config(highlightthickness=0, font=font, width=width)
                 element.TKOptionMenu['menu'].config(font=font)
                 element.TKOptionMenu.config(borderwidth=border_depth)
@@ -16430,20 +20085,25 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.TextColor != COLOR_SYSTEM_DEFAULT and element.TextColor is not None:
                     element.TKOptionMenu.configure(fg=element.TextColor)
                     element.TKOptionMenu['menu'].config(fg=element.TextColor)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
-                element.TKOptionMenu.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
+                element.TKOptionMenu.pack(
+                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
+                )
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element.TKOptionMenu.pack_forget()
-                if element.Disabled == True:
+                if element.Disabled is True:
                     element.TKOptionMenu['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKOptionMenu, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKOptionMenu, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
             # -------------------------  LISTBOX placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_LISTBOX:
                 element = element  # type: Listbox
-                max_line_len = max([len(str(l)) for l in element.Values]) if len(element.Values) else 0
+                max_line_len = max([len(str(line)) for line in element.Values]) if len(element.Values) else 0
                 if auto_size_text is False:
                     width = element_size[0]
                 else:
@@ -16461,8 +20121,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         justification = tk.CENTER
 
                 element.TKStringVar = tk.StringVar()
-                element.TKListbox = element.Widget = tk.Listbox(element_frame, height=element_size[1], width=width,
-                                                                selectmode=element.SelectMode, font=font, exportselection=False)
+                element.TKListbox = element.Widget = tk.Listbox(
+                    element_frame,
+                    height=element_size[1],
+                    width=width,
+                    selectmode=element.SelectMode,
+                    font=font,
+                    exportselection=False,
+                )
                 # On OLD versions of tkinter the justify option isn't available
                 try:
                     element.Widget.config(justify=justification)
@@ -16476,7 +20142,10 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         element.TKListbox.selection_set(index)
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element.TKListbox.configure(background=element.BackgroundColor)
-                if element.HighlightBackgroundColor is not None and element.HighlightBackgroundColor != COLOR_SYSTEM_DEFAULT:
+                if (
+                    element.HighlightBackgroundColor is not None
+                    and element.HighlightBackgroundColor != COLOR_SYSTEM_DEFAULT
+                ):
                     element.TKListbox.config(selectbackground=element.HighlightBackgroundColor)
                 if text_color is not None and text_color != COLOR_SYSTEM_DEFAULT:
                     element.TKListbox.configure(fg=text_color)
@@ -16501,32 +20170,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.Widget.bind('<Enter>', lambda event, em=element: testMouseHook(em))
                     element.Widget.bind('<Leave>', lambda event, em=element: testMouseUnhook(em))
 
-                # else:
-                #     element.TKText.config(wrap='word')
-
-                # if not element.NoScrollbar:
-                #     # Vertical scrollbar
-                #     element.vsb = tk.Scrollbar(element_frame, orient="vertical", command=element.TKListbox.yview)
-                #     element.TKListbox.configure(yscrollcommand=element.vsb.set)
-                #     element.vsb.pack(side=tk.RIGHT, fill='y')
-
-                # Horizontal scrollbar
-                # if element.HorizontalScroll:
-                #     hscrollbar = tk.Scrollbar(element_frame, orient=tk.HORIZONTAL)
-                #     hscrollbar.pack(side=tk.BOTTOM, fill='x')
-                #     hscrollbar.config(command=element.Widget.xview)
-                #     element.Widget.configure(xscrollcommand=hscrollbar.set)
-                #     element.hsb = hscrollbar
-                #
-                #     # Chr0nic
-                #     element.TKListbox.bind("<Enter>", lambda event, em=element: testMouseHook(em))
-                #     element.TKListbox.bind("<Leave>", lambda event, em=element: testMouseUnhook(em))
-                #
-                #
-
-
-
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand)
                 element.TKListbox.pack(side=tk.LEFT, fill=fill, expand=expand)
                 if element.visible is False:
@@ -16538,8 +20184,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Disabled is True:
                     element.TKListbox['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKListbox, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKListbox, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 _add_right_click_menu_and_grab(element)
             # -------------------------  MULTILINE placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_MULTILINE:
@@ -16549,7 +20196,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.element_frame = element_frame = tk.Frame(tk_row_frame)
 
                 # if element.no_scrollbar:
-                element.TKText = element.Widget = tk.Text(element_frame, width=width, height=height,  bd=bd, font=font, relief=RELIEF_SUNKEN)
+                element.TKText = element.Widget = tk.Text(
+                    element_frame, width=width, height=height, bd=bd, font=font, relief=RELIEF_SUNKEN
+                )
                 # else:
                 #     element.TKText = element.Widget = tk.scrolledtext.ScrolledText(element_frame, width=width, height=height, bd=bd, font=font, relief=RELIEF_SUNKEN)
 
@@ -16585,7 +20234,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.TKText.configure(fg=text_color, selectbackground=text_color)
                     element.TKText.config(insertbackground=text_color)
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
-                    element.TKText.configure(background=element.BackgroundColor, selectforeground=element.BackgroundColor)
+                    element.TKText.configure(
+                        background=element.BackgroundColor, selectforeground=element.BackgroundColor
+                    )
                 if element.selected_background_color not in (None, COLOR_SYSTEM_DEFAULT):
                     element.TKText.configure(selectbackground=element.selected_background_color)
                 if element.selected_text_color not in (None, COLOR_SYSTEM_DEFAULT):
@@ -16605,9 +20256,13 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.justification_tag = 'center'
                 # if DEFAULT_SCROLLBAR_COLOR not in (None, COLOR_SYSTEM_DEFAULT):               # only works on Linux so not including it
                 #     element.TKText.vbar.config(troughcolor=DEFAULT_SCROLLBAR_COLOR)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
 
-                element.element_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand)
+                element.element_frame.pack(
+                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand
+                )
                 element.Widget.pack(side=tk.LEFT, fill=fill, expand=expand)
 
                 if element.visible is False:
@@ -16624,7 +20279,6 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Focus is True or (toplevel_form.UseDefaultFocus and not toplevel_form.FocusSet):
                     toplevel_form.FocusSet = True
                     element.TKText.focus_set()
-
 
                 if element.Disabled is True:
                     element.TKText['state'] = 'disabled'
@@ -16650,17 +20304,24 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.TKIntVar = tk.IntVar()
                 element.TKIntVar.set(default_value if default_value is not None else 0)
 
-                element.TKCheckbutton = element.Widget = tk.Checkbutton(tk_row_frame, anchor=tk.NW,
-                                                                            text=element.Text, width=width,
-                                                                            variable=element.TKIntVar, bd=border_depth,
-                                                                            font=font)
+                element.TKCheckbutton = element.Widget = tk.Checkbutton(
+                    tk_row_frame,
+                    anchor=tk.NW,
+                    text=element.Text,
+                    width=width,
+                    variable=element.TKIntVar,
+                    bd=border_depth,
+                    font=font,
+                )
                 if element.ChangeSubmits:
                     element.TKCheckbutton.configure(command=element._CheckboxHandler)
                 if element.Disabled:
                     element.TKCheckbutton.configure(state='disable')
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element.TKCheckbutton.configure(background=element.BackgroundColor)
-                    element.TKCheckbutton.configure(selectcolor=element.CheckboxBackgroundColor)  # The background of the checkbox
+                    element.TKCheckbutton.configure(
+                        selectcolor=element.CheckboxBackgroundColor
+                    )  # The background of the checkbox
                     element.TKCheckbutton.configure(activebackground=element.BackgroundColor)
                 if text_color is not None and text_color != COLOR_SYSTEM_DEFAULT:
                     element.TKCheckbutton.configure(fg=text_color)
@@ -16671,14 +20332,19 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.TKCheckbutton.config(highlightbackground=element.BackgroundColor)
                 if element.TextColor != COLOR_SYSTEM_DEFAULT:
                     element.TKCheckbutton.config(highlightcolor=element.TextColor)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
-                element.TKCheckbutton.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
+                element.TKCheckbutton.pack(
+                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
+                )
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element.TKCheckbutton.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKCheckbutton, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKCheckbutton, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 _add_right_click_menu_and_grab(element)
 
             # -------------------------  PROGRESS placement element  ------------------------- #
@@ -16702,13 +20368,26 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 else:
                     base_style_name = '.Vertical.TProgressbar'
                 style_name = _make_ttk_style_name(base_style_name, element, primary_style=True)
-                element.TKProgressBar = TKProgressBar(tk_row_frame, element.MaxValue, progress_length, progress_width,
-                                                      orientation=direction, BarColor=bar_color,
-                                                      border_width=element.BorderWidth, relief=element.Relief,
-                                                      ttk_theme=toplevel_form.TtkTheme, key=element.Key, style_name=style_name)
+                element.TKProgressBar = TKProgressBar(
+                    tk_row_frame,
+                    element.MaxValue,
+                    progress_length,
+                    progress_width,
+                    orientation=direction,
+                    BarColor=bar_color,
+                    border_width=element.BorderWidth,
+                    relief=element.Relief,
+                    ttk_theme=toplevel_form.TtkTheme,
+                    key=element.Key,
+                    style_name=style_name,
+                )
                 element.Widget = element.TKProgressBar.TKProgressBarForReal
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
-                element.TKProgressBar.TKProgressBarForReal.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
+                element.TKProgressBar.TKProgressBarForReal.pack(
+                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
+                )
                 if element.visible is False:
                     element._pack_forget_save_settings(alternate_widget=element.TKProgressBar.TKProgressBarForReal)
                     # element.TKProgressBar.TKProgressBarForReal.pack_forget()
@@ -16721,8 +20400,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 default_value = element.InitialState
                 ID = element.GroupID
                 # see if ID has already been placed
-                value = EncodeRadioRowCol(form.ContainerElemementNumber, row_num,
-                                          col_num)  # value to set intvar to if this radio is selected
+                value = EncodeRadioRowCol(
+                    form.ContainerElemementNumber, row_num, col_num
+                )  # value to set intvar to if this radio is selected
                 element.EncodedRadioValue = value
                 if ID in toplevel_form.RadioDict:
                     RadVar = toplevel_form.RadioDict[ID]
@@ -16732,12 +20412,19 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.TKIntVar = RadVar  # store the RadVar in Radio object
                 if default_value:  # if this radio is the one selected, set RadVar to match
                     element.TKIntVar.set(value)
-                element.TKRadio = element.Widget = tk.Radiobutton(tk_row_frame, anchor=tk.NW, text=element.Text,
-                                                                  width=width, variable=element.TKIntVar, value=value,
-                                                                  bd=border_depth, font=font)
+                element.TKRadio = element.Widget = tk.Radiobutton(
+                    tk_row_frame,
+                    anchor=tk.NW,
+                    text=element.Text,
+                    width=width,
+                    variable=element.TKIntVar,
+                    value=value,
+                    bd=border_depth,
+                    font=font,
+                )
                 if element.ChangeSubmits:
                     element.TKRadio.configure(command=element._RadioHandler)
-                if not element.BackgroundColor in (None, COLOR_SYSTEM_DEFAULT):
+                if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                     element.TKRadio.configure(background=element.BackgroundColor)
                     element.TKRadio.configure(selectcolor=element.CircleBackgroundColor)
                     element.TKRadio.configure(activebackground=element.BackgroundColor)
@@ -16753,7 +20440,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 if element.Disabled:
                     element.TKRadio['state'] = 'disabled'
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element.TKRadio.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -16768,20 +20457,24 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 width, height = element_size
                 width = 0 if auto_size_text else element_size[0]
                 element.TKStringVar = tk.StringVar()
-                element.TKSpinBox = element.Widget = tk.Spinbox(tk_row_frame, values=element.Values, textvariable=element.TKStringVar, width=width, bd=border_depth)
+                element.TKSpinBox = element.Widget = tk.Spinbox(
+                    tk_row_frame, values=element.Values, textvariable=element.TKStringVar, width=width, bd=border_depth
+                )
                 if element.DefaultValue is not None:
                     element.TKStringVar.set(element.DefaultValue)
                 element.TKSpinBox.configure(font=font)  # set wrap to width of widget
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element.TKSpinBox.configure(background=element.BackgroundColor)
                     element.TKSpinBox.configure(buttonbackground=element.BackgroundColor)
-                if text_color  not in (None, COLOR_SYSTEM_DEFAULT):
+                if text_color not in (None, COLOR_SYSTEM_DEFAULT):
                     element.TKSpinBox.configure(fg=text_color)
                     element.TKSpinBox.config(insertbackground=text_color)
                 element.Widget.config(highlightthickness=0)
                 if element.wrap is True:
                     element.Widget.configure(wrap=True)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element.TKSpinBox.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
@@ -16796,7 +20489,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.Disabled is True:  # note overrides readonly if disabled
                     element.TKSpinBox['state'] = 'disabled'
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKSpinBox, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKSpinBox, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 if element.BindReturnKey:
                     element.TKSpinBox.bind('<Return>', element._SpinboxSelectHandler)
                 _add_right_click_menu_and_grab(element)
@@ -16819,35 +20514,46 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         # print('*ERROR laying out form.... Image Element has no image specified*')
                 except Exception as e:
                     photo = None
-                    _error_popup_with_traceback('Your Window has an Image Element with a problem',
-                                                'The traceback will show you the Window with the problem layout',
-                                                'Look in this Window\'s layout for an Image element that has a key of {}'.format(element.Key),
-                                                'The error occuring is:', e)
+                    _error_popup_with_traceback(
+                        'Your Window has an Image Element with a problem',
+                        'The traceback will show you the Window with the problem layout',
+                        'Look in this Window\'s layout for an Image element that has a key of {}'.format(element.Key),
+                        'The error occuring is:',
+                        e,
+                    )
 
                 element.tktext_label = element.Widget = tk.Label(tk_row_frame, bd=0)
 
                 if photo is not None:
-                    if element_size == (None, None) or element_size is None or element_size == toplevel_form.DefaultElementSize:
+                    if (
+                        element_size == (None, None)
+                        or element_size is None
+                        or element_size == toplevel_form.DefaultElementSize
+                    ):
                         width, height = photo.width(), photo.height()
                     else:
                         width, height = element_size
                     element.tktext_label.config(image=photo, width=width, height=height)
 
-
-                if not element.BackgroundColor in (None, COLOR_SYSTEM_DEFAULT):
+                if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                     element.tktext_label.config(background=element.BackgroundColor)
 
                 element.tktext_label.image = photo
                 # tktext_label.configure(anchor=tk.NW, image=photo)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
-                element.tktext_label.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
+                element.tktext_label.pack(
+                    side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
+                )
 
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element.tktext_label.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.tktext_label, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.tktext_label, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 if element.EnableEvents and element.tktext_label is not None:
                     element.tktext_label.bind('<ButtonPress-1>', element._ClickHandler)
 
@@ -16865,14 +20571,17 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     element._TKCanvas.configure(background=element.BackgroundColor, highlightthickness=0)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element._TKCanvas.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # element._TKCanvas.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element._TKCanvas, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element._TKCanvas, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 _add_right_click_menu_and_grab(element)
 
                 # -------------------------  Graph placement element  ------------------------- #
@@ -16884,9 +20593,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 #     element._TKCanvas = tk.Canvas(tk_row_frame, width=width, height=height, bd=border_depth)
                 # else:
                 #     element._TKCanvas.master = tk_row_frame
-                element._TKCanvas2 = element.Widget = tk.Canvas(tk_row_frame, width=width, height=height,
-                                                                bd=border_depth)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                element._TKCanvas2 = element.Widget = tk.Canvas(
+                    tk_row_frame, width=width, height=height, bd=border_depth
+                )
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element._TKCanvas2.pack(side=tk.LEFT, expand=expand, fill=fill)
                 element._TKCanvas2.addtag_all('mytag')
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
@@ -16897,8 +20609,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element._pack_forget_save_settings()
                     # element._TKCanvas2.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element._TKCanvas2, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element._TKCanvas2, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 if element.ChangeSubmits:
                     element._TKCanvas2.bind('<ButtonRelease-1>', element.ButtonReleaseCallBack)
                     element._TKCanvas2.bind('<ButtonPress-1>', element.ButtonPressCallBack)
@@ -16909,8 +20622,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             elif element_type == ELEM_TYPE_MENUBAR:
                 element = element  # type: MenuBar
                 menu_def = element.MenuDefinition
-                element.TKMenu = element.Widget = tk.Menu(toplevel_form.TKroot, tearoff=element.Tearoff,
-                                                          tearoffcommand=element._tearoff_menu_callback)  # create the menubar
+                element.TKMenu = element.Widget = tk.Menu(
+                    toplevel_form.TKroot, tearoff=element.Tearoff, tearoffcommand=element._tearoff_menu_callback
+                )  # create the menubar
                 menubar = element.TKMenu
                 if font is not None:  # if a font is used, make sure it's saved in the element
                     element.Font = font
@@ -16930,11 +20644,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     # print(pos)
                     if pos != -1:
                         if pos == 0 or menu_entry[0][pos - len(MENU_SHORTCUT_CHARACTER)] != '\\':
-                            menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + 1:]
+                            menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + 1 :]
                     if menu_entry[0][0] == MENU_DISABLED_CHARACTER:
-                        menubar.add_cascade(label=menu_entry[0][len(MENU_DISABLED_CHARACTER):], menu=baritem,
-                                            underline=pos - 1)
-                        menubar.entryconfig(menu_entry[0][len(MENU_DISABLED_CHARACTER):], state='disabled')
+                        menubar.add_cascade(
+                            label=menu_entry[0][len(MENU_DISABLED_CHARACTER) :], menu=baritem, underline=pos - 1
+                        )
+                        menubar.entryconfig(menu_entry[0][len(MENU_DISABLED_CHARACTER) :], state='disabled')
                     else:
                         menubar.add_cascade(label=menu_entry[0], menu=baritem, underline=pos)
 
@@ -16947,7 +20662,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 labeled_frame = element.Widget = tk.LabelFrame(tk_row_frame, text=element.Title, relief=element.Relief)
                 element.TKFrame = labeled_frame
                 PackFormIntoFrame(element, labeled_frame, toplevel_form)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 if element.VerticalAlignment is not None:
                     anchor = tk.CENTER  # Default to center if a bad choice is made
                     if element.VerticalAlignment.lower().startswith('t'):
@@ -16956,7 +20673,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         anchor = tk.CENTER
                     if element.VerticalAlignment.lower().startswith('b'):
                         anchor = tk.S
-                    labeled_frame.pack(side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
+                    labeled_frame.pack(
+                        side=tk.LEFT, anchor=anchor, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill
+                    )
                 else:
                     labeled_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
 
@@ -16967,9 +20686,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element._pack_forget_save_settings()
                     # labeled_frame.pack_forget()
                 if element.BackgroundColor != COLOR_SYSTEM_DEFAULT and element.BackgroundColor is not None:
-                    labeled_frame.configure(background=element.BackgroundColor,
-                                            highlightbackground=element.BackgroundColor,
-                                            highlightcolor=element.BackgroundColor)
+                    labeled_frame.configure(
+                        background=element.BackgroundColor,
+                        highlightbackground=element.BackgroundColor,
+                        highlightcolor=element.BackgroundColor,
+                    )
                 if element.TextColor != COLOR_SYSTEM_DEFAULT and element.TextColor is not None:
                     labeled_frame.configure(foreground=element.TextColor)
                 if font is not None:
@@ -16985,7 +20706,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             # -------------------------  Tab placement element  ------------------------- #
             elif element_type == ELEM_TYPE_TAB:
                 element = element  # type: Tab
-                form = form   # type: TabGroup
+                form = form  # type: TabGroup
                 element.TKFrame = element.Widget = tk.Frame(form.TKNotebook)
                 PackFormIntoFrame(element, element.TKFrame, toplevel_form)
                 state = 'normal'
@@ -17009,14 +20730,21 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         # print('*ERROR laying out form.... Image Element has no image specified*')
                 except Exception as e:
                     photo = None
-                    _error_popup_with_traceback('Your Window has an Tab Element with an IMAGE problem',
-                                                'The traceback will show you the Window with the problem layout',
-                                                'Look in this Window\'s layout for an Image element that has a key of {}'.format(element.Key),
-                                                'The error occuring is:', e)
+                    _error_popup_with_traceback(
+                        'Your Window has an Tab Element with an IMAGE problem',
+                        'The traceback will show you the Window with the problem layout',
+                        'Look in this Window\'s layout for an Image element that has a key of {}'.format(element.Key),
+                        'The error occuring is:',
+                        e,
+                    )
 
                 element.photo = photo
                 if photo is not None:
-                    if element_size == (None, None) or element_size is None or element_size == toplevel_form.DefaultElementSize:
+                    if (
+                        element_size == (None, None)
+                        or element_size is None
+                        or element_size == toplevel_form.DefaultElementSize
+                    ):
                         width, height = photo.width(), photo.height()
                     else:
                         width, height = element_size
@@ -17024,11 +20752,10 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 else:
                     element.tktext_label = tk.Label(tk_row_frame, bd=0)
                 if photo is not None:
-                    form.TKNotebook.add(element.TKFrame, text=element.Title, compound=tk.LEFT, state=state,image=photo)
+                    form.TKNotebook.add(element.TKFrame, text=element.Title, compound=tk.LEFT, state=state, image=photo)
 
                 # element.photo_image = tk.PhotoImage(data=DEFAULT_BASE64_ICON)
                 # form.TKNotebook.add(element.TKFrame, text=element.Title, compound=tk.LEFT, state=state,image = element.photo_image)
-
 
                 form.TKNotebook.add(element.TKFrame, text=element.Title, state=state)
                 # July 28 2022 removing the expansion and pack as a test
@@ -17037,10 +20764,16 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 element.ParentNotebook = form.TKNotebook
                 element.TabID = form.TabCount
-                form.tab_index_to_key[element.TabID] = element.key      # has a list of the tabs in the notebook and their associated key
+                form.tab_index_to_key[element.TabID] = (
+                    element.key
+                )  # has a list of the tabs in the notebook and their associated key
                 form.TabCount += 1
                 if element.BackgroundColor not in (COLOR_SYSTEM_DEFAULT, None):
-                    element.TKFrame.configure(background=element.BackgroundColor, highlightbackground=element.BackgroundColor, highlightcolor=element.BackgroundColor)
+                    element.TKFrame.configure(
+                        background=element.BackgroundColor,
+                        highlightbackground=element.BackgroundColor,
+                        highlightcolor=element.BackgroundColor,
+                    )
 
                 # if element.BorderWidth is not None:
                 #     element.TKFrame.configure(borderwidth=element.BorderWidth)
@@ -17057,9 +20790,20 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 _change_ttk_theme(style, toplevel_form.TtkTheme)
 
                 if element.TabLocation is not None:
-                    position_dict = {'left': 'w', 'right': 'e', 'top': 'n', 'bottom': 's', 'lefttop': 'wn',
-                                     'leftbottom': 'ws', 'righttop': 'en', 'rightbottom': 'es', 'bottomleft': 'sw',
-                                     'bottomright': 'se', 'topleft': 'nw', 'topright': 'ne'}
+                    position_dict = {
+                        'left': 'w',
+                        'right': 'e',
+                        'top': 'n',
+                        'bottom': 's',
+                        'lefttop': 'wn',
+                        'leftbottom': 'ws',
+                        'righttop': 'en',
+                        'rightbottom': 'es',
+                        'bottomleft': 'sw',
+                        'bottomright': 'se',
+                        'topleft': 'nw',
+                        'topright': 'ne',
+                    }
                     try:
                         tab_position = position_dict[element.TabLocation]
                     except:
@@ -17072,7 +20816,10 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 # FINALLY the proper styling to get tab colors!
                 if element.SelectedTitleColor is not None and element.SelectedTitleColor != COLOR_SYSTEM_DEFAULT:
                     style.map(custom_style + '.Tab', foreground=[('selected', element.SelectedTitleColor)])
-                if element.SelectedBackgroundColor is not None and element.SelectedBackgroundColor != COLOR_SYSTEM_DEFAULT:
+                if (
+                    element.SelectedBackgroundColor is not None
+                    and element.SelectedBackgroundColor != COLOR_SYSTEM_DEFAULT
+                ):
                     style.map(custom_style + '.Tab', background=[('selected', element.SelectedBackgroundColor)])
                 if element.TabBackgroundColor is not None and element.TabBackgroundColor != COLOR_SYSTEM_DEFAULT:
                     style.configure(custom_style + '.Tab', background=element.TabBackgroundColor)
@@ -17081,7 +20828,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.BorderWidth is not None:
                     style.configure(custom_style, borderwidth=element.BorderWidth)
                 if element.TabBorderWidth is not None:
-                    style.configure(custom_style + '.Tab', borderwidth=element.TabBorderWidth)       # if ever want to get rid of border around the TABS themselves
+                    style.configure(
+                        custom_style + '.Tab', borderwidth=element.TabBorderWidth
+                    )  # if ever want to get rid of border around the TABS themselves
                 if element.FocusColor not in (None, COLOR_SYSTEM_DEFAULT):
                     style.configure(custom_style + '.Tab', focuscolor=element.FocusColor)
 
@@ -17092,13 +20841,19 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 PackFormIntoFrame(element, toplevel_form.TKroot, toplevel_form)
 
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
-                element.TKNotebook.pack(anchor=tk.SW, side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
+                element.TKNotebook.pack(
+                    anchor=tk.SW, side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=fill, expand=expand
+                )
 
                 if element.ChangeSubmits:
                     element.TKNotebook.bind('<<NotebookTabChanged>>', element._TabGroupSelectHandler)
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKNotebook, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKNotebook, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 if element.Size != (None, None):
                     element.TKNotebook.configure(width=element.Size[0], height=element.Size[1])
                 _add_right_click_menu_and_grab(element)
@@ -17119,13 +20874,20 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 else:
                     range_from = element.Range[0]
                     range_to = element.Range[1]
-                tkscale = element.Widget = tk.Scale(tk_row_frame, orient=element.Orientation,
-                                                        variable=element.TKIntVar,
-                                                        from_=range_from, to_=range_to, resolution=element.Resolution,
-                                                        length=slider_length, width=slider_width,
-                                                        bd=element.BorderWidth,
-                                                        relief=element.Relief, font=font,
-                                                        tickinterval=element.TickInterval)
+                tkscale = element.Widget = tk.Scale(
+                    tk_row_frame,
+                    orient=element.Orientation,
+                    variable=element.TKIntVar,
+                    from_=range_from,
+                    to_=range_to,
+                    resolution=element.Resolution,
+                    length=slider_length,
+                    width=slider_width,
+                    bd=element.BorderWidth,
+                    relief=element.Relief,
+                    font=font,
+                    tickinterval=element.TickInterval,
+                )
                 tkscale.config(highlightthickness=0)
                 if element.ChangeSubmits:
                     tkscale.config(command=element._SliderChangedHandler)
@@ -17137,13 +20899,15 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     tkscale.config(showvalue=0)
                 if text_color not in (None, COLOR_SYSTEM_DEFAULT):
                     tkscale.configure(fg=text_color)
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 tkscale.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
                     element._pack_forget_save_settings()
                     # tkscale.pack_forget()
                 element.TKScale = tkscale
-                if element.Disabled == True:
+                if element.Disabled is True:
                     element.TKScale['state'] = 'disabled'
                 if element.Tooltip is not None:
                     element.TooltipObject = ToolTip(element.TKScale, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
@@ -17185,30 +20949,47 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 column_headings = element.ColumnHeadings if element.ColumnHeadings is not None else displaycolumns
                 if element.DisplayRowNumbers:  # if display row number, tack on the numbers to front of columns
-                    displaycolumns = [element.RowHeaderText, ] + displaycolumns
+                    displaycolumns = [
+                        element.RowHeaderText,
+                    ] + displaycolumns
                     if column_headings is not None:
-                        column_headings = [element.RowHeaderText, ] + element.ColumnHeadings
+                        column_headings = [
+                            element.RowHeaderText,
+                        ] + element.ColumnHeadings
                     else:
-                        column_headings = [element.RowHeaderText, ] + displaycolumns
-                element.TKTreeview = element.Widget = ttk.Treeview(frame, columns=column_headings,
-                                                                   displaycolumns=displaycolumns, show='headings',
-                                                                   height=height,
-                                                                   selectmode=element.SelectMode, )
+                        column_headings = [
+                            element.RowHeaderText,
+                        ] + displaycolumns
+                element.TKTreeview = element.Widget = ttk.Treeview(
+                    frame,
+                    columns=column_headings,
+                    displaycolumns=displaycolumns,
+                    show='headings',
+                    height=height,
+                    selectmode=element.SelectMode,
+                )
                 treeview = element.TKTreeview
                 if element.DisplayRowNumbers:
                     treeview.heading(element.RowHeaderText, text=element.RowHeaderText)  # make a dummy heading
-                    row_number_header_width =_string_width_in_pixels(element.HeaderFont, element.RowHeaderText) + 10
+                    row_number_header_width = _string_width_in_pixels(element.HeaderFont, element.RowHeaderText) + 10
                     row_number_width = _string_width_in_pixels(font, str(len(element.Values))) + 10
                     row_number_width = max(row_number_header_width, row_number_width)
-                    treeview.column(element.RowHeaderText, width=row_number_width, minwidth=10, anchor=anchor, stretch=0)
+                    treeview.column(
+                        element.RowHeaderText, width=row_number_width, minwidth=10, anchor=anchor, stretch=0
+                    )
 
                 headings = element.ColumnHeadings if element.ColumnHeadings is not None else element.Values[0]
                 for i, heading in enumerate(headings):
                     # heading = str(heading)
                     treeview.heading(heading, text=heading)
                     if element.AutoSizeColumns:
-                        col_width = column_widths.get(i, len(heading))      # in case more headings than there are columns of data
-                        width = max(col_width * _char_width_in_pixels(font), len(heading)*_char_width_in_pixels(element.HeaderFont))
+                        col_width = column_widths.get(
+                            i, len(heading)
+                        )  # in case more headings than there are columns of data
+                        width = max(
+                            col_width * _char_width_in_pixels(font),
+                            len(heading) * _char_width_in_pixels(element.HeaderFont),
+                        )
                     else:
                         try:
                             width = element.ColumnWidths[i] * _char_width_in_pixels(font)
@@ -17225,7 +21006,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             else:
                                 col_anchor = anchor
 
-                        except:             # likely didn't specify enough entries (must be one per col)
+                        except:  # likely didn't specify enough entries (must be one per col)
                             col_anchor = anchor
                     else:
                         col_anchor = anchor
@@ -17247,7 +21028,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             treeview.tag_configure(row_def[0], background=row_def[2], foreground=row_def[1])
                 # ------ Do Styling of Colors -----
                 # style_name = str(element.Key) + 'customtable.Treeview'
-                style_name = _make_ttk_style_name( '.Treeview', element, primary_style=True)
+                style_name = _make_ttk_style_name('.Treeview', element, primary_style=True)
                 element.table_ttk_style_name = style_name
                 table_style = ttk.Style()
                 element.ttk_style = table_style
@@ -17255,13 +21036,23 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 _change_ttk_theme(table_style, toplevel_form.TtkTheme)
 
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
-                    table_style.configure(style_name, background=element.BackgroundColor, fieldbackground=element.BackgroundColor, )
+                    table_style.configure(
+                        style_name,
+                        background=element.BackgroundColor,
+                        fieldbackground=element.BackgroundColor,
+                    )
                     if element.SelectedRowColors[1] is not None:
-                        table_style.map(style_name, background=_fixed_map(table_style, style_name, 'background', element.SelectedRowColors))
+                        table_style.map(
+                            style_name,
+                            background=_fixed_map(table_style, style_name, 'background', element.SelectedRowColors),
+                        )
                 if element.TextColor is not None and element.TextColor != COLOR_SYSTEM_DEFAULT:
                     table_style.configure(style_name, foreground=element.TextColor)
                     if element.SelectedRowColors[0] is not None:
-                        table_style.map(style_name, foreground=_fixed_map(table_style, style_name, 'foreground', element.SelectedRowColors))
+                        table_style.map(
+                            style_name,
+                            foreground=_fixed_map(table_style, style_name, 'foreground', element.SelectedRowColors),
+                        )
                 if element.RowHeight is not None:
                     table_style.configure(style_name, rowheight=element.RowHeight)
                 else:
@@ -17282,11 +21073,24 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.BorderWidth is not None:
                     table_style.configure(style_name, borderwidth=element.BorderWidth)
 
-                if element.HeaderBackgroundColor not in  (None, COLOR_SYSTEM_DEFAULT) and  element.HeaderTextColor not in  (None, COLOR_SYSTEM_DEFAULT):
-                    table_style.map(style_name + '.Heading', background=[('pressed', '!focus', element.HeaderBackgroundColor),
-                                                                         ('active', element.HeaderTextColor),])
-                    table_style.map(style_name + '.Heading', foreground=[('pressed', '!focus', element.HeaderTextColor),
-                                                                         ('active', element.HeaderBackgroundColor),])
+                if element.HeaderBackgroundColor not in (
+                    None,
+                    COLOR_SYSTEM_DEFAULT,
+                ) and element.HeaderTextColor not in (None, COLOR_SYSTEM_DEFAULT):
+                    table_style.map(
+                        style_name + '.Heading',
+                        background=[
+                            ('pressed', '!focus', element.HeaderBackgroundColor),
+                            ('active', element.HeaderTextColor),
+                        ],
+                    )
+                    table_style.map(
+                        style_name + '.Heading',
+                        foreground=[
+                            ('pressed', '!focus', element.HeaderTextColor),
+                            ('active', element.HeaderBackgroundColor),
+                        ],
+                    )
 
                 treeview.configure(style=style_name)
                 # scrollable_frame.pack(side=tk.LEFT,  padx=elementpad[0], pady=elementpad[1], expand=True, fill='both')
@@ -17301,9 +21105,6 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 if element.BindReturnKey:
                     treeview.bind('<Return>', element._treeview_double_click)
                     treeview.bind('<Double-Button-1>', element._treeview_double_click)
-
-
-
 
                 if not element.HideVerticalScroll:
                     _make_ttk_scrollbar(element, 'v', toplevel_form)
@@ -17323,41 +21124,29 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.Widget.bind('<Enter>', lambda event, em=element: testMouseHook(em))
                     element.Widget.bind('<Leave>', lambda event, em=element: testMouseUnhook(em))
 
-
-
-                # if not element.HideVerticalScroll:
-                #     scrollbar = tk.Scrollbar(frame)
-                #     scrollbar.pack(side=tk.RIGHT, fill='y')
-                #     scrollbar.config(command=treeview.yview)
-                #     treeview.configure(yscrollcommand=scrollbar.set)
-
-                # if not element.VerticalScrollOnly:
-                #     hscrollbar = tk.Scrollbar(frame, orient=tk.HORIZONTAL)
-                #     hscrollbar.pack(side=tk.BOTTOM, fill='x')
-                #     hscrollbar.config(command=treeview.xview)
-                #     treeview.configure(xscrollcommand=hscrollbar.set)
-
-
-
-
-
-
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element.TKTreeview.pack(side=tk.LEFT, padx=0, pady=0, expand=expand, fill=fill)
                 frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
-                    element._pack_forget_save_settings(alternate_widget=element.element_frame)       # seems like it should be the frame if following other elements conventions
+                    element._pack_forget_save_settings(
+                        alternate_widget=element.element_frame
+                    )  # seems like it should be the frame if following other elements conventions
                     # element.TKTreeview.pack_forget()
                 if element.Tooltip is not None:
-                    element.TooltipObject = ToolTip(element.TKTreeview, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKTreeview, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 _add_right_click_menu_and_grab(element)
 
                 if tclversion_detailed == '8.6.9' and ENABLE_TREEVIEW_869_PATCH:
                     # print('*** tk version 8.6.9 detected.... patching ttk treeview code ***')
-                    table_style.map(style_name,
-                                    foreground=_fixed_map(table_style, style_name, 'foreground', element.SelectedRowColors),
-                                    background=_fixed_map(table_style, style_name, 'background', element.SelectedRowColors))
+                    table_style.map(
+                        style_name,
+                        foreground=_fixed_map(table_style, style_name, 'foreground', element.SelectedRowColors),
+                        background=_fixed_map(table_style, style_name, 'background', element.SelectedRowColors),
+                    )
             # -------------------------  Tree placement element  ------------------------- #
             elif element_type == ELEM_TYPE_TREE:
                 element = element  # type: Tree
@@ -17380,11 +21169,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                             displaycolumns.append(element.ColumnHeadings[i])
                 column_headings = element.ColumnHeadings
                 # ------------- GET THE TREEVIEW WIDGET -------------
-                element.TKTreeview = element.Widget = ttk.Treeview(element_frame, columns=column_headings,
-                                                                   displaycolumns=displaycolumns,
-                                                                   show='tree headings' if column_headings is not None else 'tree',
-                                                                   height=height,
-                                                                   selectmode=element.SelectMode)
+                element.TKTreeview = element.Widget = ttk.Treeview(
+                    element_frame,
+                    columns=column_headings,
+                    displaycolumns=displaycolumns,
+                    show='tree headings' if column_headings is not None else 'tree',
+                    height=height,
+                    selectmode=element.SelectMode,
+                )
                 treeview = element.TKTreeview
                 max_widths = {}
                 for key, node in element.TreeData.tree_dict.items():
@@ -17399,7 +21191,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                         if element.AutoSizeColumns:
                             max_width = max_widths.get(i, 0)
                             max_width = max(max_width, len(heading))
-                            width = min(element.MaxColumnWidth, max_width+1)
+                            width = min(element.MaxColumnWidth, max_width + 1)
                         else:
                             try:
                                 width = element.ColumnWidths[i]
@@ -17427,13 +21219,28 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                             node.photo = photo
                             try:
-                                id = treeview.insert(element.KeyToID[node.parent], 'end', iid=None, text=node.text, values=node.values, open=element.ShowExpanded, image=node.photo)
+                                id = treeview.insert(
+                                    element.KeyToID[node.parent],
+                                    'end',
+                                    iid=None,
+                                    text=node.text,
+                                    values=node.values,
+                                    open=element.ShowExpanded,
+                                    image=node.photo,
+                                )
                                 element.IdToKey[id] = node.key
                                 element.KeyToID[node.key] = id
                             except Exception as e:
                                 print('Error inserting image into tree', e)
                         else:
-                            id = treeview.insert(element.KeyToID[node.parent], 'end', iid=None, text=node.text, values=node.values, open=element.ShowExpanded)
+                            id = treeview.insert(
+                                element.KeyToID[node.parent],
+                                'end',
+                                iid=None,
+                                text=node.text,
+                                values=node.values,
+                                open=element.ShowExpanded,
+                            )
                             element.IdToKey[id] = node.key
                             element.KeyToID[node.key] = id
 
@@ -17451,13 +21258,21 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 _change_ttk_theme(tree_style, toplevel_form.TtkTheme)
 
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
-                    tree_style.configure(style_name, background=element.BackgroundColor, fieldbackground=element.BackgroundColor)
+                    tree_style.configure(
+                        style_name, background=element.BackgroundColor, fieldbackground=element.BackgroundColor
+                    )
                     if element.SelectedRowColors[1] is not None:
-                        tree_style.map(style_name, background=_fixed_map(tree_style, style_name, 'background', element.SelectedRowColors))
+                        tree_style.map(
+                            style_name,
+                            background=_fixed_map(tree_style, style_name, 'background', element.SelectedRowColors),
+                        )
                 if element.TextColor is not None and element.TextColor != COLOR_SYSTEM_DEFAULT:
                     tree_style.configure(style_name, foreground=element.TextColor)
                     if element.SelectedRowColors[0] is not None:
-                        tree_style.map(style_name, foreground=_fixed_map(tree_style, style_name, 'foreground', element.SelectedRowColors))
+                        tree_style.map(
+                            style_name,
+                            foreground=_fixed_map(tree_style, style_name, 'foreground', element.SelectedRowColors),
+                        )
                 if element.HeaderTextColor is not None and element.HeaderTextColor != COLOR_SYSTEM_DEFAULT:
                     tree_style.configure(style_name + '.Heading', foreground=element.HeaderTextColor)
                 if element.HeaderBackgroundColor is not None and element.HeaderBackgroundColor != COLOR_SYSTEM_DEFAULT:
@@ -17480,8 +21295,6 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 treeview.configure(style=style_name)  # IMPORTANT! Be sure and set the style name for this widget
 
-
-
                 if not element.HideVerticalScroll:
                     _make_ttk_scrollbar(element, 'v', toplevel_form)
 
@@ -17496,50 +21309,33 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     element.Widget.configure(xscrollcommand=element.hsb.set)
 
                 if not element.HideVerticalScroll or not element.VerticalScrollOnly:
-                    # Chr0nic
                     element.Widget.bind('<Enter>', lambda event, em=element: testMouseHook(em))
                     element.Widget.bind('<Leave>', lambda event, em=element: testMouseUnhook(em))
 
-
-                # Horizontal scrollbar
-                # if not element.VerticalScrollOnly:
-                #     element.TKText.config(wrap='none')
-                #     _make_ttk_scrollbar(element, 'h')
-                #     element.hsb.pack(side=tk.BOTTOM, fill='x')
-                #     element.Widget.configure(xscrollcommand=element.hsb.set)
-
-                # if not element.HideVerticalScroll or not element.VerticalScrollOnly:
-                    # Chr0nic
-                # element.Widget.bind("<Enter>", lambda event, em=element: testMouseHook(em))
-                # element.Widget.bind("<Leave>", lambda event, em=element: testMouseUnhook(em))
-
-
-
-
-
-                # element.scrollbar = scrollbar = tk.Scrollbar(element_frame)
-                # scrollbar.pack(side=tk.RIGHT, fill='y')
-                # scrollbar.config(command=treeview.yview)
-                # treeview.configure(yscrollcommand=scrollbar.set)
-
-
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
                 element.TKTreeview.pack(side=tk.LEFT, padx=0, pady=0, expand=expand, fill=fill)
                 element_frame.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], expand=expand, fill=fill)
                 if element.visible is False:
-                    element._pack_forget_save_settings(alternate_widget=element.element_frame)       # seems like it should be the frame if following other elements conventions
+                    element._pack_forget_save_settings(
+                        alternate_widget=element.element_frame
+                    )  # seems like it should be the frame if following other elements conventions
                     # element.TKTreeview.pack_forget()
                 treeview.bind('<<TreeviewSelect>>', element._treeview_selected)
                 if element.Tooltip is not None:  # tooltip
-                    element.TooltipObject = ToolTip(element.TKTreeview, text=element.Tooltip,
-                                                    timeout=DEFAULT_TOOLTIP_TIME)
+                    element.TooltipObject = ToolTip(
+                        element.TKTreeview, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME
+                    )
                 _add_right_click_menu_and_grab(element)
 
                 if tclversion_detailed == '8.6.9' and ENABLE_TREEVIEW_869_PATCH:
                     # print('*** tk version 8.6.9 detected.... patching ttk treeview code ***')
-                    tree_style.map(style_name,
-                                   foreground=_fixed_map(tree_style, style_name, 'foreground', element.SelectedRowColors),
-                                   background=_fixed_map(tree_style, style_name, 'background', element.SelectedRowColors))
+                    tree_style.map(
+                        style_name,
+                        foreground=_fixed_map(tree_style, style_name, 'foreground', element.SelectedRowColors),
+                        background=_fixed_map(tree_style, style_name, 'background', element.SelectedRowColors),
+                    )
 
             # -------------------------  Separator placement element  ------------------------- #
             elif element_type == ELEM_TYPE_SEPARATOR:
@@ -17552,9 +21348,14 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
                 if element.color not in (None, COLOR_SYSTEM_DEFAULT):
                     style.configure(style_name, background=element.color)
-                separator = element.Widget = ttk.Separator(tk_row_frame, orient=element.Orientation, )
+                separator = element.Widget = ttk.Separator(
+                    tk_row_frame,
+                    orient=element.Orientation,
+                )
 
-                expand, fill, row_should_expand, row_fill_direction = _add_expansion(element, row_should_expand, row_fill_direction)
+                expand, fill, row_should_expand, row_fill_direction = _add_expansion(
+                    element, row_should_expand, row_fill_direction
+                )
 
                 if element.Orientation.startswith('h'):
                     separator.pack(side=tk.LEFT, padx=elementpad[0], pady=elementpad[1], fill=tk.X, expand=True)
@@ -17578,7 +21379,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     style.configure(style_name, background=toplevel_form.TKroot['bg'])
                 size_grip.configure(style=style_name)
 
-                size_grip.pack(side=tk.BOTTOM, anchor='se', padx=elementpad[0], pady=elementpad[1], fill=tk.X, expand=True)
+                size_grip.pack(
+                    side=tk.BOTTOM, anchor='se', padx=elementpad[0], pady=elementpad[1], fill=tk.X, expand=True
+                )
                 # tricky part of sizegrip... it shouldn't cause the row to expand, but should expand and should add X axis if
                 # not already filling in that direction.  Otherwise, leaves things alone!
                 # row_should_expand = True
@@ -17591,7 +21394,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     width, height = element_size
                 else:
                     lines = display_text.split('\n')
-                    max_line_len = max([len(l) for l in lines])
+                    max_line_len = max([len(line) for line in lines])
                     num_lines = len(lines)
                     if max_line_len > element_size[0]:  # if text exceeds element size, the will have to wrap
                         width = element_size[0]
@@ -17610,13 +21413,21 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = tk.LEFT if justification.startswith('l') else tk.CENTER if justification.startswith('c') else tk.RIGHT
+                justify = (
+                    tk.LEFT
+                    if justification.startswith('l')
+                    else tk.CENTER if justification.startswith('c') else tk.RIGHT
+                )
                 anchor = tk.NW if justification.startswith('l') else tk.N if justification.startswith('c') else tk.NE
-                # tktext_label = tk.Label(tk_row_frame, textvariable=stringvar, width=width, height=height,
-                #                         justify=justify, bd=border_depth, font=font)
-                tktext_label = element.Widget = tk.Label(tk_row_frame, textvariable=stringvar, width=width,
-                                                         height=height,
-                                                         justify=justify, bd=border_depth, font=font)
+                tktext_label = element.Widget = tk.Label(
+                    tk_row_frame,
+                    textvariable=stringvar,
+                    width=width,
+                    height=height,
+                    justify=justify,
+                    bd=border_depth,
+                    font=font,
+                )
                 # Set wrap-length for text (in PIXELS) == PAIN IN THE ASS
                 wraplen = tktext_label.winfo_reqwidth() + 40  # width of widget in Pixels
                 if not auto_size_text and height == 1:
@@ -17643,36 +21454,15 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
         # ............................DONE WITH ROW pack the row of widgets ..........................#
         # done with row, pack the row of widgets
-        # tk_row_frame.grid(row=row_num+2, sticky=tk.NW, padx=DEFAULT_MARGINS[0])
 
         anchor = 'nw'
 
         if row_justify.lower().startswith('c'):
             anchor = 'n'
-            side = tk.LEFT
         elif row_justify.lower().startswith('r'):
             anchor = 'ne'
-            side = tk.RIGHT
         elif row_justify.lower().startswith('l'):
             anchor = 'nw'
-            side = tk.LEFT
-        # elif toplevel_form.ElementJustification.lower().startswith('c'):
-        #     anchor = 'n'
-        #     side = tk.TOP
-        # elif toplevel_form.ElementJustification.lower().startswith('r'):
-        #     anchor = 'ne'
-        #     side = tk.TOP
-        # else:
-        #     anchor = 'nw'
-        #     side = tk.TOP
-
-        # row_should_expand = False
-
-        # if form.RightClickMenu:
-        #     menu = form.RightClickMenu
-        #     top_menu = tk.Menu(toplevel_form.TKroot, tearoff=False)
-        #     AddMenuItem(top_menu, menu[1], form)
-        #     tk_row_frame.bind('<Button-3>', form._RightClickMenuCallback)
 
         tk_row_frame.pack(side=tk.TOP, anchor=anchor, padx=0, pady=0, expand=row_should_expand, fill=row_fill_direction)
         if form.BackgroundColor is not None and form.BackgroundColor != COLOR_SYSTEM_DEFAULT:
@@ -17738,11 +21528,9 @@ def _convert_window_to_tk(window):
     master.title(window.Title)
     InitializeResults(window)
 
-
     PackFormIntoFrame(window, master, window)
 
     window.TKroot.configure(padx=window.Margins[0], pady=window.Margins[1])
-
 
     # ....................................... DONE creating and laying out window ..........................#
     if window._Size != (None, None):
@@ -17781,10 +21569,10 @@ def _convert_window_to_tk(window):
     else:
         master.update_idletasks()
         x, y = int(master.winfo_x()), int(master.winfo_y())
-        window.config_last_location = x,y
+        window.config_last_location = x, y
         window.TKroot.x = x
         window.TKroot.y = y
-        window.starting_window_position = x,y
+        window.starting_window_position = x, y
     _no_titlebar_setup(window)
 
     return
@@ -17819,18 +21607,18 @@ def StartupTK(window):
         root.bind('<Cancel>', window._callback_main_debugger_window_create_keystroke)
         root.bind('<Pause>', window._callback_popout_window_create_keystroke)
 
-
     # If location is None, then there's no need to hide the window.  Let it build where it is going to end up being.
     if DEFAULT_HIDE_WINDOW_WHEN_CREATING is True and window.Location is not None:
         try:
-            if not running_mac() or \
-                (running_mac() and not window.NoTitleBar) or \
-                (running_mac() and window.NoTitleBar and not _mac_should_apply_notitlebar_patch()):
+            if (
+                not running_mac()
+                or (running_mac() and not window.NoTitleBar)
+                or (running_mac() and window.NoTitleBar and not _mac_should_apply_notitlebar_patch())
+            ):
 
                 root.attributes('-alpha', 0)  # hide window while building it. makes for smoother 'paint'
         except Exception as e:
             print('*** Exception setting alpha channel to zero while creating window ***', e)
-
 
     if window.BackgroundColor is not None and window.BackgroundColor != COLOR_SYSTEM_DEFAULT:
         root.configure(background=window.BackgroundColor)
@@ -17862,20 +21650,19 @@ def StartupTK(window):
     if window.scaling is not None:
         root.tk.call('tk', 'scaling', window.scaling)
 
-
     # root.protocol("WM_DELETE_WINDOW", MyFlexForm.DestroyedCallback())
     # root.bind('<Destroy>', MyFlexForm.DestroyedCallback())
     _convert_window_to_tk(window)
 
     # Make moveable window
-    if (window.GrabAnywhere is not False and not (
-            window.NonBlocking and window.GrabAnywhere is not True)):
+    if window.GrabAnywhere is not False and not (window.NonBlocking and window.GrabAnywhere is not True):
         if not (ENABLE_MAC_DISABLE_GRAB_ANYWHERE_WITH_TITLEBAR and running_mac() and not window.NoTitleBar):
             root.bind('<ButtonPress-1>', window._StartMoveGrabAnywhere)
             root.bind('<ButtonRelease-1>', window._StopMove)
             root.bind('<B1-Motion>', window._OnMotionGrabAnywhere)
-    if (window.GrabAnywhereUsingControlKey is not False and not (
-            window.NonBlocking and window.GrabAnywhereUsingControlKey is not True)):
+    if window.GrabAnywhereUsingControlKey is not False and not (
+        window.NonBlocking and window.GrabAnywhereUsingControlKey is not True
+    ):
         root.bind('<Control-Button-1>', window._StartMoveUsingControlKey)
         root.bind('<Control-ButtonRelease-1>', window._StopMove)
         root.bind('<Control-B1-Motion>', window._OnMotionUsingControlKey)
@@ -17921,7 +21708,7 @@ def StartupTK(window):
             # duration = DEFAULT_AUTOCLOSE_TIME if window.AutoCloseDuration is None else window.AutoCloseDuration
             # window.TKAfterID = root.after(int(duration * 1000), window._AutoCloseAlarmCallback)
 
-    if window.Timeout != None:
+    if window.Timeout is not None:
         window.TKAfterID = root.after(int(window.Timeout), window._TimeoutAlarmCallback)
     if window.NonBlocking:
         window.TKroot.protocol('WM_DESTROY_WINDOW', window._OnClosingCallback)
@@ -17992,11 +21779,11 @@ def _set_icon_for_tkinter_window(root, icon=None, pngbase64=None):
     wicon = icon
     try:
         root.iconbitmap(icon)
-    except  Exception as e:
+    except Exception:
         try:
             wicon = tkinter.PhotoImage(file=icon)
             root.tk.call('wm', 'iconphoto', root._w, wicon)
-        except  Exception as e:
+        except Exception as e:
             try:
                 wicon = tkinter.PhotoImage(data=DEFAULT_BASE64_ICON)
                 try:
@@ -18016,8 +21803,6 @@ def _GetNumLinesNeeded(text, max_line_width):
     if max_line_width == 0:
         return 1
     lines = text.split('\n')
-    num_lines = len(lines)  # number of original lines of text
-    max_line_len = max([len(l) for l in lines])  # longest line
     lines_used = []
     for L in lines:
         lines_used.append(len(L) // max_line_width + (len(L) % max_line_width > 0))  # fancy math to round up
@@ -18027,6 +21812,7 @@ def _GetNumLinesNeeded(text, max_line_width):
 
 # ==============================  PROGRESS METER ========================================== #
 
+
 def convert_args_to_single_string(*args):
     """
 
@@ -18034,14 +21820,22 @@ def convert_args_to_single_string(*args):
     :type *args:
 
     """
-    max_line_total, width_used, total_lines, = 0, 0, 0
+    (
+        max_line_total,
+        width_used,
+        total_lines,
+    ) = (
+        0,
+        0,
+        0,
+    )
     single_line_message = ''
     # loop through args and built a SINGLE string from them
     for message in args:
         # fancy code to check if string and convert if not is not need. Just always convert to string :-)
         # if not isinstance(message, str): message = str(message)
         message = str(message)
-        longest_line_len = max([len(l) for l in message.split('\n')])
+        longest_line_len = max([len(line) for line in message.split('\n')])
         width_used = max(longest_line_len, width_used)
         max_line_total = max(max_line_total, width_used)
         lines_needed = _GetNumLinesNeeded(message, width_used)
@@ -18061,8 +21855,23 @@ class _QuickMeter(object):
     active_meters = {}
     exit_reasons = {}
 
-    def __init__(self, title, current_value, max_value, key, *args, orientation='v', bar_color=(None, None), button_color=(None, None),
-                 size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False, no_titlebar=False, keep_on_top=None, no_button=False):
+    def __init__(
+        self,
+        title,
+        current_value,
+        max_value,
+        key,
+        *args,
+        orientation='v',
+        bar_color=(None, None),
+        button_color=(None, None),
+        size=DEFAULT_PROGRESS_BAR_SIZE,
+        border_width=None,
+        grab_anywhere=False,
+        no_titlebar=False,
+        keep_on_top=None,
+        no_button=False,
+    ):
         """
 
         :param title:         text to display in element
@@ -18115,43 +21924,79 @@ class _QuickMeter(object):
         layout = []
         if self.orientation.lower().startswith('h'):
             col = []
-            col += [[T(''.join(map(lambda x: str(x) + '\n', args)),
-                       key='-OPTMSG-')]]  ### convert all *args into one string that can be updated
-            col += [[T('', size=(30, 10), key='-STATS-')],
-                    [ProgressBar(max_value=self.max_value, orientation='h', key='-PROG-', size=self.size,
-                                 bar_color=self.bar_color)]]
+            col += [
+                [T(''.join(map(lambda x: str(x) + '\n', args)), key='-OPTMSG-')]
+            ]  # convert all *args into one string that can be updated
+
+            col += [
+                [T('', size=(30, 10), key='-STATS-')],
+                [
+                    ProgressBar(
+                        max_value=self.max_value,
+                        orientation='h',
+                        key='-PROG-',
+                        size=self.size,
+                        bar_color=self.bar_color,
+                    )
+                ],
+            ]
             if not self.no_button:
                 col += [[Cancel(button_color=self.button_color), Stretch()]]
             layout = [Column(col)]
         else:
-            col = [[ProgressBar(max_value=self.max_value, orientation='v', key='-PROG-', size=self.size,
-                                bar_color=self.bar_color)]]
+            col = [
+                [
+                    ProgressBar(
+                        max_value=self.max_value,
+                        orientation='v',
+                        key='-PROG-',
+                        size=self.size,
+                        bar_color=self.bar_color,
+                    )
+                ]
+            ]
             col2 = []
-            col2 += [[T(''.join(map(lambda x: str(x) + '\n', args)),
-                        key='-OPTMSG-')]]  ### convert all *args into one string that can be updated
+
+            col2 += [
+                [T(''.join(map(lambda x: str(x) + '\n', args)), key='-OPTMSG-')]
+            ]  # convert all *args into one string that can be updated
+
             col2 += [[T('', size=(30, 10), key='-STATS-')]]
+
             if not self.no_button:
                 col2 += [[Cancel(button_color=self.button_color), Stretch()]]
 
             layout = [Column(col), Column(col2)]
-        self.window = Window(self.title, grab_anywhere=self.grab_anywhere, border_depth=self.border_width, no_titlebar=self.no_titlebar, disable_close=True, keep_on_top=self.keep_on_top)
+        self.window = Window(
+            self.title,
+            grab_anywhere=self.grab_anywhere,
+            border_depth=self.border_width,
+            no_titlebar=self.no_titlebar,
+            disable_close=True,
+            keep_on_top=self.keep_on_top,
+        )
         self.window.Layout([layout]).Finalize()
 
         return self.window
 
-    def UpdateMeter(self, current_value, max_value, *args):  ### support for *args when updating
+    def UpdateMeter(self, current_value, max_value, *args):  # support for *args when updating
 
         self.current_value = current_value
         self.max_value = max_value
         self.window.Element('-PROG-').UpdateBar(self.current_value, self.max_value)
         self.window.Element('-STATS-').Update('\n'.join(self.ComputeProgressStats()))
         self.window.Element('-OPTMSG-').Update(
-            value=''.join(map(lambda x: str(x) + '\n', args)))  ###  update the string with the args
+            value=''.join(map(lambda x: str(x) + '\n', args))
+        )  # update the string with the args
         event, values = self.window.read(timeout=0)
         if event in ('Cancel', None) or current_value >= max_value:
-            exit_reason = METER_REASON_CANCELLED if event in ('Cancel', None) else METER_REASON_REACHED_MAX if current_value >= max_value else METER_STOPPED
+            exit_reason = (
+                METER_REASON_CANCELLED
+                if event in ('Cancel', None)
+                else METER_REASON_REACHED_MAX if current_value >= max_value else METER_STOPPED
+            )
             self.window.close()
-            del (_QuickMeter.active_meters[self.key])
+            del _QuickMeter.active_meters[self.key]
             _QuickMeter.exit_reasons[self.key] = exit_reason
             return _QuickMeter.exit_reasons[self.key]
         return METER_OK
@@ -18181,11 +22026,27 @@ class _QuickMeter(object):
             '',
             '{} Elapsed Time'.format(time_delta_short),
             '{} Time Remaining'.format(time_remaining_short),
-            '{} Estimated Total Time'.format(total_time_short)]
+            '{} Estimated Total Time'.format(total_time_short),
+        ]
         return self.stat_messages
 
 
-def one_line_progress_meter(title, current_value, max_value, *args, key='OK for 1 meter', orientation='v', bar_color=(None, None), button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False, no_titlebar=False, keep_on_top=None, no_button=False):
+def one_line_progress_meter(
+    title,
+    current_value,
+    max_value,
+    *args,
+    key='OK for 1 meter',
+    orientation='v',
+    bar_color=(None, None),
+    button_color=None,
+    size=DEFAULT_PROGRESS_BAR_SIZE,
+    border_width=None,
+    grab_anywhere=False,
+    no_titlebar=False,
+    keep_on_top=None,
+    no_button=False,
+):
     """
     :param title:         text to display in titlebar of window
     :type title:          (str)
@@ -18219,14 +22080,29 @@ def one_line_progress_meter(title, current_value, max_value, *args, key='OK for 
     :rtype:               (bool)
     """
     if key not in _QuickMeter.active_meters:
-        meter = _QuickMeter(title, current_value, max_value, key, *args, orientation=orientation, bar_color=bar_color, button_color=button_color, size=size, border_width=border_width, grab_anywhere=grab_anywhere, no_titlebar=no_titlebar, keep_on_top=keep_on_top, no_button=no_button)
+        meter = _QuickMeter(
+            title,
+            current_value,
+            max_value,
+            key,
+            *args,
+            orientation=orientation,
+            bar_color=bar_color,
+            button_color=button_color,
+            size=size,
+            border_width=border_width,
+            grab_anywhere=grab_anywhere,
+            no_titlebar=no_titlebar,
+            keep_on_top=keep_on_top,
+            no_button=no_button,
+        )
         _QuickMeter.active_meters[key] = meter
         _QuickMeter.exit_reasons[key] = None
 
     else:
         meter = _QuickMeter.active_meters[key]
 
-    rc = meter.UpdateMeter(current_value, max_value, *args)  ### pass the *args to to UpdateMeter function
+    meter.UpdateMeter(current_value, max_value, *args)  # pass the *args to UpdateMeter function
     OneLineProgressMeter.exit_reasons = getattr(OneLineProgressMeter, 'exit_reasons', _QuickMeter.exit_reasons)
     exit_reason = OneLineProgressMeter.exit_reasons.get(key)
     return METER_OK if exit_reason in (None, METER_REASON_REACHED_MAX) else METER_STOPPED
@@ -18244,7 +22120,7 @@ def one_line_progress_meter_cancel(key='OK for 1 meter'):
     try:
         meter = _QuickMeter.active_meters[key]
         meter.window.Close()
-        del (_QuickMeter.active_meters[key])
+        del _QuickMeter.active_meters[key]
         _QuickMeter.exit_reasons[key] = METER_REASON_CANCELLED
     except:  # meter is already deleted
         return
@@ -18272,11 +22148,24 @@ def get_complimentary_hex(color):
 
 # ========================  EasyPrint           =====#
 # ===================================================#
-class _DebugWin():
+class _DebugWin:
     debug_window = None
 
-    def __init__(self, size=(None, None), location=(None, None), relative_location=(None, None), font=None, no_titlebar=False, no_button=False,
-                 grab_anywhere=False, keep_on_top=None, do_not_reroute_stdout=True, echo_stdout=False, resizable=True, blocking=False):
+    def __init__(
+        self,
+        size=(None, None),
+        location=(None, None),
+        relative_location=(None, None),
+        font=None,
+        no_titlebar=False,
+        no_button=False,
+        grab_anywhere=False,
+        keep_on_top=None,
+        do_not_reroute_stdout=True,
+        echo_stdout=False,
+        resizable=True,
+        blocking=False,
+    ):
         """
 
         :param size:                  (w,h) w=characters-wide, h=rows-high
@@ -18320,7 +22209,17 @@ class _DebugWin():
         self.blocking = blocking
 
         win_size = size if size != (None, None) else DEFAULT_DEBUG_WINDOW_SIZE
-        self.output_element = Multiline(size=win_size, autoscroll=True, auto_refresh=True, reroute_stdout=False if do_not_reroute_stdout else True, echo_stdout_stderr=self.echo_stdout, reroute_stderr=False if do_not_reroute_stdout else True, expand_x=True, expand_y=True, key='-MULTILINE-')
+        self.output_element = Multiline(
+            size=win_size,
+            autoscroll=True,
+            auto_refresh=True,
+            reroute_stdout=False if do_not_reroute_stdout else True,
+            echo_stdout_stderr=self.echo_stdout,
+            reroute_stderr=False if do_not_reroute_stdout else True,
+            expand_x=True,
+            expand_y=True,
+            key='-MULTILINE-',
+        )
         if no_button:
             self.layout = [[self.output_element]]
         else:
@@ -18328,32 +22227,61 @@ class _DebugWin():
                 self.quit_button = Button('Quit', key='Quit')
             else:
                 self.quit_button = DummyButton('Quit', key='Quit')
-            self.layout = [[self.output_element],
-                           [pin(self.quit_button), pin(B('Pause', key='-PAUSE-')), Stretch()]]
+            self.layout = [[self.output_element], [pin(self.quit_button), pin(B('Pause', key='-PAUSE-')), Stretch()]]
 
         self.layout[-1] += [Sizegrip()]
 
-        self.window = Window('Debug Window', self.layout, no_titlebar=no_titlebar, auto_size_text=True, location=location, relative_location=relative_location,
-                             font=font or ('Courier New', 10), grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, finalize=True, resizable=resizable)
+        self.window = Window(
+            'Debug Window',
+            self.layout,
+            no_titlebar=no_titlebar,
+            auto_size_text=True,
+            location=location,
+            relative_location=relative_location,
+            font=font or ('Courier New', 10),
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+            finalize=True,
+            resizable=resizable,
+        )
         return
 
     def reopen_window(self):
         if self.window is None or (self.window is not None and self.window.is_closed()):
-            self.__init__(size=self.size, location=self.location, relative_location=self.relative_location, font=self.font, no_titlebar=self.no_titlebar,
-                          no_button=self.no_button, grab_anywhere=self.grab_anywhere, keep_on_top=self.keep_on_top,
-                          do_not_reroute_stdout=self.do_not_reroute_stdout, resizable=self.resizable, echo_stdout=self.echo_stdout)
+            self.__init__(
+                size=self.size,
+                location=self.location,
+                relative_location=self.relative_location,
+                font=self.font,
+                no_titlebar=self.no_titlebar,
+                no_button=self.no_button,
+                grab_anywhere=self.grab_anywhere,
+                keep_on_top=self.keep_on_top,
+                do_not_reroute_stdout=self.do_not_reroute_stdout,
+                resizable=self.resizable,
+                echo_stdout=self.echo_stdout,
+            )
 
-
-    def Print(self, *args, end=None, sep=None, text_color=None, background_color=None, erase_all=False, font=None, blocking=None):
+    def Print(
+        self,
+        *args,
+        end=None,
+        sep=None,
+        text_color=None,
+        background_color=None,
+        erase_all=False,
+        font=None,
+        blocking=None,
+    ):
         global SUPPRESS_WIDGET_NOT_FINALIZED_WARNINGS
         suppress = SUPPRESS_WIDGET_NOT_FINALIZED_WARNINGS
         SUPPRESS_WIDGET_NOT_FINALIZED_WARNINGS = True
         sepchar = sep if sep is not None else ' '
         endchar = end if end is not None else '\n'
-        self.reopen_window()            # if needed, open the window again
+        self.reopen_window()  # if needed, open the window again
 
-        timeout  = 0 if not blocking else None
-        if  erase_all:
+        timeout = 0 if not blocking else None
+        if erase_all:
             self.output_element.update('')
 
         if self.do_not_reroute_stdout:
@@ -18368,29 +22296,41 @@ class _DebugWin():
                     outstring += sep_str
             outstring += end_str
             try:
-                self.output_element.update(outstring, append=True, text_color_for_value=text_color, background_color_for_value=background_color, font_for_value=font)
+                self.output_element.update(
+                    outstring,
+                    append=True,
+                    text_color_for_value=text_color,
+                    background_color_for_value=background_color,
+                    font_for_value=font,
+                )
             except:
-                self.window=None
+                self.window = None
                 self.reopen_window()
-                self.output_element.update(outstring, append=True, text_color_for_value=text_color, background_color_for_value=background_color, font_for_value=font)
+                self.output_element.update(
+                    outstring,
+                    append=True,
+                    text_color_for_value=text_color,
+                    background_color_for_value=background_color,
+                    font_for_value=font,
+                )
 
         else:
             print(*args, sep=sepchar, end=endchar)
         # This is tricky....changing the button type depending on the blocking parm. If blocking, then the "Quit" button should become a normal button
         if blocking and not self.no_button:
             self.quit_button.BType = BUTTON_TYPE_READ_FORM
-            try:                    # The window may be closed by user at any time, so have to protect
+            try:  # The window may be closed by user at any time, so have to protect
                 self.quit_button.update(text='Click to continue...')
             except:
                 self.window = None
         elif not self.no_button:
             self.quit_button.BType = BUTTON_TYPE_CLOSES_WIN_ONLY
-            try:                    # The window may be closed by user at any time, so have to protect
+            try:  # The window may be closed by user at any time, so have to protect
                 self.quit_button.update(text='Quit')
             except:
                 self.window = None
 
-        try:                        # The window may be closed by user at any time, so have to protect
+        try:  # The window may be closed by user at any time, so have to protect
             if blocking and not self.no_button:
                 self.window['-PAUSE-'].update(visible=False)
             elif not self.no_button:
@@ -18398,7 +22338,7 @@ class _DebugWin():
         except:
             self.window = None
 
-        self.reopen_window()            # if needed, open the window again
+        self.reopen_window()  # if needed, open the window again
 
         paused = None
         while True:
@@ -18412,7 +22352,9 @@ class _DebugWin():
             elif not paused and event == TIMEOUT_EVENT and not blocking:
                 break
             elif event == '-PAUSE-':
-                if blocking or self.no_button:            # if blocking or shouldn't have been a button event, ignore the pause button entirely
+                if (
+                    blocking or self.no_button
+                ):  # if blocking or shouldn't have been a button event, ignore the pause button entirely
                     continue
                 if paused:
                     self.window['-PAUSE-'].update(text='Pause')
@@ -18432,8 +22374,29 @@ class _DebugWin():
         self.window = None
 
 
-def easy_print(*args, size=(None, None), end=None, sep=None, location=(None, None), relative_location=(None, None), font=None, no_titlebar=False,
-               no_button=False, grab_anywhere=False, keep_on_top=None, do_not_reroute_stdout=True, echo_stdout=False, text_color=None, background_color=None, colors=None, c=None, erase_all=False, resizable=True, blocking=None, wait=None):
+def easy_print(
+    *args,
+    size=(None, None),
+    end=None,
+    sep=None,
+    location=(None, None),
+    relative_location=(None, None),
+    font=None,
+    no_titlebar=False,
+    no_button=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    do_not_reroute_stdout=True,
+    echo_stdout=False,
+    text_color=None,
+    background_color=None,
+    colors=None,
+    c=None,
+    erase_all=False,
+    resizable=True,
+    blocking=None,
+    wait=None,
+):
     """
     Works like a "print" statement but with windowing options.  Routes output to the "Debug Window"
 
@@ -18494,12 +22457,31 @@ def easy_print(*args, size=(None, None), end=None, sep=None, location=(None, Non
 
     blocking = blocking or wait
     if _DebugWin.debug_window is None:
-        _DebugWin.debug_window = _DebugWin(size=size, location=location, relative_location=relative_location, font=font, no_titlebar=no_titlebar,
-                                           no_button=no_button, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top,
-                                           do_not_reroute_stdout=do_not_reroute_stdout, echo_stdout=echo_stdout, resizable=resizable, blocking=blocking)
+        _DebugWin.debug_window = _DebugWin(
+            size=size,
+            location=location,
+            relative_location=relative_location,
+            font=font,
+            no_titlebar=no_titlebar,
+            no_button=no_button,
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+            do_not_reroute_stdout=do_not_reroute_stdout,
+            echo_stdout=echo_stdout,
+            resizable=resizable,
+            blocking=blocking,
+        )
     txt_color, bg_color = _parse_colors_parm(c or colors)
-    _DebugWin.debug_window.Print(*args, end=end, sep=sep, text_color=text_color or txt_color, background_color=background_color or bg_color,
-                                 erase_all=erase_all, font=font, blocking=blocking)
+    _DebugWin.debug_window.Print(
+        *args,
+        end=end,
+        sep=sep,
+        text_color=text_color or txt_color,
+        background_color=background_color or bg_color,
+        erase_all=erase_all,
+        font=font,
+        blocking=blocking,
+    )
 
 
 def easy_print_close():
@@ -18548,8 +22530,23 @@ def cprint_set_output_destination(window, multiline_key):
     CPRINT_DESTINATION_MULTILINE_ELMENT_KEY = multiline_key
 
 
-def cprint(*args, end=None, sep=' ', text_color=None, font=None, t=None, background_color=None, b=None, colors=None, c=None, window=None, key=None,
-           justification=None, autoscroll=True, erase_all=False):
+def cprint(
+    *args,
+    end=None,
+    sep=' ',
+    text_color=None,
+    font=None,
+    t=None,
+    background_color=None,
+    b=None,
+    colors=None,
+    c=None,
+    window=None,
+    key=None,
+    justification=None,
+    autoscroll=True,
+    erase_all=False,
+):
     """
     Color print to a multiline element in a window of your choice.
     Must have EITHER called cprint_set_output_destination prior to making this call so that the
@@ -18614,9 +22611,11 @@ def cprint(*args, end=None, sep=' ', text_color=None, font=None, t=None, backgro
     destination_window = window or CPRINT_DESTINATION_WINDOW
 
     if (destination_window is None and window is None) or (destination_key is None and key is None):
-        print('** Warning ** Attempting to perform a cprint without a valid window & key',
-              'Will instead print on Console',
-              'You can specify window and key in this cprint call, or set ahead of time using cprint_set_output_destination')
+        print(
+            '** Warning ** Attempting to perform a cprint without a valid window & key',
+            'Will instead print on Console',
+            'You can specify window and key in this cprint call, or set ahead of time using cprint_set_output_destination',
+        )
         print(*args)
         return
 
@@ -18642,12 +22641,28 @@ def cprint(*args, end=None, sep=' ', text_color=None, font=None, t=None, backgro
         if erase_all is True:
             mline.update('')
         if end is None:
-            mline.print(*args, text_color=kw_text_color, background_color=kw_background_color, end='', sep=sep, justification=justification, font=font,
-                        autoscroll=autoscroll)
+            mline.print(
+                *args,
+                text_color=kw_text_color,
+                background_color=kw_background_color,
+                end='',
+                sep=sep,
+                justification=justification,
+                font=font,
+                autoscroll=autoscroll,
+            )
             mline.print('', justification=justification, autoscroll=autoscroll)
         else:
-            mline.print(*args, text_color=kw_text_color, background_color=kw_background_color, end=end, sep=sep, justification=justification, font=font,
-                        autoscroll=autoscroll)
+            mline.print(
+                *args,
+                text_color=kw_text_color,
+                background_color=kw_background_color,
+                end=end,
+                sep=sep,
+                justification=justification,
+                font=font,
+                autoscroll=autoscroll,
+            )
     except Exception as e:
         print('** cprint error trying to print to the multiline. Printing to console instead **', e)
         print(*args, end=end, sep=sep)
@@ -18657,7 +22672,18 @@ def cprint(*args, end=None, sep=' ', text_color=None, font=None, t=None, backgro
 # A print-like call that can be used to output to a multiline element as if it's an Output element #
 # ------------------------------------------------------------------------------------------------ #
 
-def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=None, justification=None, font=None):
+
+def _print_to_element(
+    multiline_element,
+    *args,
+    end=None,
+    sep=None,
+    text_color=None,
+    background_color=None,
+    autoscroll=None,
+    justification=None,
+    font=None,
+):
     """
     Print like Python normally prints except route the output to a multiline element and also add colors if desired
 
@@ -18689,8 +22715,15 @@ def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=N
             outstring += sep_str
     outstring += end_str
 
-    multiline_element.update(outstring, append=True, text_color_for_value=text_color, background_color_for_value=background_color, autoscroll=autoscroll,
-                             justification=justification, font_for_value=font)
+    multiline_element.update(
+        outstring,
+        append=True,
+        text_color_for_value=text_color,
+        background_color_for_value=background_color,
+        autoscroll=autoscroll,
+        justification=justification,
+        font_for_value=font,
+    )
 
     try:  # if the element is set to autorefresh, then refresh the parent window
         if multiline_element.AutoRefresh:
@@ -18748,22 +22781,75 @@ def set_global_icon(icon):
 # ============================== set_options ========#
 # Sets the icon to be used by default                #
 # ===================================================#
-def set_options(icon=None, button_color=None, element_size=(None, None), button_element_size=(None, None),
-                margins=(None, None),
-                element_padding=(None, None), auto_size_text=None, auto_size_buttons=None, font=None, border_width=None,
-                slider_border_width=None, slider_relief=None, slider_orientation=None,
-                autoclose_time=None, message_box_line_width=None,
-                progress_meter_border_depth=None, progress_meter_style=None,
-                progress_meter_relief=None, progress_meter_color=None, progress_meter_size=None,
-                text_justification=None, background_color=None, element_background_color=None,
-                text_element_background_color=None, input_elements_background_color=None, input_text_color=None,
-                scrollbar_color=None, text_color=None, element_text_color=None, debug_win_size=(None, None),
-                window_location=(None, None), error_button_color=(None, None), tooltip_time=None, tooltip_font=None, use_ttk_buttons=None, ttk_theme=None,
-                suppress_error_popups=None, suppress_raise_key_errors=None, suppress_key_guessing=None,warn_button_key_duplicates=False, enable_treeview_869_patch=None,
-                enable_mac_notitlebar_patch=None, use_custom_titlebar=None, titlebar_background_color=None, titlebar_text_color=None, titlebar_font=None,
-                titlebar_icon=None, user_settings_path=None, pysimplegui_settings_path=None, pysimplegui_settings_filename=None, keep_on_top=None, dpi_awareness=None, scaling=None, disable_modal_windows=None, force_modal_windows=None, tooltip_offset=(None, None),
-                sbar_trough_color=None, sbar_background_color=None, sbar_arrow_color=None, sbar_width=None, sbar_arrow_width=None, sbar_frame_color=None, sbar_relief=None, alpha_channel=None,
-                hide_window_when_creating=None, use_button_shortcuts=None, watermark_text=None):
+def set_options(
+    icon=None,
+    button_color=None,
+    element_size=(None, None),
+    button_element_size=(None, None),
+    margins=(None, None),
+    element_padding=(None, None),
+    auto_size_text=None,
+    auto_size_buttons=None,
+    font=None,
+    border_width=None,
+    slider_border_width=None,
+    slider_relief=None,
+    slider_orientation=None,
+    autoclose_time=None,
+    message_box_line_width=None,
+    progress_meter_border_depth=None,
+    progress_meter_style=None,
+    progress_meter_relief=None,
+    progress_meter_color=None,
+    progress_meter_size=None,
+    text_justification=None,
+    background_color=None,
+    element_background_color=None,
+    text_element_background_color=None,
+    input_elements_background_color=None,
+    input_text_color=None,
+    scrollbar_color=None,
+    text_color=None,
+    element_text_color=None,
+    debug_win_size=(None, None),
+    window_location=(None, None),
+    error_button_color=(None, None),
+    tooltip_time=None,
+    tooltip_font=None,
+    use_ttk_buttons=None,
+    ttk_theme=None,
+    suppress_error_popups=None,
+    suppress_raise_key_errors=None,
+    suppress_key_guessing=None,
+    warn_button_key_duplicates=False,
+    enable_treeview_869_patch=None,
+    enable_mac_notitlebar_patch=None,
+    use_custom_titlebar=None,
+    titlebar_background_color=None,
+    titlebar_text_color=None,
+    titlebar_font=None,
+    titlebar_icon=None,
+    user_settings_path=None,
+    pysimplegui_settings_path=None,
+    pysimplegui_settings_filename=None,
+    keep_on_top=None,
+    dpi_awareness=None,
+    scaling=None,
+    disable_modal_windows=None,
+    force_modal_windows=None,
+    tooltip_offset=(None, None),
+    sbar_trough_color=None,
+    sbar_background_color=None,
+    sbar_arrow_color=None,
+    sbar_width=None,
+    sbar_arrow_width=None,
+    sbar_frame_color=None,
+    sbar_relief=None,
+    alpha_channel=None,
+    hide_window_when_creating=None,
+    use_button_shortcuts=None,
+    watermark_text=None,
+):
     """
     :param icon:                            Can be either a filename or Base64 value. For Windows if filename, it MUST be ICO format. For Linux, must NOT be ICO. Most portable is to use a Base64 of a PNG file. This works universally across all OS's
     :type icon:                             bytes | str
@@ -18968,7 +23054,7 @@ def set_options(icon=None, button_color=None, element_size=(None, None), button_
         Window._user_defined_icon = icon
         # _my_windows._user_defined_icon = icon
 
-    if button_color != None:
+    if button_color is not None:
         if button_color == COLOR_SYSTEM_DEFAULT:
             DEFAULT_BUTTON_COLOR = (COLOR_SYSTEM_DEFAULT, COLOR_SYSTEM_DEFAULT)
         else:
@@ -18986,62 +23072,64 @@ def set_options(icon=None, button_color=None, element_size=(None, None), button_
     if element_padding != (None, None):
         DEFAULT_ELEMENT_PADDING = element_padding
 
-    if auto_size_text != None:
+    if auto_size_text is not None:
         DEFAULT_AUTOSIZE_TEXT = auto_size_text
 
-    if auto_size_buttons != None:
+    if auto_size_buttons is not None:
         DEFAULT_AUTOSIZE_BUTTONS = auto_size_buttons
 
-    if font != None:
+    if font is not None:
         DEFAULT_FONT = font
 
-    if border_width != None:
+    if border_width is not None:
         DEFAULT_BORDER_WIDTH = border_width
 
-    if autoclose_time != None:
+    if autoclose_time is not None:
         DEFAULT_AUTOCLOSE_TIME = autoclose_time
 
-    if message_box_line_width != None:
+    if message_box_line_width is not None:
         MESSAGE_BOX_LINE_WIDTH = message_box_line_width
 
-    if progress_meter_border_depth != None:
+    if progress_meter_border_depth is not None:
         DEFAULT_PROGRESS_BAR_BORDER_WIDTH = progress_meter_border_depth
 
-    if progress_meter_style != None:
-        warnings.warn('You can no longer set a progress bar style. All ttk styles must be the same for the window', UserWarning)
+    if progress_meter_style is not None:
+        warnings.warn(
+            'You can no longer set a progress bar style. All ttk styles must be the same for the window', UserWarning
+        )
         # DEFAULT_PROGRESS_BAR_STYLE = progress_meter_style
 
-    if progress_meter_relief != None:
+    if progress_meter_relief is not None:
         DEFAULT_PROGRESS_BAR_RELIEF = progress_meter_relief
 
-    if progress_meter_color != None:
+    if progress_meter_color is not None:
         DEFAULT_PROGRESS_BAR_COLOR = progress_meter_color
 
-    if progress_meter_size != None:
+    if progress_meter_size is not None:
         DEFAULT_PROGRESS_BAR_SIZE = progress_meter_size
 
-    if slider_border_width != None:
+    if slider_border_width is not None:
         DEFAULT_SLIDER_BORDER_WIDTH = slider_border_width
 
-    if slider_orientation != None:
+    if slider_orientation is not None:
         DEFAULT_SLIDER_ORIENTATION = slider_orientation
 
-    if slider_relief != None:
+    if slider_relief is not None:
         DEFAULT_SLIDER_RELIEF = slider_relief
 
-    if text_justification != None:
+    if text_justification is not None:
         DEFAULT_TEXT_JUSTIFICATION = text_justification
 
-    if background_color != None:
+    if background_color is not None:
         DEFAULT_BACKGROUND_COLOR = background_color
 
-    if text_element_background_color != None:
+    if text_element_background_color is not None:
         DEFAULT_TEXT_ELEMENT_BACKGROUND_COLOR = text_element_background_color
 
-    if input_elements_background_color != None:
+    if input_elements_background_color is not None:
         DEFAULT_INPUT_ELEMENTS_COLOR = input_elements_background_color
 
-    if element_background_color != None:
+    if element_background_color is not None:
         DEFAULT_ELEMENT_BACKGROUND_COLOR = element_background_color
 
     if window_location != (None, None):
@@ -19050,13 +23138,13 @@ def set_options(icon=None, button_color=None, element_size=(None, None), button_
     if debug_win_size != (None, None):
         DEFAULT_DEBUG_WINDOW_SIZE = debug_win_size
 
-    if text_color != None:
+    if text_color is not None:
         DEFAULT_TEXT_COLOR = text_color
 
-    if scrollbar_color != None:
+    if scrollbar_color is not None:
         DEFAULT_SCROLLBAR_COLOR = scrollbar_color
 
-    if element_text_color != None:
+    if element_text_color is not None:
         DEFAULT_ELEMENT_TEXT_COLOR = element_text_color
 
     if input_text_color is not None:
@@ -19120,8 +23208,9 @@ def set_options(icon=None, button_color=None, element_size=(None, None), button_
         DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME = pysimplegui_settings_filename
 
     if pysimplegui_settings_filename is not None or pysimplegui_settings_filename is not None:
-        _pysimplegui_user_settings = UserSettings(filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME,
-                                                  path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH)
+        _pysimplegui_user_settings = UserSettings(
+            filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH
+        )
 
     if keep_on_top is not None:
         DEFAULT_KEEP_ON_TOP = keep_on_top
@@ -19144,7 +23233,6 @@ def set_options(icon=None, button_color=None, element_size=(None, None), button_
 
     if tooltip_offset != (None, None):
         DEFAULT_TOOLTIP_OFFSET = tooltip_offset
-
 
     if alpha_channel is not None:
         DEFAULT_ALPHA_CHANNEL = alpha_channel
@@ -19202,427 +23290,2072 @@ def set_options(icon=None, button_color=None, element_size=(None, None), button_
 # of the elements.                                           #
 ##############################################################
 LOOK_AND_FEEL_TABLE = {
-    'SystemDefault': {'BACKGROUND': COLOR_SYSTEM_DEFAULT, 'TEXT': COLOR_SYSTEM_DEFAULT, 'INPUT': COLOR_SYSTEM_DEFAULT, 'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                      'SCROLL': COLOR_SYSTEM_DEFAULT, 'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR, 'PROGRESS': COLOR_SYSTEM_DEFAULT, 'BORDER': 1,
-                      'SLIDER_DEPTH': 1, 'PROGRESS_DEPTH': 0, },
-    'SystemDefaultForReal': {'BACKGROUND': COLOR_SYSTEM_DEFAULT, 'TEXT': COLOR_SYSTEM_DEFAULT, 'INPUT': COLOR_SYSTEM_DEFAULT,
-                             'TEXT_INPUT': COLOR_SYSTEM_DEFAULT, 'SCROLL': COLOR_SYSTEM_DEFAULT, 'BUTTON': COLOR_SYSTEM_DEFAULT,
-                             'PROGRESS': COLOR_SYSTEM_DEFAULT, 'BORDER': 1, 'SLIDER_DEPTH': 1, 'PROGRESS_DEPTH': 0, },
-    'SystemDefault1': {'BACKGROUND': COLOR_SYSTEM_DEFAULT, 'TEXT': COLOR_SYSTEM_DEFAULT, 'INPUT': COLOR_SYSTEM_DEFAULT, 'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                       'SCROLL': COLOR_SYSTEM_DEFAULT, 'BUTTON': COLOR_SYSTEM_DEFAULT, 'PROGRESS': COLOR_SYSTEM_DEFAULT, 'BORDER': 1, 'SLIDER_DEPTH': 1,
-                       'PROGRESS_DEPTH': 0, },
-    'Material1': {'BACKGROUND': '#E3F2FD', 'TEXT': '#000000', 'INPUT': '#86A8FF', 'TEXT_INPUT': '#000000', 'SCROLL': '#86A8FF',
-                  'BUTTON': ('#FFFFFF', '#5079D3'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 0, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'ACCENT1': '#FF0266', 'ACCENT2': '#FF5C93', 'ACCENT3': '#C5003C', },
-    'Material2': {'BACKGROUND': '#FAFAFA', 'TEXT': '#000000', 'INPUT': '#004EA1', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#5EA7FF',
-                  'BUTTON': ('#FFFFFF', '#0079D3'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 0, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'ACCENT1': '#FF0266', 'ACCENT2': '#FF5C93', 'ACCENT3': '#C5003C', },
-    'Reddit': {'BACKGROUND': '#ffffff', 'TEXT': '#1a1a1b', 'INPUT': '#dae0e6', 'TEXT_INPUT': '#222222', 'SCROLL': '#a5a4a4', 'BUTTON': ('#FFFFFF', '#0079d3'),
-               'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, 'ACCENT1': '#ff5414', 'ACCENT2': '#33a8ff',
-               'ACCENT3': '#dbf0ff', },
-    'Topanga': {'BACKGROUND': '#282923', 'TEXT': '#E7DB74', 'INPUT': '#393a32', 'TEXT_INPUT': '#E7C855', 'SCROLL': '#E7C855', 'BUTTON': ('#E7C855', '#284B5A'),
-                'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, 'ACCENT1': '#c15226', 'ACCENT2': '#7a4d5f',
-                'ACCENT3': '#889743', },
-    'GreenTan': {'BACKGROUND': '#9FB8AD', 'TEXT': '#000000', 'INPUT': '#F7F3EC', 'TEXT_INPUT': '#000000', 'SCROLL': '#F7F3EC', 'BUTTON': ('#FFFFFF', '#475841'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Dark': {'BACKGROUND': '#404040', 'TEXT': '#FFFFFF', 'INPUT': '#4D4D4D', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#707070', 'BUTTON': ('#FFFFFF', '#004F00'),
-             'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightGreen': {'BACKGROUND': '#B7CECE', 'TEXT': '#000000', 'INPUT': '#FDFFF7', 'TEXT_INPUT': '#000000', 'SCROLL': '#FDFFF7',
-                   'BUTTON': ('#FFFFFF', '#658268'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'ACCENT1': '#76506d',
-                   'ACCENT2': '#5148f1', 'ACCENT3': '#0a1c84', 'PROGRESS_DEPTH': 0, },
-    'Dark2': {'BACKGROUND': '#404040', 'TEXT': '#FFFFFF', 'INPUT': '#FFFFFF', 'TEXT_INPUT': '#000000', 'SCROLL': '#707070', 'BUTTON': ('#FFFFFF', '#004F00'),
-              'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Black': {'BACKGROUND': '#000000', 'TEXT': '#FFFFFF', 'INPUT': '#4D4D4D', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#707070', 'BUTTON': ('#000000', '#FFFFFF'),
-              'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Black2': {'BACKGROUND': '#000000', 'TEXT': '#FFFFFF', 'INPUT': '#000000', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#FFFFFF', 'BUTTON': ('#000000', '#FFFFFF'),
-               'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Tan': {'BACKGROUND': '#fdf6e3', 'TEXT': '#268bd1', 'INPUT': '#eee8d5', 'TEXT_INPUT': '#6c71c3', 'SCROLL': '#eee8d5', 'BUTTON': ('#FFFFFF', '#063542'),
-            'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'TanBlue': {'BACKGROUND': '#e5dece', 'TEXT': '#063289', 'INPUT': '#f9f8f4', 'TEXT_INPUT': '#242834', 'SCROLL': '#eee8d5', 'BUTTON': ('#FFFFFF', '#063289'),
-                'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkTanBlue': {'BACKGROUND': '#242834', 'TEXT': '#dfe6f8', 'INPUT': '#97755c', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#a9afbb',
-                    'BUTTON': ('#FFFFFF', '#063289'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkAmber': {'BACKGROUND': '#2c2825', 'TEXT': '#fdcb52', 'INPUT': '#705e52', 'TEXT_INPUT': '#fdcb52', 'SCROLL': '#705e52',
-                  'BUTTON': ('#000000', '#fdcb52'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBlue': {'BACKGROUND': '#1a2835', 'TEXT': '#d1ecff', 'INPUT': '#335267', 'TEXT_INPUT': '#acc2d0', 'SCROLL': '#1b6497', 'BUTTON': ('#000000', '#fafaf8'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Reds': {'BACKGROUND': '#280001', 'TEXT': '#FFFFFF', 'INPUT': '#d8d584', 'TEXT_INPUT': '#000000', 'SCROLL': '#763e00', 'BUTTON': ('#000000', '#daad28'),
-             'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Green': {'BACKGROUND': '#82a459', 'TEXT': '#000000', 'INPUT': '#d8d584', 'TEXT_INPUT': '#000000', 'SCROLL': '#e3ecf3', 'BUTTON': ('#FFFFFF', '#517239'),
-              'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'BluePurple': {'BACKGROUND': '#A5CADD', 'TEXT': '#6E266E', 'INPUT': '#E0F5FF', 'TEXT_INPUT': '#000000', 'SCROLL': '#E0F5FF',
-                   'BUTTON': ('#FFFFFF', '#303952'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Purple': {'BACKGROUND': '#B0AAC2', 'TEXT': '#000000', 'INPUT': '#F2EFE8', 'SCROLL': '#F2EFE8', 'TEXT_INPUT': '#000000', 'BUTTON': ('#000000', '#C2D4D8'),
-               'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'BlueMono': {'BACKGROUND': '#AAB6D3', 'TEXT': '#000000', 'INPUT': '#F1F4FC', 'SCROLL': '#F1F4FC', 'TEXT_INPUT': '#000000', 'BUTTON': ('#FFFFFF', '#7186C7'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'GreenMono': {'BACKGROUND': '#A8C1B4', 'TEXT': '#000000', 'INPUT': '#DDE0DE', 'SCROLL': '#E3E3E3', 'TEXT_INPUT': '#000000',
-                  'BUTTON': ('#FFFFFF', '#6D9F85'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'BrownBlue': {'BACKGROUND': '#64778d', 'TEXT': '#FFFFFF', 'INPUT': '#f0f3f7', 'SCROLL': '#A6B2BE', 'TEXT_INPUT': '#000000',
-                  'BUTTON': ('#FFFFFF', '#283b5b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'BrightColors': {'BACKGROUND': '#b4ffb4', 'TEXT': '#000000', 'INPUT': '#ffff64', 'SCROLL': '#ffb482', 'TEXT_INPUT': '#000000',
-                     'BUTTON': ('#000000', '#ffa0dc'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'NeutralBlue': {'BACKGROUND': '#92aa9d', 'TEXT': '#000000', 'INPUT': '#fcfff6', 'SCROLL': '#fcfff6', 'TEXT_INPUT': '#000000',
-                    'BUTTON': ('#000000', '#d0dbbd'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Kayak': {'BACKGROUND': '#a7ad7f', 'TEXT': '#000000', 'INPUT': '#e6d3a8', 'SCROLL': '#e6d3a8', 'TEXT_INPUT': '#000000', 'BUTTON': ('#FFFFFF', '#5d907d'),
-              'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'SandyBeach': {'BACKGROUND': '#efeccb', 'TEXT': '#012f2f', 'INPUT': '#e6d3a8', 'SCROLL': '#e6d3a8', 'TEXT_INPUT': '#012f2f',
-                   'BUTTON': ('#FFFFFF', '#046380'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'TealMono': {'BACKGROUND': '#a8cfdd', 'TEXT': '#000000', 'INPUT': '#dfedf2', 'SCROLL': '#dfedf2', 'TEXT_INPUT': '#000000', 'BUTTON': ('#FFFFFF', '#183440'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'Default': {'BACKGROUND': COLOR_SYSTEM_DEFAULT, 'TEXT': COLOR_SYSTEM_DEFAULT, 'INPUT': COLOR_SYSTEM_DEFAULT, 'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                'SCROLL': COLOR_SYSTEM_DEFAULT, 'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR, 'PROGRESS': COLOR_SYSTEM_DEFAULT, 'BORDER': 1, 'SLIDER_DEPTH': 1,
-                'PROGRESS_DEPTH': 0, },
-    'Default1': {'BACKGROUND': COLOR_SYSTEM_DEFAULT, 'TEXT': COLOR_SYSTEM_DEFAULT, 'INPUT': COLOR_SYSTEM_DEFAULT, 'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                 'SCROLL': COLOR_SYSTEM_DEFAULT, 'BUTTON': COLOR_SYSTEM_DEFAULT, 'PROGRESS': COLOR_SYSTEM_DEFAULT, 'BORDER': 1, 'SLIDER_DEPTH': 1,
-                 'PROGRESS_DEPTH': 0, },
-    'DefaultNoMoreNagging': {'BACKGROUND': COLOR_SYSTEM_DEFAULT, 'TEXT': COLOR_SYSTEM_DEFAULT, 'INPUT': COLOR_SYSTEM_DEFAULT,
-                             'TEXT_INPUT': COLOR_SYSTEM_DEFAULT, 'SCROLL': COLOR_SYSTEM_DEFAULT, 'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-                             'PROGRESS': COLOR_SYSTEM_DEFAULT, 'BORDER': 1, 'SLIDER_DEPTH': 1, 'PROGRESS_DEPTH': 0, },
-    'GrayGrayGray': {'BACKGROUND': COLOR_SYSTEM_DEFAULT, 'TEXT': COLOR_SYSTEM_DEFAULT, 'INPUT': COLOR_SYSTEM_DEFAULT, 'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                     'SCROLL': COLOR_SYSTEM_DEFAULT, 'BUTTON': COLOR_SYSTEM_DEFAULT, 'PROGRESS': COLOR_SYSTEM_DEFAULT, 'BORDER': 1, 'SLIDER_DEPTH': 1,
-                     'PROGRESS_DEPTH': 0, },
-    'LightBlue': {'BACKGROUND': '#E3F2FD', 'TEXT': '#000000', 'INPUT': '#86A8FF', 'TEXT_INPUT': '#000000', 'SCROLL': '#86A8FF',
-                  'BUTTON': ('#FFFFFF', '#5079D3'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 0, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'ACCENT1': '#FF0266', 'ACCENT2': '#FF5C93', 'ACCENT3': '#C5003C', },
-    'LightGrey': {'BACKGROUND': '#FAFAFA', 'TEXT': '#000000', 'INPUT': '#004EA1', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#5EA7FF',
-                  'BUTTON': ('#FFFFFF', '#0079D3'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 0, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'ACCENT1': '#FF0266', 'ACCENT2': '#FF5C93', 'ACCENT3': '#C5003C', },
-    'LightGrey1': {'BACKGROUND': '#ffffff', 'TEXT': '#1a1a1b', 'INPUT': '#dae0e6', 'TEXT_INPUT': '#222222', 'SCROLL': '#a5a4a4',
-                   'BUTTON': ('#FFFFFF', '#0079d3'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'ACCENT1': '#ff5414', 'ACCENT2': '#33a8ff', 'ACCENT3': '#dbf0ff', },
-    'DarkBrown': {'BACKGROUND': '#282923', 'TEXT': '#E7DB74', 'INPUT': '#393a32', 'TEXT_INPUT': '#E7C855', 'SCROLL': '#E7C855',
-                  'BUTTON': ('#E7C855', '#284B5A'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'ACCENT1': '#c15226', 'ACCENT2': '#7a4d5f', 'ACCENT3': '#889743', },
-    'LightGreen1': {'BACKGROUND': '#9FB8AD', 'TEXT': '#000000', 'INPUT': '#F7F3EC', 'TEXT_INPUT': '#000000', 'SCROLL': '#F7F3EC',
-                    'BUTTON': ('#FFFFFF', '#475841'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey': {'BACKGROUND': '#404040', 'TEXT': '#FFFFFF', 'INPUT': '#4D4D4D', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#707070', 'BUTTON': ('#FFFFFF', '#004F00'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightGreen2': {'BACKGROUND': '#B7CECE', 'TEXT': '#000000', 'INPUT': '#FDFFF7', 'TEXT_INPUT': '#000000', 'SCROLL': '#FDFFF7',
-                    'BUTTON': ('#FFFFFF', '#658268'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'ACCENT1': '#76506d',
-                    'ACCENT2': '#5148f1', 'ACCENT3': '#0a1c84', 'PROGRESS_DEPTH': 0, },
-    'DarkGrey1': {'BACKGROUND': '#404040', 'TEXT': '#FFFFFF', 'INPUT': '#FFFFFF', 'TEXT_INPUT': '#000000', 'SCROLL': '#707070',
-                  'BUTTON': ('#FFFFFF', '#004F00'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBlack': {'BACKGROUND': '#000000', 'TEXT': '#FFFFFF', 'INPUT': '#4D4D4D', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#707070',
-                  'BUTTON': ('#000000', '#FFFFFF'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBrown': {'BACKGROUND': '#fdf6e3', 'TEXT': '#268bd1', 'INPUT': '#eee8d5', 'TEXT_INPUT': '#6c71c3', 'SCROLL': '#eee8d5',
-                   'BUTTON': ('#FFFFFF', '#063542'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBrown1': {'BACKGROUND': '#e5dece', 'TEXT': '#063289', 'INPUT': '#f9f8f4', 'TEXT_INPUT': '#242834', 'SCROLL': '#eee8d5',
-                    'BUTTON': ('#FFFFFF', '#063289'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBlue1': {'BACKGROUND': '#242834', 'TEXT': '#dfe6f8', 'INPUT': '#97755c', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#a9afbb',
-                  'BUTTON': ('#FFFFFF', '#063289'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBrown1': {'BACKGROUND': '#2c2825', 'TEXT': '#fdcb52', 'INPUT': '#705e52', 'TEXT_INPUT': '#fdcb52', 'SCROLL': '#705e52',
-                   'BUTTON': ('#000000', '#fdcb52'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBlue2': {'BACKGROUND': '#1a2835', 'TEXT': '#d1ecff', 'INPUT': '#335267', 'TEXT_INPUT': '#acc2d0', 'SCROLL': '#1b6497',
-                  'BUTTON': ('#000000', '#fafaf8'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBrown2': {'BACKGROUND': '#280001', 'TEXT': '#FFFFFF', 'INPUT': '#d8d584', 'TEXT_INPUT': '#000000', 'SCROLL': '#763e00',
-                   'BUTTON': ('#000000', '#daad28'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGreen': {'BACKGROUND': '#82a459', 'TEXT': '#000000', 'INPUT': '#d8d584', 'TEXT_INPUT': '#000000', 'SCROLL': '#e3ecf3',
-                  'BUTTON': ('#FFFFFF', '#517239'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBlue1': {'BACKGROUND': '#A5CADD', 'TEXT': '#6E266E', 'INPUT': '#E0F5FF', 'TEXT_INPUT': '#000000', 'SCROLL': '#E0F5FF',
-                   'BUTTON': ('#FFFFFF', '#303952'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightPurple': {'BACKGROUND': '#B0AAC2', 'TEXT': '#000000', 'INPUT': '#F2EFE8', 'SCROLL': '#F2EFE8', 'TEXT_INPUT': '#000000',
-                    'BUTTON': ('#000000', '#C2D4D8'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBlue2': {'BACKGROUND': '#AAB6D3', 'TEXT': '#000000', 'INPUT': '#F1F4FC', 'SCROLL': '#F1F4FC', 'TEXT_INPUT': '#000000',
-                   'BUTTON': ('#FFFFFF', '#7186C7'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightGreen3': {'BACKGROUND': '#A8C1B4', 'TEXT': '#000000', 'INPUT': '#DDE0DE', 'SCROLL': '#E3E3E3', 'TEXT_INPUT': '#000000',
-                    'BUTTON': ('#FFFFFF', '#6D9F85'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBlue3': {'BACKGROUND': '#64778d', 'TEXT': '#FFFFFF', 'INPUT': '#f0f3f7', 'SCROLL': '#A6B2BE', 'TEXT_INPUT': '#000000',
-                  'BUTTON': ('#FFFFFF', '#283b5b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightGreen4': {'BACKGROUND': '#b4ffb4', 'TEXT': '#000000', 'INPUT': '#ffff64', 'SCROLL': '#ffb482', 'TEXT_INPUT': '#000000',
-                    'BUTTON': ('#000000', '#ffa0dc'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightGreen5': {'BACKGROUND': '#92aa9d', 'TEXT': '#000000', 'INPUT': '#fcfff6', 'SCROLL': '#fcfff6', 'TEXT_INPUT': '#000000',
-                    'BUTTON': ('#000000', '#d0dbbd'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBrown2': {'BACKGROUND': '#a7ad7f', 'TEXT': '#000000', 'INPUT': '#e6d3a8', 'SCROLL': '#e6d3a8', 'TEXT_INPUT': '#000000',
-                    'BUTTON': ('#FFFFFF', '#5d907d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBrown3': {'BACKGROUND': '#efeccb', 'TEXT': '#012f2f', 'INPUT': '#e6d3a8', 'SCROLL': '#e6d3a8', 'TEXT_INPUT': '#012f2f',
-                    'BUTTON': ('#FFFFFF', '#046380'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBlue3': {'BACKGROUND': '#a8cfdd', 'TEXT': '#000000', 'INPUT': '#dfedf2', 'SCROLL': '#dfedf2', 'TEXT_INPUT': '#000000',
-                   'BUTTON': ('#FFFFFF', '#183440'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'LightBrown4': {'BACKGROUND': '#d7c79e', 'TEXT': '#a35638', 'INPUT': '#9dab86', 'TEXT_INPUT': '#000000', 'SCROLL': '#a35638',
-                    'BUTTON': ('#FFFFFF', '#a35638'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'], },
-    'DarkTeal': {'BACKGROUND': '#003f5c', 'TEXT': '#fb5b5a', 'INPUT': '#bc4873', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#bc4873', 'BUTTON': ('#FFFFFF', '#fb5b5a'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                 'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'], },
-    'DarkPurple': {'BACKGROUND': '#472b62', 'TEXT': '#fb5b5a', 'INPUT': '#bc4873', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#bc4873',
-                   'BUTTON': ('#FFFFFF', '#472b62'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'], },
-    'LightGreen6': {'BACKGROUND': '#eafbea', 'TEXT': '#1f6650', 'INPUT': '#6f9a8d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#1f6650',
-                    'BUTTON': ('#FFFFFF', '#1f6650'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'], },
-    'DarkGrey2': {'BACKGROUND': '#2b2b28', 'TEXT': '#f8f8f8', 'INPUT': '#f1d6ab', 'TEXT_INPUT': '#000000', 'SCROLL': '#f1d6ab',
-                  'BUTTON': ('#2b2b28', '#e3b04b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'], },
-    'LightBrown6': {'BACKGROUND': '#f9b282', 'TEXT': '#8f4426', 'INPUT': '#de6b35', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#8f4426',
-                    'BUTTON': ('#FFFFFF', '#8f4426'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'], },
-    'DarkTeal1': {'BACKGROUND': '#396362', 'TEXT': '#ffe7d1', 'INPUT': '#f6c89f', 'TEXT_INPUT': '#000000', 'SCROLL': '#f6c89f',
-                  'BUTTON': ('#ffe7d1', '#4b8e8d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'], },
-    'LightBrown7': {'BACKGROUND': '#f6c89f', 'TEXT': '#396362', 'INPUT': '#4b8e8d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#396362',
-                    'BUTTON': ('#FFFFFF', '#396362'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'], },
-    'DarkPurple1': {'BACKGROUND': '#0c093c', 'TEXT': '#fad6d6', 'INPUT': '#eea5f6', 'TEXT_INPUT': '#000000', 'SCROLL': '#eea5f6',
-                    'BUTTON': ('#FFFFFF', '#df42d1'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'], },
-    'DarkGrey3': {'BACKGROUND': '#211717', 'TEXT': '#dfddc7', 'INPUT': '#f58b54', 'TEXT_INPUT': '#000000', 'SCROLL': '#f58b54',
-                  'BUTTON': ('#dfddc7', '#a34a28'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'], },
-    'LightBrown8': {'BACKGROUND': '#dfddc7', 'TEXT': '#211717', 'INPUT': '#a34a28', 'TEXT_INPUT': '#dfddc7', 'SCROLL': '#211717',
-                    'BUTTON': ('#dfddc7', '#a34a28'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'], },
-    'DarkBlue4': {'BACKGROUND': '#494ca2', 'TEXT': '#e3e7f1', 'INPUT': '#c6cbef', 'TEXT_INPUT': '#000000', 'SCROLL': '#c6cbef',
-                  'BUTTON': ('#FFFFFF', '#8186d5'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'], },
-    'LightBlue4': {'BACKGROUND': '#5c94bd', 'TEXT': '#470938', 'INPUT': '#1a3e59', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#470938',
-                   'BUTTON': ('#FFFFFF', '#470938'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'], },
-    'DarkTeal2': {'BACKGROUND': '#394a6d', 'TEXT': '#c0ffb3', 'INPUT': '#52de97', 'TEXT_INPUT': '#000000', 'SCROLL': '#52de97',
-                  'BUTTON': ('#c0ffb3', '#394a6d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'], },
-    'DarkTeal3': {'BACKGROUND': '#3c9d9b', 'TEXT': '#c0ffb3', 'INPUT': '#52de97', 'TEXT_INPUT': '#000000', 'SCROLL': '#52de97',
-                  'BUTTON': ('#c0ffb3', '#394a6d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'], },
-    'DarkPurple5': {'BACKGROUND': '#730068', 'TEXT': '#f6f078', 'INPUT': '#01d28e', 'TEXT_INPUT': '#000000', 'SCROLL': '#01d28e',
-                    'BUTTON': ('#f6f078', '#730068'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'], },
-    'DarkPurple2': {'BACKGROUND': '#202060', 'TEXT': '#b030b0', 'INPUT': '#602080', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#602080',
-                    'BUTTON': ('#FFFFFF', '#202040'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'], },
-    'DarkBlue5': {'BACKGROUND': '#000272', 'TEXT': '#ff6363', 'INPUT': '#a32f80', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#a32f80',
-                  'BUTTON': ('#FFFFFF', '#341677'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'], },
-    'LightGrey2': {'BACKGROUND': '#f6f6f6', 'TEXT': '#420000', 'INPUT': '#d4d7dd', 'TEXT_INPUT': '#420000', 'SCROLL': '#420000',
-                   'BUTTON': ('#420000', '#d4d7dd'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'], },
-    'LightGrey3': {'BACKGROUND': '#eae9e9', 'TEXT': '#420000', 'INPUT': '#d4d7dd', 'TEXT_INPUT': '#420000', 'SCROLL': '#420000',
-                   'BUTTON': ('#420000', '#d4d7dd'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'], },
-    'DarkBlue6': {'BACKGROUND': '#01024e', 'TEXT': '#ff6464', 'INPUT': '#8b4367', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#8b4367',
-                  'BUTTON': ('#FFFFFF', '#543864'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'], },
-    'DarkBlue7': {'BACKGROUND': '#241663', 'TEXT': '#eae7af', 'INPUT': '#a72693', 'TEXT_INPUT': '#eae7af', 'SCROLL': '#a72693',
-                  'BUTTON': ('#eae7af', '#160f30'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'], },
-    'LightBrown9': {'BACKGROUND': '#f6d365', 'TEXT': '#3a1f5d', 'INPUT': '#c83660', 'TEXT_INPUT': '#f6d365', 'SCROLL': '#3a1f5d',
-                    'BUTTON': ('#f6d365', '#c83660'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'], },
-    'DarkPurple3': {'BACKGROUND': '#6e2142', 'TEXT': '#ffd692', 'INPUT': '#e16363', 'TEXT_INPUT': '#ffd692', 'SCROLL': '#e16363',
-                    'BUTTON': ('#ffd692', '#943855'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'], },
-    'LightBrown10': {'BACKGROUND': '#ffd692', 'TEXT': '#6e2142', 'INPUT': '#943855', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#6e2142',
-                     'BUTTON': ('#FFFFFF', '#6e2142'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                     'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'], },
-    'DarkPurple4': {'BACKGROUND': '#200f21', 'TEXT': '#f638dc', 'INPUT': '#5a3d5c', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#5a3d5c',
-                    'BUTTON': ('#FFFFFF', '#382039'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'], },
-    'LightBlue5': {'BACKGROUND': '#b2fcff', 'TEXT': '#3e64ff', 'INPUT': '#5edfff', 'TEXT_INPUT': '#000000', 'SCROLL': '#3e64ff',
-                   'BUTTON': ('#FFFFFF', '#3e64ff'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'], },
-    'DarkTeal4': {'BACKGROUND': '#464159', 'TEXT': '#c7f0db', 'INPUT': '#8bbabb', 'TEXT_INPUT': '#000000', 'SCROLL': '#8bbabb',
-                  'BUTTON': ('#FFFFFF', '#6c7b95'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-    'LightTeal': {'BACKGROUND': '#c7f0db', 'TEXT': '#464159', 'INPUT': '#6c7b95', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#464159',
-                  'BUTTON': ('#FFFFFF', '#464159'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-    'DarkTeal5': {'BACKGROUND': '#8bbabb', 'TEXT': '#464159', 'INPUT': '#6c7b95', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#464159',
-                  'BUTTON': ('#c7f0db', '#6c7b95'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-    'LightGrey4': {'BACKGROUND': '#faf5ef', 'TEXT': '#672f2f', 'INPUT': '#99b19c', 'TEXT_INPUT': '#672f2f', 'SCROLL': '#672f2f',
-                   'BUTTON': ('#672f2f', '#99b19c'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-    'LightGreen7': {'BACKGROUND': '#99b19c', 'TEXT': '#faf5ef', 'INPUT': '#d7d1c9', 'TEXT_INPUT': '#000000', 'SCROLL': '#d7d1c9',
-                    'BUTTON': ('#FFFFFF', '#99b19c'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-    'LightGrey5': {'BACKGROUND': '#d7d1c9', 'TEXT': '#672f2f', 'INPUT': '#99b19c', 'TEXT_INPUT': '#672f2f', 'SCROLL': '#672f2f',
-                   'BUTTON': ('#FFFFFF', '#672f2f'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-    'DarkBrown3': {'BACKGROUND': '#a0855b', 'TEXT': '#f9f6f2', 'INPUT': '#f1d6ab', 'TEXT_INPUT': '#000000', 'SCROLL': '#f1d6ab',
-                   'BUTTON': ('#FFFFFF', '#38470b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'], },
-    'LightBrown11': {'BACKGROUND': '#f1d6ab', 'TEXT': '#38470b', 'INPUT': '#a0855b', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#38470b',
-                     'BUTTON': ('#f9f6f2', '#a0855b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                     'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'], },
-    'DarkRed': {'BACKGROUND': '#83142c', 'TEXT': '#f9d276', 'INPUT': '#ad1d45', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#ad1d45', 'BUTTON': ('#f9d276', '#ad1d45'),
-                'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'], },
-    'DarkTeal6': {'BACKGROUND': '#204969', 'TEXT': '#fff7f7', 'INPUT': '#dadada', 'TEXT_INPUT': '#000000', 'SCROLL': '#dadada',
-                  'BUTTON': ('#000000', '#fff7f7'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'], },
-    'DarkBrown4': {'BACKGROUND': '#252525', 'TEXT': '#ff0000', 'INPUT': '#af0404', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#af0404',
-                   'BUTTON': ('#FFFFFF', '#252525'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'], },
-    'LightYellow': {'BACKGROUND': '#f4ff61', 'TEXT': '#27aa80', 'INPUT': '#32ff6a', 'TEXT_INPUT': '#000000', 'SCROLL': '#27aa80',
-                    'BUTTON': ('#f4ff61', '#27aa80'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'], },
-    'DarkGreen1': {'BACKGROUND': '#2b580c', 'TEXT': '#fdef96', 'INPUT': '#f7b71d', 'TEXT_INPUT': '#000000', 'SCROLL': '#f7b71d',
-                   'BUTTON': ('#fdef96', '#2b580c'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'], },
-    'LightGreen8': {'BACKGROUND': '#c8dad3', 'TEXT': '#63707e', 'INPUT': '#93b5b3', 'TEXT_INPUT': '#000000', 'SCROLL': '#63707e',
-                    'BUTTON': ('#FFFFFF', '#63707e'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'], },
-    'DarkTeal7': {'BACKGROUND': '#248ea9', 'TEXT': '#fafdcb', 'INPUT': '#aee7e8', 'TEXT_INPUT': '#000000', 'SCROLL': '#aee7e8',
-                  'BUTTON': ('#000000', '#fafdcb'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'], },
-    'DarkBlue8': {'BACKGROUND': '#454d66', 'TEXT': '#d9d872', 'INPUT': '#58b368', 'TEXT_INPUT': '#000000', 'SCROLL': '#58b368',
-                  'BUTTON': ('#000000', '#009975'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'], },
-    'DarkBlue9': {'BACKGROUND': '#263859', 'TEXT': '#ff6768', 'INPUT': '#6b778d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#6b778d',
-                  'BUTTON': ('#ff6768', '#263859'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'], },
-    'DarkBlue10': {'BACKGROUND': '#0028ff', 'TEXT': '#f1f4df', 'INPUT': '#10eaf0', 'TEXT_INPUT': '#000000', 'SCROLL': '#10eaf0',
-                   'BUTTON': ('#f1f4df', '#24009c'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'], },
-    'DarkBlue11': {'BACKGROUND': '#6384b3', 'TEXT': '#e6f0b6', 'INPUT': '#b8e9c0', 'TEXT_INPUT': '#000000', 'SCROLL': '#b8e9c0',
-                   'BUTTON': ('#e6f0b6', '#684949'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'], },
-    'DarkTeal8': {'BACKGROUND': '#71a0a5', 'TEXT': '#212121', 'INPUT': '#665c84', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#212121',
-                  'BUTTON': ('#fab95b', '#665c84'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'], },
-    'DarkRed1': {'BACKGROUND': '#c10000', 'TEXT': '#eeeeee', 'INPUT': '#dedede', 'TEXT_INPUT': '#000000', 'SCROLL': '#dedede', 'BUTTON': ('#c10000', '#eeeeee'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                 'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'], },
-    'LightBrown5': {'BACKGROUND': '#fff591', 'TEXT': '#e41749', 'INPUT': '#f5587b', 'TEXT_INPUT': '#000000', 'SCROLL': '#e41749',
-                    'BUTTON': ('#fff591', '#e41749'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'], },
-    'LightGreen9': {'BACKGROUND': '#f1edb3', 'TEXT': '#3b503d', 'INPUT': '#4a746e', 'TEXT_INPUT': '#f1edb3', 'SCROLL': '#3b503d',
-                    'BUTTON': ('#f1edb3', '#3b503d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'], 'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'], },
-    'DarkGreen2': {'BACKGROUND': '#3b503d', 'TEXT': '#f1edb3', 'INPUT': '#c8cf94', 'TEXT_INPUT': '#000000', 'SCROLL': '#c8cf94',
-                   'BUTTON': ('#f1edb3', '#3b503d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'], 'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'], },
-    'LightGray1': {'BACKGROUND': '#f2f2f2', 'TEXT': '#222831', 'INPUT': '#393e46', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#222831',
-                   'BUTTON': ('#f2f2f2', '#222831'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'], 'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn'], },
-    'DarkGrey4': {'BACKGROUND': '#52524e', 'TEXT': '#e9e9e5', 'INPUT': '#d4d6c8', 'TEXT_INPUT': '#000000', 'SCROLL': '#d4d6c8',
-                  'BUTTON': ('#FFFFFF', '#9a9b94'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'], 'DESCRIPTION': ['Grey', 'Pastel', 'Winter'], },
-    'DarkBlue12': {'BACKGROUND': '#324e7b', 'TEXT': '#f8f8f8', 'INPUT': '#86a6df', 'TEXT_INPUT': '#000000', 'SCROLL': '#86a6df',
-                   'BUTTON': ('#FFFFFF', '#5068a9'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'], 'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'], },
-    'DarkPurple6': {'BACKGROUND': '#070739', 'TEXT': '#e1e099', 'INPUT': '#c327ab', 'TEXT_INPUT': '#e1e099', 'SCROLL': '#c327ab',
-                    'BUTTON': ('#e1e099', '#521477'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                    'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'], 'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark'], },
-    'DarkPurple7': {'BACKGROUND': '#191930', 'TEXT': '#B1B7C5', 'INPUT': '#232B5C', 'TEXT_INPUT': '#D0E3E7', 'SCROLL': '#B1B7C5',
-                    'BUTTON': ('#272D38', '#B1B7C5'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkBlue13': {'BACKGROUND': '#203562', 'TEXT': '#e3e8f8', 'INPUT': '#c0c5cd', 'TEXT_INPUT': '#000000', 'SCROLL': '#c0c5cd',
-                   'BUTTON': ('#FFFFFF', '#3e588f'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'], 'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'], },
-    'DarkBrown5': {'BACKGROUND': '#3c1b1f', 'TEXT': '#f6e1b5', 'INPUT': '#e2bf81', 'TEXT_INPUT': '#000000', 'SCROLL': '#e2bf81',
-                   'BUTTON': ('#3c1b1f', '#f6e1b5'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'], 'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'], },
-    'DarkGreen3': {'BACKGROUND': '#062121', 'TEXT': '#eeeeee', 'INPUT': '#e4dcad', 'TEXT_INPUT': '#000000', 'SCROLL': '#e4dcad',
-                   'BUTTON': ('#eeeeee', '#181810'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'], 'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'], },
-    'DarkBlack1': {'BACKGROUND': '#181810', 'TEXT': '#eeeeee', 'INPUT': '#e4dcad', 'TEXT_INPUT': '#000000', 'SCROLL': '#e4dcad',
-                   'BUTTON': ('#FFFFFF', '#062121'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'], 'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'], },
-    'DarkGrey5': {'BACKGROUND': '#343434', 'TEXT': '#f3f3f3', 'INPUT': '#e9dcbe', 'TEXT_INPUT': '#000000', 'SCROLL': '#e9dcbe',
-                  'BUTTON': ('#FFFFFF', '#8e8b82'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'], 'DESCRIPTION': ['Grey', 'Brown'], },
-    'LightBrown12': {'BACKGROUND': '#8e8b82', 'TEXT': '#f3f3f3', 'INPUT': '#e9dcbe', 'TEXT_INPUT': '#000000', 'SCROLL': '#e9dcbe',
-                     'BUTTON': ('#f3f3f3', '#8e8b82'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                     'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'], 'DESCRIPTION': ['Grey', 'Brown'], },
-    'DarkTeal9': {'BACKGROUND': '#13445a', 'TEXT': '#fef4e8', 'INPUT': '#446878', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#446878',
-                  'BUTTON': ('#fef4e8', '#446878'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'], 'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'], },
-    'DarkBlue14': {'BACKGROUND': '#21273d', 'TEXT': '#f1f6f8', 'INPUT': '#b9d4f1', 'TEXT_INPUT': '#000000', 'SCROLL': '#b9d4f1',
-                   'BUTTON': ('#FFFFFF', '#6a759b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'], 'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'], },
-    'LightBlue6': {'BACKGROUND': '#f1f6f8', 'TEXT': '#21273d', 'INPUT': '#6a759b', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#21273d',
-                   'BUTTON': ('#f1f6f8', '#6a759b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'], 'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'], },
-    'DarkGreen4': {'BACKGROUND': '#044343', 'TEXT': '#e4e4e4', 'INPUT': '#045757', 'TEXT_INPUT': '#e4e4e4', 'SCROLL': '#045757',
-                   'BUTTON': ('#e4e4e4', '#045757'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'], 'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark'], },
-    'DarkGreen5': {'BACKGROUND': '#1b4b36', 'TEXT': '#e0e7f1', 'INPUT': '#aebd77', 'TEXT_INPUT': '#000000', 'SCROLL': '#aebd77',
-                   'BUTTON': ('#FFFFFF', '#538f6a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'], 'DESCRIPTION': ['Green', 'Grey'], },
-    'DarkTeal10': {'BACKGROUND': '#0d3446', 'TEXT': '#d8dfe2', 'INPUT': '#71adb5', 'TEXT_INPUT': '#000000', 'SCROLL': '#71adb5',
-                   'BUTTON': ('#FFFFFF', '#176d81'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'], 'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'], },
-    'DarkGrey6': {'BACKGROUND': '#3e3e3e', 'TEXT': '#ededed', 'INPUT': '#68868c', 'TEXT_INPUT': '#ededed', 'SCROLL': '#68868c',
-                  'BUTTON': ('#FFFFFF', '#405559'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'], 'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'], },
-    'DarkTeal11': {'BACKGROUND': '#405559', 'TEXT': '#ededed', 'INPUT': '#68868c', 'TEXT_INPUT': '#ededed', 'SCROLL': '#68868c',
-                   'BUTTON': ('#ededed', '#68868c'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'], 'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'], },
-    'LightBlue7': {'BACKGROUND': '#9ed0e0', 'TEXT': '#19483f', 'INPUT': '#5c868e', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#19483f',
-                   'BUTTON': ('#FFFFFF', '#19483f'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'], 'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'], },
-    'LightGreen10': {'BACKGROUND': '#d8ebb5', 'TEXT': '#205d67', 'INPUT': '#639a67', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#205d67',
-                     'BUTTON': ('#d8ebb5', '#205d67'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                     'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'], 'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'], },
-    'DarkBlue15': {'BACKGROUND': '#151680', 'TEXT': '#f1fea4', 'INPUT': '#375fc0', 'TEXT_INPUT': '#f1fea4', 'SCROLL': '#375fc0',
-                   'BUTTON': ('#f1fea4', '#1c44ac'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'], 'DESCRIPTION': ['Blue', 'Yellow', 'Cold'], },
-    'DarkBlue16': {'BACKGROUND': '#1c44ac', 'TEXT': '#f1fea4', 'INPUT': '#375fc0', 'TEXT_INPUT': '#f1fea4', 'SCROLL': '#375fc0',
-                   'BUTTON': ('#f1fea4', '#151680'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'], 'DESCRIPTION': ['Blue', 'Yellow', 'Cold'], },
-    'DarkTeal12': {'BACKGROUND': '#004a7c', 'TEXT': '#fafafa', 'INPUT': '#e8f1f5', 'TEXT_INPUT': '#000000', 'SCROLL': '#e8f1f5',
-                   'BUTTON': ('#fafafa', '#005691'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'], 'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'], },
-    'LightBrown13': {'BACKGROUND': '#ebf5ee', 'TEXT': '#921224', 'INPUT': '#bdc6b8', 'TEXT_INPUT': '#921224', 'SCROLL': '#921224',
-                     'BUTTON': ('#FFFFFF', '#921224'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                     'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'], 'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'], },
-    'DarkBlue17': {'BACKGROUND': '#21294c', 'TEXT': '#f9f2d7', 'INPUT': '#f2dea8', 'TEXT_INPUT': '#000000', 'SCROLL': '#f2dea8',
-                   'BUTTON': ('#f9f2d7', '#141829'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'], 'DESCRIPTION': ['#000000', 'Blue', 'Yellow'], },
-    'DarkBlue18': {'BACKGROUND': '#0c1825', 'TEXT': '#d1d7dd', 'INPUT': '#001c35', 'TEXT_INPUT': '#d1d7dd', 'SCROLL': '#00438e',
-                   'BUTTON': ('#75b7ff', '#001c35'), 'PROGRESS': ('#0074ff', '#75b7ff'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'], 'DESCRIPTION': ['#000000', 'Blue', 'Yellow'], },
-    'DarkBrown6': {'BACKGROUND': '#785e4d', 'TEXT': '#f2eee3', 'INPUT': '#baaf92', 'TEXT_INPUT': '#000000', 'SCROLL': '#baaf92',
-                   'BUTTON': ('#FFFFFF', '#785e4d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'], 'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'], },
-    'DarkGreen6': {'BACKGROUND': '#5c715e', 'TEXT': '#f2f9f1', 'INPUT': '#ddeedf', 'TEXT_INPUT': '#000000', 'SCROLL': '#ddeedf',
-                   'BUTTON': ('#f2f9f1', '#5c715e'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'], 'DESCRIPTION': ['Grey', 'Green', 'Vintage'], },
-    'DarkGreen7': {'BACKGROUND': '#0C231E', 'TEXT': '#efbe1c', 'INPUT': '#153C33', 'TEXT_INPUT': '#efbe1c', 'SCROLL': '#153C33',
-                   'BUTTON': ('#efbe1c', '#153C33'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey7': {'BACKGROUND': '#4b586e', 'TEXT': '#dddddd', 'INPUT': '#574e6d', 'TEXT_INPUT': '#dddddd', 'SCROLL': '#574e6d',
-                  'BUTTON': ('#dddddd', '#43405d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                  'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'], 'DESCRIPTION': ['Grey', 'Winter', 'Cold'], },
-    'DarkRed2': {'BACKGROUND': '#ab1212', 'TEXT': '#f6e4b5', 'INPUT': '#cd3131', 'TEXT_INPUT': '#f6e4b5', 'SCROLL': '#cd3131', 'BUTTON': ('#f6e4b5', '#ab1212'),
-                 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                 'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'], 'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'], },
-    'LightGrey6': {'BACKGROUND': '#e3e3e3', 'TEXT': '#233142', 'INPUT': '#455d7a', 'TEXT_INPUT': '#e3e3e3', 'SCROLL': '#233142',
-                   'BUTTON': ('#e3e3e3', '#455d7a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                   'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'], 'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey'], },
-    'HotDogStand': {'BACKGROUND': 'red', 'TEXT': 'yellow', 'INPUT': 'yellow', 'TEXT_INPUT': '#000000', 'SCROLL': 'yellow', 'BUTTON': ('red', 'yellow'),
-                    'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey8': {'BACKGROUND': '#19232D', 'TEXT': '#ffffff', 'INPUT': '#32414B', 'TEXT_INPUT': '#ffffff', 'SCROLL': '#505F69',
-                  'BUTTON': ('#ffffff', '#32414B'), 'PROGRESS': ('#505F69', '#32414B'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey9': {'BACKGROUND': '#36393F', 'TEXT': '#DCDDDE', 'INPUT': '#40444B', 'TEXT_INPUT': '#ffffff', 'SCROLL': '#202225',
-                  'BUTTON': ('#202225', '#B9BBBE'), 'PROGRESS': ('#202225', '#40444B'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey10': {'BACKGROUND': '#1c1e23', 'TEXT': '#cccdcf', 'INPUT': '#272a31', 'TEXT_INPUT': '#8b9fde', 'SCROLL': '#313641',
-                   'BUTTON': ('#f5f5f6', '#2e3d5a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey11': {'BACKGROUND': '#1c1e23', 'TEXT': '#cccdcf', 'INPUT': '#313641', 'TEXT_INPUT': '#cccdcf', 'SCROLL': '#313641',
-                   'BUTTON': ('#f5f5f6', '#313641'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey12': {'BACKGROUND': '#1c1e23', 'TEXT': '#8b9fde', 'INPUT': '#313641', 'TEXT_INPUT': '#8b9fde', 'SCROLL': '#313641',
-                   'BUTTON': ('#cccdcf', '#2e3d5a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey13': {'BACKGROUND': '#1c1e23', 'TEXT': '#cccdcf', 'INPUT': '#272a31', 'TEXT_INPUT': '#cccdcf', 'SCROLL': '#313641',
-                   'BUTTON': ('#8b9fde', '#313641'), 'PROGRESS': ('#cccdcf', '#272a31'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey14': {'BACKGROUND': '#24292e', 'TEXT': '#fafbfc', 'INPUT': '#1d2125', 'TEXT_INPUT': '#fafbfc', 'SCROLL': '#1d2125',
-                   'BUTTON': ('#fafbfc', '#155398'), 'PROGRESS': ('#155398', '#1d2125'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'DarkGrey15': {'BACKGROUND': '#121212', 'TEXT': '#dddddd', 'INPUT': '#1e1e1e', 'TEXT_INPUT': '#69b1ef', 'SCROLL': '#272727',
-                  'BUTTON': ('#69b1ef', '#2e2e2e'), 'PROGRESS': ('#69b1ef', '#2e2e2e'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,},
-    'DarkGrey16':     {'BACKGROUND': '#353535', 'TEXT': '#ffffff', 'INPUT': '#191919', 'TEXT_INPUT': '#ffffff', 'SCROLL': '#454545',
-                       'BUTTON': ('#ffffff', '#454545'), 'PROGRESS': ('#757575', '#454545'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,},
-    'DarkBrown7': {'BACKGROUND': '#2c2417', 'TEXT': '#baa379', 'INPUT': '#baa379', 'TEXT_INPUT': '#000000', 'SCROLL': '#392e1c',
-                   'BUTTON': ('#000000', '#baa379'), 'PROGRESS': ('#baa379', '#453923'), 'BORDER': 1, 'SLIDER_DEPTH': 1, 'PROGRESS_DEPTH': 0, },
-    'Python': {'BACKGROUND': '#3d7aab', 'TEXT': '#ffde56', 'INPUT': '#295273', 'TEXT_INPUT': '#ffde56', 'SCROLL': '#295273',
-               'BUTTON': ('#ffde56', '#295273'), 'PROGRESS': ('#ffde56', '#295273'), 'BORDER': 1, 'SLIDER_DEPTH': 1, 'PROGRESS_DEPTH': 0, },
-    'PythonPlus': {'BACKGROUND': '#001d3c', 'TEXT': '#ffffff', 'INPUT': '#015bbb', 'TEXT_INPUT': '#fed500', 'SCROLL': '#015bbb',
-                   'BUTTON': ('#fed500', '#015bbb'), 'PROGRESS': ('#015bbb', '#fed500'), 'BORDER': 1, 'SLIDER_DEPTH': 1, 'PROGRESS_DEPTH': 0, },
-    'NeonBlue1': {'BACKGROUND': '#000000', 'TEXT': '#ffffff', 'INPUT': '#000000', 'TEXT_INPUT': '#33ccff', 'SCROLL': '#33ccff',
-                  'BUTTON': ('#33ccff', '#000000'), 'PROGRESS': ('#33ccff', '#ffffff'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'NeonGreen1': {'BACKGROUND': '#000000', 'TEXT': '#ffffff', 'INPUT': '#000000', 'TEXT_INPUT': '#96ff7b', 'SCROLL': '#96ff7b',
-                   'BUTTON': ('#96ff7b', '#000000'), 'PROGRESS': ('#96ff7b', '#ffffff'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
-    'NeonYellow1': {'BACKGROUND': '#000000', 'TEXT': '#ffffff', 'INPUT': '#000000', 'TEXT_INPUT': '#ffcf40', 'SCROLL': '#ffcf40',
-                    'BUTTON': ('#ffcf40', '#000000'), 'PROGRESS': ('#ffcf40', '#ffffff'), 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0, },
+    'SystemDefault': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefaultForReal': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefault1': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Material1': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Material2': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Reddit': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('#FFFFFF', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'Topanga': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'GreenTan': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': '#000000',
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('#FFFFFF', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': '#000000',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('#FFFFFF', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark2': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#FFFFFF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Black': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#000000', '#FFFFFF'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Black2': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#000000',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#FFFFFF',
+        'BUTTON': ('#000000', '#FFFFFF'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Tan': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TanBlue': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkTanBlue': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkAmber': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('#000000', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('#000000', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Reds': {
+        'BACKGROUND': '#280001',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#763e00',
+        'BUTTON': ('#000000', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Green': {
+        'BACKGROUND': '#82a459',
+        'TEXT': '#000000',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('#FFFFFF', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BluePurple': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('#FFFFFF', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Purple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': '#000000',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BlueMono': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': '#000000',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'GreenMono': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': '#000000',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrownBlue': {
+        'BACKGROUND': '#64778d',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrightColors': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': '#000000',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'NeutralBlue': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': '#000000',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Kayak': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': '#000000',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SandyBeach': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('#FFFFFF', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TealMono': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': '#000000',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Default': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Default1': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DefaultNoMoreNagging': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'GrayGrayGray': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey1': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('#FFFFFF', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'DarkBrown': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'LightGreen1': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': '#000000',
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('#FFFFFF', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen2': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': '#000000',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('#FFFFFF', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey1': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#FFFFFF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlack': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#000000', '#FFFFFF'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown1': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue1': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown1': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('#000000', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue2': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('#000000', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown2': {
+        'BACKGROUND': '#280001',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#763e00',
+        'BUTTON': ('#000000', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGreen': {
+        'BACKGROUND': '#82a459',
+        'TEXT': '#000000',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('#FFFFFF', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue1': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('#FFFFFF', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightPurple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': '#000000',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue2': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': '#000000',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen3': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': '#000000',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue3': {
+        'BACKGROUND': '#64778d',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen4': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': '#000000',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen5': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': '#000000',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown2': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': '#000000',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown3': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('#FFFFFF', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue3': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': '#000000',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown4': {
+        'BACKGROUND': '#d7c79e',
+        'TEXT': '#a35638',
+        'INPUT': '#9dab86',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#a35638',
+        'BUTTON': ('#FFFFFF', '#a35638'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'],
+    },
+    'DarkTeal': {
+        'BACKGROUND': '#003f5c',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('#FFFFFF', '#fb5b5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'DarkPurple': {
+        'BACKGROUND': '#472b62',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('#FFFFFF', '#472b62'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'LightGreen6': {
+        'BACKGROUND': '#eafbea',
+        'TEXT': '#1f6650',
+        'INPUT': '#6f9a8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#1f6650',
+        'BUTTON': ('#FFFFFF', '#1f6650'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'],
+    },
+    'DarkGrey2': {
+        'BACKGROUND': '#2b2b28',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('#2b2b28', '#e3b04b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'],
+    },
+    'LightBrown6': {
+        'BACKGROUND': '#f9b282',
+        'TEXT': '#8f4426',
+        'INPUT': '#de6b35',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8f4426',
+        'BUTTON': ('#FFFFFF', '#8f4426'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'],
+    },
+    'DarkTeal1': {
+        'BACKGROUND': '#396362',
+        'TEXT': '#ffe7d1',
+        'INPUT': '#f6c89f',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f6c89f',
+        'BUTTON': ('#ffe7d1', '#4b8e8d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'LightBrown7': {
+        'BACKGROUND': '#f6c89f',
+        'TEXT': '#396362',
+        'INPUT': '#4b8e8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#396362',
+        'BUTTON': ('#FFFFFF', '#396362'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'DarkPurple1': {
+        'BACKGROUND': '#0c093c',
+        'TEXT': '#fad6d6',
+        'INPUT': '#eea5f6',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#eea5f6',
+        'BUTTON': ('#FFFFFF', '#df42d1'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'],
+    },
+    'DarkGrey3': {
+        'BACKGROUND': '#211717',
+        'TEXT': '#dfddc7',
+        'INPUT': '#f58b54',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f58b54',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'LightBrown8': {
+        'BACKGROUND': '#dfddc7',
+        'TEXT': '#211717',
+        'INPUT': '#a34a28',
+        'TEXT_INPUT': '#dfddc7',
+        'SCROLL': '#211717',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'DarkBlue4': {
+        'BACKGROUND': '#494ca2',
+        'TEXT': '#e3e7f1',
+        'INPUT': '#c6cbef',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c6cbef',
+        'BUTTON': ('#FFFFFF', '#8186d5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'],
+    },
+    'LightBlue4': {
+        'BACKGROUND': '#5c94bd',
+        'TEXT': '#470938',
+        'INPUT': '#1a3e59',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#470938',
+        'BUTTON': ('#FFFFFF', '#470938'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'],
+    },
+    'DarkTeal2': {
+        'BACKGROUND': '#394a6d',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkTeal3': {
+        'BACKGROUND': '#3c9d9b',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkPurple5': {
+        'BACKGROUND': '#730068',
+        'TEXT': '#f6f078',
+        'INPUT': '#01d28e',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#01d28e',
+        'BUTTON': ('#f6f078', '#730068'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'],
+    },
+    'DarkPurple2': {
+        'BACKGROUND': '#202060',
+        'TEXT': '#b030b0',
+        'INPUT': '#602080',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#602080',
+        'BUTTON': ('#FFFFFF', '#202040'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'],
+    },
+    'DarkBlue5': {
+        'BACKGROUND': '#000272',
+        'TEXT': '#ff6363',
+        'INPUT': '#a32f80',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a32f80',
+        'BUTTON': ('#FFFFFF', '#341677'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'],
+    },
+    'LightGrey2': {
+        'BACKGROUND': '#f6f6f6',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'LightGrey3': {
+        'BACKGROUND': '#eae9e9',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'DarkBlue6': {
+        'BACKGROUND': '#01024e',
+        'TEXT': '#ff6464',
+        'INPUT': '#8b4367',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8b4367',
+        'BUTTON': ('#FFFFFF', '#543864'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'],
+    },
+    'DarkBlue7': {
+        'BACKGROUND': '#241663',
+        'TEXT': '#eae7af',
+        'INPUT': '#a72693',
+        'TEXT_INPUT': '#eae7af',
+        'SCROLL': '#a72693',
+        'BUTTON': ('#eae7af', '#160f30'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'],
+    },
+    'LightBrown9': {
+        'BACKGROUND': '#f6d365',
+        'TEXT': '#3a1f5d',
+        'INPUT': '#c83660',
+        'TEXT_INPUT': '#f6d365',
+        'SCROLL': '#3a1f5d',
+        'BUTTON': ('#f6d365', '#c83660'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'],
+    },
+    'DarkPurple3': {
+        'BACKGROUND': '#6e2142',
+        'TEXT': '#ffd692',
+        'INPUT': '#e16363',
+        'TEXT_INPUT': '#ffd692',
+        'SCROLL': '#e16363',
+        'BUTTON': ('#ffd692', '#943855'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'LightBrown10': {
+        'BACKGROUND': '#ffd692',
+        'TEXT': '#6e2142',
+        'INPUT': '#943855',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6e2142',
+        'BUTTON': ('#FFFFFF', '#6e2142'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'DarkPurple4': {
+        'BACKGROUND': '#200f21',
+        'TEXT': '#f638dc',
+        'INPUT': '#5a3d5c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5a3d5c',
+        'BUTTON': ('#FFFFFF', '#382039'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'],
+    },
+    'LightBlue5': {
+        'BACKGROUND': '#b2fcff',
+        'TEXT': '#3e64ff',
+        'INPUT': '#5edfff',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#3e64ff',
+        'BUTTON': ('#FFFFFF', '#3e64ff'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'],
+    },
+    'DarkTeal4': {
+        'BACKGROUND': '#464159',
+        'TEXT': '#c7f0db',
+        'INPUT': '#8bbabb',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#8bbabb',
+        'BUTTON': ('#FFFFFF', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightTeal': {
+        'BACKGROUND': '#c7f0db',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('#FFFFFF', '#464159'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'DarkTeal5': {
+        'BACKGROUND': '#8bbabb',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('#c7f0db', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightGrey4': {
+        'BACKGROUND': '#faf5ef',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('#672f2f', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGreen7': {
+        'BACKGROUND': '#99b19c',
+        'TEXT': '#faf5ef',
+        'INPUT': '#d7d1c9',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d7d1c9',
+        'BUTTON': ('#FFFFFF', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGrey5': {
+        'BACKGROUND': '#d7d1c9',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('#FFFFFF', '#672f2f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'DarkBrown3': {
+        'BACKGROUND': '#a0855b',
+        'TEXT': '#f9f6f2',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('#FFFFFF', '#38470b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'LightBrown11': {
+        'BACKGROUND': '#f1d6ab',
+        'TEXT': '#38470b',
+        'INPUT': '#a0855b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#38470b',
+        'BUTTON': ('#f9f6f2', '#a0855b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'DarkRed': {
+        'BACKGROUND': '#83142c',
+        'TEXT': '#f9d276',
+        'INPUT': '#ad1d45',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#ad1d45',
+        'BUTTON': ('#f9d276', '#ad1d45'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'],
+    },
+    'DarkTeal6': {
+        'BACKGROUND': '#204969',
+        'TEXT': '#fff7f7',
+        'INPUT': '#dadada',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dadada',
+        'BUTTON': ('#000000', '#fff7f7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'],
+    },
+    'DarkBrown4': {
+        'BACKGROUND': '#252525',
+        'TEXT': '#ff0000',
+        'INPUT': '#af0404',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#af0404',
+        'BUTTON': ('#FFFFFF', '#252525'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'],
+    },
+    'LightYellow': {
+        'BACKGROUND': '#f4ff61',
+        'TEXT': '#27aa80',
+        'INPUT': '#32ff6a',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#27aa80',
+        'BUTTON': ('#f4ff61', '#27aa80'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'],
+    },
+    'DarkGreen1': {
+        'BACKGROUND': '#2b580c',
+        'TEXT': '#fdef96',
+        'INPUT': '#f7b71d',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f7b71d',
+        'BUTTON': ('#fdef96', '#2b580c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'],
+    },
+    'LightGreen8': {
+        'BACKGROUND': '#c8dad3',
+        'TEXT': '#63707e',
+        'INPUT': '#93b5b3',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#63707e',
+        'BUTTON': ('#FFFFFF', '#63707e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'],
+    },
+    'DarkTeal7': {
+        'BACKGROUND': '#248ea9',
+        'TEXT': '#fafdcb',
+        'INPUT': '#aee7e8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aee7e8',
+        'BUTTON': ('#000000', '#fafdcb'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'],
+    },
+    'DarkBlue8': {
+        'BACKGROUND': '#454d66',
+        'TEXT': '#d9d872',
+        'INPUT': '#58b368',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#58b368',
+        'BUTTON': ('#000000', '#009975'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'],
+    },
+    'DarkBlue9': {
+        'BACKGROUND': '#263859',
+        'TEXT': '#ff6768',
+        'INPUT': '#6b778d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6b778d',
+        'BUTTON': ('#ff6768', '#263859'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'],
+    },
+    'DarkBlue10': {
+        'BACKGROUND': '#0028ff',
+        'TEXT': '#f1f4df',
+        'INPUT': '#10eaf0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#10eaf0',
+        'BUTTON': ('#f1f4df', '#24009c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'],
+    },
+    'DarkBlue11': {
+        'BACKGROUND': '#6384b3',
+        'TEXT': '#e6f0b6',
+        'INPUT': '#b8e9c0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b8e9c0',
+        'BUTTON': ('#e6f0b6', '#684949'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'],
+    },
+    'DarkTeal8': {
+        'BACKGROUND': '#71a0a5',
+        'TEXT': '#212121',
+        'INPUT': '#665c84',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#212121',
+        'BUTTON': ('#fab95b', '#665c84'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'],
+    },
+    'DarkRed1': {
+        'BACKGROUND': '#c10000',
+        'TEXT': '#eeeeee',
+        'INPUT': '#dedede',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dedede',
+        'BUTTON': ('#c10000', '#eeeeee'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'],
+    },
+    'LightBrown5': {
+        'BACKGROUND': '#fff591',
+        'TEXT': '#e41749',
+        'INPUT': '#f5587b',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e41749',
+        'BUTTON': ('#fff591', '#e41749'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'],
+    },
+    'LightGreen9': {
+        'BACKGROUND': '#f1edb3',
+        'TEXT': '#3b503d',
+        'INPUT': '#4a746e',
+        'TEXT_INPUT': '#f1edb3',
+        'SCROLL': '#3b503d',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'DarkGreen2': {
+        'BACKGROUND': '#3b503d',
+        'TEXT': '#f1edb3',
+        'INPUT': '#c8cf94',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c8cf94',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'LightGray1': {
+        'BACKGROUND': '#f2f2f2',
+        'TEXT': '#222831',
+        'INPUT': '#393e46',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#222831',
+        'BUTTON': ('#f2f2f2', '#222831'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],
+        'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn'],
+    },
+    'DarkGrey4': {
+        'BACKGROUND': '#52524e',
+        'TEXT': '#e9e9e5',
+        'INPUT': '#d4d6c8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d4d6c8',
+        'BUTTON': ('#FFFFFF', '#9a9b94'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],
+        'DESCRIPTION': ['Grey', 'Pastel', 'Winter'],
+    },
+    'DarkBlue12': {
+        'BACKGROUND': '#324e7b',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#86a6df',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86a6df',
+        'BUTTON': ('#FFFFFF', '#5068a9'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkPurple6': {
+        'BACKGROUND': '#070739',
+        'TEXT': '#e1e099',
+        'INPUT': '#c327ab',
+        'TEXT_INPUT': '#e1e099',
+        'SCROLL': '#c327ab',
+        'BUTTON': ('#e1e099', '#521477'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],
+        'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark'],
+    },
+    'DarkPurple7': {
+        'BACKGROUND': '#191930',
+        'TEXT': '#B1B7C5',
+        'INPUT': '#232B5C',
+        'TEXT_INPUT': '#D0E3E7',
+        'SCROLL': '#B1B7C5',
+        'BUTTON': ('#272D38', '#B1B7C5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue13': {
+        'BACKGROUND': '#203562',
+        'TEXT': '#e3e8f8',
+        'INPUT': '#c0c5cd',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c0c5cd',
+        'BUTTON': ('#FFFFFF', '#3e588f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'],
+    },
+    'DarkBrown5': {
+        'BACKGROUND': '#3c1b1f',
+        'TEXT': '#f6e1b5',
+        'INPUT': '#e2bf81',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e2bf81',
+        'BUTTON': ('#3c1b1f', '#f6e1b5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],
+        'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'],
+    },
+    'DarkGreen3': {
+        'BACKGROUND': '#062121',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('#eeeeee', '#181810'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
+    },
+    'DarkBlack1': {
+        'BACKGROUND': '#181810',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('#FFFFFF', '#062121'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
+    },
+    'DarkGrey5': {
+        'BACKGROUND': '#343434',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#FFFFFF', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'LightBrown12': {
+        'BACKGROUND': '#8e8b82',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#f3f3f3', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'DarkTeal9': {
+        'BACKGROUND': '#13445a',
+        'TEXT': '#fef4e8',
+        'INPUT': '#446878',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#446878',
+        'BUTTON': ('#fef4e8', '#446878'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],
+        'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'],
+    },
+    'DarkBlue14': {
+        'BACKGROUND': '#21273d',
+        'TEXT': '#f1f6f8',
+        'INPUT': '#b9d4f1',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b9d4f1',
+        'BUTTON': ('#FFFFFF', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
+    },
+    'LightBlue6': {
+        'BACKGROUND': '#f1f6f8',
+        'TEXT': '#21273d',
+        'INPUT': '#6a759b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#21273d',
+        'BUTTON': ('#f1f6f8', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkGreen4': {
+        'BACKGROUND': '#044343',
+        'TEXT': '#e4e4e4',
+        'INPUT': '#045757',
+        'TEXT_INPUT': '#e4e4e4',
+        'SCROLL': '#045757',
+        'BUTTON': ('#e4e4e4', '#045757'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],
+        'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark'],
+    },
+    'DarkGreen5': {
+        'BACKGROUND': '#1b4b36',
+        'TEXT': '#e0e7f1',
+        'INPUT': '#aebd77',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aebd77',
+        'BUTTON': ('#FFFFFF', '#538f6a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'],
+        'DESCRIPTION': ['Green', 'Grey'],
+    },
+    'DarkTeal10': {
+        'BACKGROUND': '#0d3446',
+        'TEXT': '#d8dfe2',
+        'INPUT': '#71adb5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#71adb5',
+        'BUTTON': ('#FFFFFF', '#176d81'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'],
+    },
+    'DarkGrey6': {
+        'BACKGROUND': '#3e3e3e',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#FFFFFF', '#405559'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'DarkTeal11': {
+        'BACKGROUND': '#405559',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#ededed', '#68868c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'LightBlue7': {
+        'BACKGROUND': '#9ed0e0',
+        'TEXT': '#19483f',
+        'INPUT': '#5c868e',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#19483f',
+        'BUTTON': ('#FFFFFF', '#19483f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],
+        'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'],
+    },
+    'LightGreen10': {
+        'BACKGROUND': '#d8ebb5',
+        'TEXT': '#205d67',
+        'INPUT': '#639a67',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#205d67',
+        'BUTTON': ('#d8ebb5', '#205d67'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],
+        'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'],
+    },
+    'DarkBlue15': {
+        'BACKGROUND': '#151680',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#1c44ac'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkBlue16': {
+        'BACKGROUND': '#1c44ac',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#151680'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkTeal12': {
+        'BACKGROUND': '#004a7c',
+        'TEXT': '#fafafa',
+        'INPUT': '#e8f1f5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e8f1f5',
+        'BUTTON': ('#fafafa', '#005691'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],
+        'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'],
+    },
+    'LightBrown13': {
+        'BACKGROUND': '#ebf5ee',
+        'TEXT': '#921224',
+        'INPUT': '#bdc6b8',
+        'TEXT_INPUT': '#921224',
+        'SCROLL': '#921224',
+        'BUTTON': ('#FFFFFF', '#921224'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],
+        'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'],
+    },
+    'DarkBlue17': {
+        'BACKGROUND': '#21294c',
+        'TEXT': '#f9f2d7',
+        'INPUT': '#f2dea8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f2dea8',
+        'BUTTON': ('#f9f2d7', '#141829'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
+        'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],
+    },
+    'DarkBlue18': {
+        'BACKGROUND': '#0c1825',
+        'TEXT': '#d1d7dd',
+        'INPUT': '#001c35',
+        'TEXT_INPUT': '#d1d7dd',
+        'SCROLL': '#00438e',
+        'BUTTON': ('#75b7ff', '#001c35'),
+        'PROGRESS': ('#0074ff', '#75b7ff'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
+        'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],
+    },
+    'DarkBrown6': {
+        'BACKGROUND': '#785e4d',
+        'TEXT': '#f2eee3',
+        'INPUT': '#baaf92',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#baaf92',
+        'BUTTON': ('#FFFFFF', '#785e4d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],
+        'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'],
+    },
+    'DarkGreen6': {
+        'BACKGROUND': '#5c715e',
+        'TEXT': '#f2f9f1',
+        'INPUT': '#ddeedf',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#ddeedf',
+        'BUTTON': ('#f2f9f1', '#5c715e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],
+        'DESCRIPTION': ['Grey', 'Green', 'Vintage'],
+    },
+    'DarkGreen7': {
+        'BACKGROUND': '#0C231E',
+        'TEXT': '#efbe1c',
+        'INPUT': '#153C33',
+        'TEXT_INPUT': '#efbe1c',
+        'SCROLL': '#153C33',
+        'BUTTON': ('#efbe1c', '#153C33'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey7': {
+        'BACKGROUND': '#4b586e',
+        'TEXT': '#dddddd',
+        'INPUT': '#574e6d',
+        'TEXT_INPUT': '#dddddd',
+        'SCROLL': '#574e6d',
+        'BUTTON': ('#dddddd', '#43405d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],
+        'DESCRIPTION': ['Grey', 'Winter', 'Cold'],
+    },
+    'DarkRed2': {
+        'BACKGROUND': '#ab1212',
+        'TEXT': '#f6e4b5',
+        'INPUT': '#cd3131',
+        'TEXT_INPUT': '#f6e4b5',
+        'SCROLL': '#cd3131',
+        'BUTTON': ('#f6e4b5', '#ab1212'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],
+        'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'],
+    },
+    'LightGrey6': {
+        'BACKGROUND': '#e3e3e3',
+        'TEXT': '#233142',
+        'INPUT': '#455d7a',
+        'TEXT_INPUT': '#e3e3e3',
+        'SCROLL': '#233142',
+        'BUTTON': ('#e3e3e3', '#455d7a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],
+        'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey'],
+    },
+    'HotDogStand': {
+        'BACKGROUND': 'red',
+        'TEXT': 'yellow',
+        'INPUT': 'yellow',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': 'yellow',
+        'BUTTON': ('red', 'yellow'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey8': {
+        'BACKGROUND': '#19232D',
+        'TEXT': '#ffffff',
+        'INPUT': '#32414B',
+        'TEXT_INPUT': '#ffffff',
+        'SCROLL': '#505F69',
+        'BUTTON': ('#ffffff', '#32414B'),
+        'PROGRESS': ('#505F69', '#32414B'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey9': {
+        'BACKGROUND': '#36393F',
+        'TEXT': '#DCDDDE',
+        'INPUT': '#40444B',
+        'TEXT_INPUT': '#ffffff',
+        'SCROLL': '#202225',
+        'BUTTON': ('#202225', '#B9BBBE'),
+        'PROGRESS': ('#202225', '#40444B'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey10': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#cccdcf',
+        'INPUT': '#272a31',
+        'TEXT_INPUT': '#8b9fde',
+        'SCROLL': '#313641',
+        'BUTTON': ('#f5f5f6', '#2e3d5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey11': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#cccdcf',
+        'INPUT': '#313641',
+        'TEXT_INPUT': '#cccdcf',
+        'SCROLL': '#313641',
+        'BUTTON': ('#f5f5f6', '#313641'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey12': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#8b9fde',
+        'INPUT': '#313641',
+        'TEXT_INPUT': '#8b9fde',
+        'SCROLL': '#313641',
+        'BUTTON': ('#cccdcf', '#2e3d5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey13': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#cccdcf',
+        'INPUT': '#272a31',
+        'TEXT_INPUT': '#cccdcf',
+        'SCROLL': '#313641',
+        'BUTTON': ('#8b9fde', '#313641'),
+        'PROGRESS': ('#cccdcf', '#272a31'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey14': {
+        'BACKGROUND': '#24292e',
+        'TEXT': '#fafbfc',
+        'INPUT': '#1d2125',
+        'TEXT_INPUT': '#fafbfc',
+        'SCROLL': '#1d2125',
+        'BUTTON': ('#fafbfc', '#155398'),
+        'PROGRESS': ('#155398', '#1d2125'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey15': {
+        'BACKGROUND': '#121212',
+        'TEXT': '#dddddd',
+        'INPUT': '#1e1e1e',
+        'TEXT_INPUT': '#69b1ef',
+        'SCROLL': '#272727',
+        'BUTTON': ('#69b1ef', '#2e2e2e'),
+        'PROGRESS': ('#69b1ef', '#2e2e2e'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey16': {
+        'BACKGROUND': '#353535',
+        'TEXT': '#ffffff',
+        'INPUT': '#191919',
+        'TEXT_INPUT': '#ffffff',
+        'SCROLL': '#454545',
+        'BUTTON': ('#ffffff', '#454545'),
+        'PROGRESS': ('#757575', '#454545'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown7': {
+        'BACKGROUND': '#2c2417',
+        'TEXT': '#baa379',
+        'INPUT': '#baa379',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#392e1c',
+        'BUTTON': ('#000000', '#baa379'),
+        'PROGRESS': ('#baa379', '#453923'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Python': {
+        'BACKGROUND': '#3d7aab',
+        'TEXT': '#ffde56',
+        'INPUT': '#295273',
+        'TEXT_INPUT': '#ffde56',
+        'SCROLL': '#295273',
+        'BUTTON': ('#ffde56', '#295273'),
+        'PROGRESS': ('#ffde56', '#295273'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'PythonPlus': {
+        'BACKGROUND': '#001d3c',
+        'TEXT': '#ffffff',
+        'INPUT': '#015bbb',
+        'TEXT_INPUT': '#fed500',
+        'SCROLL': '#015bbb',
+        'BUTTON': ('#fed500', '#015bbb'),
+        'PROGRESS': ('#015bbb', '#fed500'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'NeonBlue1': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#ffffff',
+        'INPUT': '#000000',
+        'TEXT_INPUT': '#33ccff',
+        'SCROLL': '#33ccff',
+        'BUTTON': ('#33ccff', '#000000'),
+        'PROGRESS': ('#33ccff', '#ffffff'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'NeonGreen1': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#ffffff',
+        'INPUT': '#000000',
+        'TEXT_INPUT': '#96ff7b',
+        'SCROLL': '#96ff7b',
+        'BUTTON': ('#96ff7b', '#000000'),
+        'PROGRESS': ('#96ff7b', '#ffffff'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'NeonYellow1': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#ffffff',
+        'INPUT': '#000000',
+        'TEXT_INPUT': '#ffcf40',
+        'SCROLL': '#ffcf40',
+        'BUTTON': ('#ffcf40', '#000000'),
+        'PROGRESS': ('#ffcf40', '#ffffff'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
 }
-
 
 
 def list_of_look_and_feel_values():
@@ -19670,7 +25403,10 @@ def theme_background_color(color=None):
 
 
 # This "constant" is misleading but rather than remove and break programs, will try this method instead
-TRANSPARENT_BUTTON = (theme_background_color(), theme_background_color())  # replaces an older version that had hardcoded numbers
+TRANSPARENT_BUTTON = (
+    theme_background_color(),
+    theme_background_color(),
+)  # replaces an older version that had hardcoded numbers
 
 
 def theme_element_background_color(color=None):
@@ -19904,10 +25640,12 @@ def theme_global(new_theme=None):
     """
     if new_theme is not None:
         if new_theme not in theme_list():
-            popup_error_with_traceback('Cannot use custom themes with theme_global call',
-                                       'Your request to use theme {} cannot be performed.'.format(new_theme),
-                                       'The PySimpleGUI Global User Settings are meant for PySimpleGUI standard items, not user config items',
-                                       'You can use any of the many built-in themes instead or use your own UserSettings file to store your custom theme')
+            popup_error_with_traceback(
+                'Cannot use custom themes with theme_global call',
+                'Your request to use theme {} cannot be performed.'.format(new_theme),
+                'The PySimpleGUI Global User Settings are meant for PySimpleGUI standard items, not user config items',
+                'You can use any of the many built-in themes instead or use your own UserSettings file to store your custom theme',
+            )
             return pysimplegui_user_settings.get('-theme-', CURRENT_LOOK_AND_FEEL)
         pysimplegui_user_settings.set('-theme-', new_theme)
         theme(new_theme)
@@ -19916,7 +25654,9 @@ def theme_global(new_theme=None):
         return pysimplegui_user_settings.get('-theme-', CURRENT_LOOK_AND_FEEL)
 
 
-def theme_previewer(columns=12, scrollable=False, scroll_area_size=(None, None), search_string=None, location=(None, None)):
+def theme_previewer(
+    columns=12, scrollable=False, scroll_area_size=(None, None), search_string=None, location=(None, None)
+):
     """
     Displays a "Quick Reference Window" showing all of the different Look and Feel settings that are available.
     They are sorted alphabetically.  The legacy color names are mixed in, but otherwise they are sorted into Dark and Light halves
@@ -19936,16 +25676,24 @@ def theme_previewer(columns=12, scrollable=False, scroll_area_size=(None, None),
     current_theme = theme()
 
     # Show a "splash" type message so the user doesn't give up waiting
-    popup_quick_message('Hang on for a moment, this will take a bit to create....', keep_on_top=True, background_color='red', text_color='#FFFFFF',
-                        auto_close=True, non_blocking=True)
+    popup_quick_message(
+        'Hang on for a moment, this will take a bit to create....',
+        keep_on_top=True,
+        background_color='red',
+        text_color='#FFFFFF',
+        auto_close=True,
+        non_blocking=True,
+    )
 
     web = False
 
     win_bg = 'black'
 
     def sample_layout():
-        return [[Text('Text element'), InputText('Input data here', size=(10, 1))],
-                [Button('Ok'), Button('Disabled', disabled=True), Slider((1, 10), orientation='h', size=(5, 15))]]
+        return [
+            [Text('Text element'), InputText('Input data here', size=(10, 1))],
+            [Button('Ok'), Button('Disabled', disabled=True), Slider((1, 10), orientation='h', size=(5, 15))],
+        ]
 
     names = list_of_look_and_feel_values()
     names.sort()
@@ -19968,8 +25716,28 @@ def theme_previewer(columns=12, scrollable=False, scroll_area_size=(None, None),
     if row:
         col_layout += [row]
 
-    layout += [[Column(col_layout, scrollable=scrollable, size=scroll_area_size, pad=(0, 0), background_color=win_bg, key='-COL-')]]
-    window = Window('Preview of Themes', layout, background_color=win_bg, resizable=True, location=location, keep_on_top=True, finalize=True, modal=True)
+    layout += [
+        [
+            Column(
+                col_layout,
+                scrollable=scrollable,
+                size=scroll_area_size,
+                pad=(0, 0),
+                background_color=win_bg,
+                key='-COL-',
+            )
+        ]
+    ]
+    window = Window(
+        'Preview of Themes',
+        layout,
+        background_color=win_bg,
+        resizable=True,
+        location=location,
+        keep_on_top=True,
+        finalize=True,
+        modal=True,
+    )
     window['-COL-'].expand(True, True, True)  # needed so that col will expand with the window
     window.read(close=True)
     theme(current_theme)
@@ -19980,15 +25748,35 @@ preview_all_look_and_feel_themes = theme_previewer
 
 def _theme_preview_window_swatches():
     # Begin the layout with a header
-    layout = [[Text('Themes as color swatches', text_color='white', background_color='black', font='Default 25')],
-              [Text('Tooltip and right click a color to get the value', text_color='white', background_color='black', font='Default 15')],
-              [Text('Left click a color to copy to clipboard', text_color='white', background_color='black', font='Default 15')]]
+    layout = [
+        [Text('Themes as color swatches', text_color='white', background_color='black', font='Default 25')],
+        [
+            Text(
+                'Tooltip and right click a color to get the value',
+                text_color='white',
+                background_color='black',
+                font='Default 15',
+            )
+        ],
+        [
+            Text(
+                'Left click a color to copy to clipboard',
+                text_color='white',
+                background_color='black',
+                font='Default 15',
+            )
+        ],
+    ]
     layout = [[Column(layout, element_justification='c', background_color='black')]]
     # Create the pain part, the rows of Text with color swatches
     for i, theme_name in enumerate(theme_list()):
         theme(theme_name)
-        colors = [theme_background_color(), theme_text_color(), theme_input_background_color(),
-                  theme_input_text_color()]
+        colors = [
+            theme_background_color(),
+            theme_text_color(),
+            theme_input_background_color(),
+            theme_input_text_color(),
+        ]
         if theme_button_color() != COLOR_SYSTEM_DEFAULT:
             colors.append(theme_button_color()[0])
             colors.append(theme_button_color()[1])
@@ -19996,8 +25784,19 @@ def _theme_preview_window_swatches():
         row = [T(theme(), background_color='black', text_color='white', size=(20, 1), justification='r')]
         for color in colors:
             if color != COLOR_SYSTEM_DEFAULT:
-                row.append(T(SYMBOL_SQUARE, text_color=color, background_color='black', pad=(0, 0), font='DEFAUlT 20', right_click_menu=['Nothing', [color]],
-                             tooltip=color, enable_events=True, key=(i, color)))
+                row.append(
+                    T(
+                        SYMBOL_SQUARE,
+                        text_color=color,
+                        background_color='black',
+                        pad=(0, 0),
+                        font='DEFAUlT 20',
+                        right_click_menu=['Nothing', [color]],
+                        tooltip=color,
+                        enable_events=True,
+                        key=(i, color),
+                    )
+                )
         layout += [row]
     # place layout inside of a Column so that it's scrollable
     layout = [[Column(layout, size=(500, 900), scrollable=True, vertical_scroll_only=True, background_color='black')]]
@@ -20015,7 +25814,13 @@ def theme_previewer_swatches():
     If you hover over a color or right click it you'll also see the hext value.
     """
     current_theme = theme()
-    popup_quick_message('This is going to take a minute...', text_color='white', background_color='red', font='Default 20', keep_on_top=True)
+    popup_quick_message(
+        'This is going to take a minute...',
+        text_color='white',
+        background_color='red',
+        font='Default 20',
+        keep_on_top=True,
+    )
     window = _theme_preview_window_swatches()
     theme(OFFICIAL_PYSIMPLEGUI_THEME)
     # col_height = window.get_screen_size()[1]-200
@@ -20112,26 +25917,29 @@ def change_look_and_feel(index, force=False):
         else:
             colors['PROGRESS'] = DEFAULT_PROGRESS_BAR_COLOR_OFFICIAL
         # call to change all the colors
-        SetOptions(background_color=colors['BACKGROUND'],
-                   text_element_background_color=colors['BACKGROUND'],
-                   element_background_color=colors['BACKGROUND'],
-                   text_color=colors['TEXT'],
-                   input_elements_background_color=colors['INPUT'],
-                   # button_color=colors['BUTTON'] if not running_mac() else None,
-                   button_color=colors['BUTTON'],
-                   progress_meter_color=colors['PROGRESS'],
-                   border_width=colors['BORDER'],
-                   slider_border_width=colors['SLIDER_DEPTH'],
-                   progress_meter_border_depth=colors['PROGRESS_DEPTH'],
-                   scrollbar_color=(colors['SCROLL']),
-                   element_text_color=colors['TEXT'],
-                   input_text_color=colors['TEXT_INPUT'])
+        SetOptions(
+            background_color=colors['BACKGROUND'],
+            text_element_background_color=colors['BACKGROUND'],
+            element_background_color=colors['BACKGROUND'],
+            text_color=colors['TEXT'],
+            input_elements_background_color=colors['INPUT'],
+            # button_color=colors['BUTTON'] if not running_mac() else None,
+            button_color=colors['BUTTON'],
+            progress_meter_color=colors['PROGRESS'],
+            border_width=colors['BORDER'],
+            slider_border_width=colors['SLIDER_DEPTH'],
+            progress_meter_border_depth=colors['PROGRESS_DEPTH'],
+            scrollbar_color=(colors['SCROLL']),
+            element_text_color=colors['TEXT'],
+            input_text_color=colors['TEXT_INPUT'],
+        )
     except:  # most likely an index out of range
         print('** Warning - Theme value not valid. Change your theme call. **')
         print('valid values are', list_of_look_and_feel_values())
 
 
 # ------------------------ Color processing functions ------------------------
+
 
 def _hex_to_hsl(hex):
     r, g, b = _hex_to_rgb(hex)
@@ -20141,7 +25949,7 @@ def _hex_to_hsl(hex):
 def _hex_to_rgb(hex):
     hex = hex.lstrip('#')
     hlen = len(hex)
-    return tuple(int(hex[i:i + hlen // 3], 16) for i in range(0, hlen, hlen // 3))
+    return tuple(int(hex[i : i + hlen // 3], 16) for i in range(0, hlen, hlen // 3))
 
 
 def _rgb_to_hsl(r, g, b):
@@ -20155,8 +25963,8 @@ def _rgb_to_hsl(r, g, b):
         h = s = 0.0
     else:
         d = high - low
-        l = (high + low) / 2
-        s = d / (2 - high - low) if l > 0.5 else d / (high + low)
+        lightness = (high + low) / 2
+        s = d / (2 - high - low) if lightness > 0.5 else d / (high + low)
         h = {
             r: (g - b) / d + (6 if g < b else 0),
             g: (b - r) / d + 2,
@@ -20166,13 +25974,16 @@ def _rgb_to_hsl(r, g, b):
     return h, s, v
 
 
-def _hsl_to_rgb(h, s, l):
+def _hsl_to_rgb(h, s, l):  # noqa
     def hue_to_rgb(p, q, t):
         t += 1 if t < 0 else 0
         t -= 1 if t > 1 else 0
-        if t < 1 / 6: return p + (q - p) * 6 * t
-        if t < 1 / 2: return q
-        if t < 2 / 3: p + (q - p) * (2 / 3 - t) * 6
+        if t < 1 / 6:
+            return p + (q - p) * 6 * t
+        if t < 1 / 2:
+            return q
+        if t < 2 / 3:
+            p + (q - p) * (2 / 3 - t) * 6
         return p
 
     if s == 0:
@@ -20187,13 +25998,13 @@ def _hsl_to_rgb(h, s, l):
     return r, g, b
 
 
-def _hsv_to_hsl(h, s, v):
-    l = 0.5 * v * (2 - s)
-    s = v * s / (1 - fabs(2 * l - 1))
-    return h, s, l
+def _hsv_to_hsl(h, s, v):  # noqa
+    lightness = 0.5 * v * (2 - s)
+    s = v * s / (1 - fabs(2 * lightness - 1))
+    return h, s, lightness
 
 
-def _hsl_to_hsv(h, s, l):
+def _hsl_to_hsv(h, s, l):  # noqa
     v = (2 * l + s * (1 - fabs(2 * l - 1))) / 2
     s = 2 * (v - l) / v
     return h, s, v
@@ -20211,8 +26022,11 @@ def obj_to_string_single_obj(obj):
     """
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    )
 
 
 def obj_to_string(obj, extra='    '):
@@ -20227,11 +26041,25 @@ def obj_to_string(obj, extra='    '):
     """
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (extra + (str(item) + ' = ' +
-                  (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(
-                      obj.__dict__[item])))
-         for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join(
+            (
+                extra
+                + (
+                    str(item)
+                    + ' = '
+                    + (
+                        ObjToString(obj.__dict__[item], extra + '    ')
+                        if hasattr(obj.__dict__[item], '__dict__')
+                        else str(obj.__dict__[item])
+                    )
+                )
+                for item in sorted(obj.__dict__)
+            )
+        )
+    )
 
 
 # ...######..##.......####.########..########...#######.....###....########..########.
@@ -20250,6 +26078,7 @@ def obj_to_string(obj, extra='    '):
 # ..##.......##.....##.##...###.##....##....##.....##..##.....##.##...###.##....##
 # ..##........#######..##....##..######.....##....####..#######..##....##..######.
 
+
 def clipboard_set(new_value):
     """
     Sets the clipboard to a specific value.
@@ -20264,6 +26093,7 @@ def clipboard_set(new_value):
     root.clipboard_clear()
     root.clipboard_append(str(new_value))
     root.update()
+
 
 def clipboard_get():
     """
@@ -20295,9 +26125,32 @@ def clipboard_get():
 # ------------------------------------------------------------------------------------------------------------------ #
 # ----------------------------------- The mighty Popup! ------------------------------------------------------------ #
 
-def popup(*args, title=None, button_color=None, background_color=None, text_color=None, button_type=POPUP_BUTTONS_OK, auto_close=False,
-          auto_close_duration=None, custom_text=(None, None), non_blocking=False, icon=None, line_width=None, font=None, no_titlebar=False, grab_anywhere=False,
-          keep_on_top=None, location=(None, None), relative_location=(None, None), any_key_closes=False, image=None, modal=True, button_justification=None, drop_whitespace=True):
+
+def popup(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    button_type=POPUP_BUTTONS_OK,
+    auto_close=False,
+    auto_close_duration=None,
+    custom_text=(None, None),
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    any_key_closes=False,
+    image=None,
+    modal=True,
+    button_justification=None,
+    drop_whitespace=True,
+):
     """
     Popup - Display a popup Window with as many parms as you wish to include.  This is the GUI equivalent of the
     "print" statement.  It's also great for "pausing" your program's flow until the user can read some error messages.
@@ -20358,13 +26211,11 @@ def popup(*args, title=None, button_color=None, background_color=None, text_colo
     :rtype:                       str | None
     """
 
-
-
     if not args:
         args_to_print = ['']
     else:
         args_to_print = args
-    if line_width != None:
+    if line_width is not None:
         local_line_width = line_width
     else:
         local_line_width = MESSAGE_BOX_LINE_WIDTH
@@ -20390,13 +26241,14 @@ def popup(*args, title=None, button_color=None, background_color=None, text_colo
         else:
             message_wrapped = textwrap.fill(message, local_line_width, drop_whitespace=drop_whitespace)
         message_wrapped_lines = message_wrapped.count('\n') + 1
-        longest_line_len = max([len(l) for l in message.split('\n')])
+        longest_line_len = max([len(line) for line in message.split('\n')])
         width_used = min(longest_line_len, local_line_width)
         max_line_total = max(max_line_total, width_used)
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
-        layout += [[
-            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)]]
+        layout += [
+            [Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)]
+        ]
         total_lines += height
 
     if non_blocking:
@@ -20406,31 +26258,74 @@ def popup(*args, title=None, button_color=None, background_color=None, text_colo
     # show either an OK or Yes/No depending on paramater
     if custom_text != (None, None):
         if type(custom_text) is not tuple:
-            layout += [[PopupButton(custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True,
-                                    bind_return_key=True)]]
+            layout += [
+                [
+                    PopupButton(
+                        custom_text,
+                        size=(len(custom_text), 1),
+                        button_color=button_color,
+                        focus=True,
+                        bind_return_key=True,
+                    )
+                ]
+            ]
         elif custom_text[1] is None:
-            layout += [[
-                PopupButton(custom_text[0], size=(len(custom_text[0]), 1), button_color=button_color, focus=True,
-                            bind_return_key=True)]]
+            layout += [
+                [
+                    PopupButton(
+                        custom_text[0],
+                        size=(len(custom_text[0]), 1),
+                        button_color=button_color,
+                        focus=True,
+                        bind_return_key=True,
+                    )
+                ]
+            ]
         else:
-            layout += [[PopupButton(custom_text[0], button_color=button_color, focus=True, bind_return_key=True,
-                                    size=(len(custom_text[0]), 1)),
-                        PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[1]), 1))]]
+            layout += [
+                [
+                    PopupButton(
+                        custom_text[0],
+                        button_color=button_color,
+                        focus=True,
+                        bind_return_key=True,
+                        size=(len(custom_text[0]), 1),
+                    ),
+                    PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[1]), 1)),
+                ]
+            ]
     elif button_type == POPUP_BUTTONS_YES_NO:
-        layout += [[PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True,
-                                size=(5, 1)), PopupButton('No', button_color=button_color, size=(5, 1))]]
+        layout += [
+            [
+                PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True, size=(5, 1)),
+                PopupButton('No', button_color=button_color, size=(5, 1)),
+            ]
+        ]
     elif button_type == POPUP_BUTTONS_CANCELLED:
-        layout += [[
-            PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True )]]
+        layout += [[PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True)]]
     elif button_type == POPUP_BUTTONS_ERROR:
         layout += [[PopupButton('Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True)]]
     elif button_type == POPUP_BUTTONS_OK_CANCEL:
-        layout += [[PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
-                    PopupButton('Cancel', size=(6, 1), button_color=button_color)]]
+        layout += [
+            [
+                PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
+                PopupButton('Cancel', size=(6, 1), button_color=button_color),
+            ]
+        ]
     elif button_type == POPUP_BUTTONS_NO_BUTTONS:
         pass
     else:
-        layout += [[PopupButton('OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True,)]]
+        layout += [
+            [
+                PopupButton(
+                    'OK',
+                    size=(5, 1),
+                    button_color=button_color,
+                    focus=True,
+                    bind_return_key=True,
+                )
+            ]
+        ]
     if button_justification is not None:
         justification = button_justification.lower()[0]
         if justification == 'r':
@@ -20438,12 +26333,24 @@ def popup(*args, title=None, button_color=None, background_color=None, text_colo
         elif justification == 'c':
             layout[-1] = [Push()] + layout[-1] + [Push()]
 
-
-    window = Window(_title, layout, auto_size_text=True, background_color=background_color, button_color=button_color,
-                    auto_close=auto_close, auto_close_duration=auto_close_duration, icon=icon, font=font,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, return_keyboard_events=any_key_closes,
-                    modal=modal)
-
+    window = Window(
+        _title,
+        layout,
+        auto_size_text=True,
+        background_color=background_color,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        icon=icon,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        return_keyboard_events=any_key_closes,
+        modal=modal,
+    )
 
     if non_blocking:
         button, values = window.read(timeout=0)
@@ -20472,7 +26379,30 @@ def MsgBox(*args):
 
 # ========================  Scrolled Text Box   =====#
 # ===================================================#
-def popup_scrolled(*args, title=None, button_color=None, background_color=None, text_color=None, yes_no=False, no_buttons=False, button_justification='l', auto_close=False, auto_close_duration=None, size=(None, None), location=(None, None), relative_location=(None, None), non_blocking=False, no_titlebar=False, grab_anywhere=False, keep_on_top=None, font=None, image=None, icon=None, modal=True, no_sizegrip=False):
+def popup_scrolled(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    yes_no=False,
+    no_buttons=False,
+    button_justification='l',
+    auto_close=False,
+    auto_close_duration=None,
+    size=(None, None),
+    location=(None, None),
+    relative_location=(None, None),
+    non_blocking=False,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    font=None,
+    image=None,
+    icon=None,
+    modal=True,
+    no_sizegrip=False,
+):
     """
     Show a scrolled Popup window containing the user's text that was supplied.  Use with as many items to print as you
     want, just like a print statement.
@@ -20525,7 +26455,8 @@ def popup_scrolled(*args, title=None, button_color=None, background_color=None, 
     :rtype:                       str | None | TIMEOUT_KEY
     """
 
-    if not args: return
+    if not args:
+        return
     width, height = size
     width = width if width else MESSAGE_BOX_LINE_WIDTH
 
@@ -20542,7 +26473,7 @@ def popup_scrolled(*args, title=None, button_color=None, background_color=None, 
         # fancy code to check if string and convert if not is not need. Just always convert to string :-)
         # if not isinstance(message, str): message = str(message)
         message = str(message)
-        longest_line_len = max([len(l) for l in message.split('\n')])
+        longest_line_len = max([len(line) for line in message.split('\n')])
         width_used = min(longest_line_len, width)
         max_line_total = max(max_line_total, width_used)
         max_line_width = width
@@ -20550,18 +26481,31 @@ def popup_scrolled(*args, title=None, button_color=None, background_color=None, 
         height_computed += lines_needed + 1
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    height_computed = (
+        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    )
     if height:
         height_computed = height
-    layout += [[Multiline(complete_output, size=(max_line_width, height_computed), background_color=background_color, text_color=text_color, expand_x=True,
-                          expand_y=True, k='-MLINE-')]]
+    layout += [
+        [
+            Multiline(
+                complete_output,
+                size=(max_line_width, height_computed),
+                background_color=background_color,
+                text_color=text_color,
+                expand_x=True,
+                expand_y=True,
+                k='-MLINE-',
+            )
+        ]
+    ]
     # show either an OK or Yes/No depending on paramater
     button = DummyButton if non_blocking else Button
 
     if yes_no:
         buttons = [button('Yes'), button('No')]
     elif no_buttons is not True:
-        buttons =  [button('OK', size=(5, 1), button_color=button_color)]
+        buttons = [button('OK', size=(5, 1), button_color=button_color)]
     else:
         buttons = None
 
@@ -20576,9 +26520,24 @@ def popup_scrolled(*args, title=None, button_color=None, background_color=None, 
     if no_sizegrip is not True:
         layout[-1] += [Sizegrip()]
 
-    window = Window(title or args[0], layout, auto_size_text=True, button_color=button_color, auto_close=auto_close,
-                    auto_close_duration=auto_close_duration, location=location, relative_location=relative_location, resizable=True, font=font, background_color=background_color,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, modal=modal, icon=icon)
+    window = Window(
+        title or args[0],
+        layout,
+        auto_size_text=True,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        location=location,
+        relative_location=relative_location,
+        resizable=True,
+        font=font,
+        background_color=background_color,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        modal=modal,
+        icon=icon,
+    )
     if non_blocking:
         button, values = window.read(timeout=0)
     else:
@@ -20598,9 +26557,25 @@ def popup_scrolled(*args, title=None, button_color=None, background_color=None, 
 
 
 # --------------------------- popup_no_buttons ---------------------------
-def popup_no_buttons(*args, title=None, background_color=None, text_color=None, auto_close=False,
-                     auto_close_duration=None, non_blocking=False, icon=None, line_width=None, font=None,
-                     no_titlebar=False, grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_no_buttons(
+    *args,
+    title=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """Show a Popup but without any buttons
 
     :param *args:               Variable number of items to display
@@ -20636,19 +26611,51 @@ def popup_no_buttons(*args, title=None, background_color=None, text_color=None, 
     :param modal:               If True then makes the popup will behave like a Modal window... all other windows are non-operational until this one is closed. Default = True
     :type modal:                bool
     :return:                    Returns text of the button that was pressed.  None will be returned if user closed window with X
-    :rtype:                     str | None | TIMEOUT_KEY    """
-    Popup(*args, title=title, background_color=background_color, text_color=text_color,
-          button_type=POPUP_BUTTONS_NO_BUTTONS,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    :rtype:                     str | None | TIMEOUT_KEY"""
+    Popup(
+        *args,
+        title=title,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=POPUP_BUTTONS_NO_BUTTONS,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_non_blocking ---------------------------
-def popup_non_blocking(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None,
-                       text_color=None, auto_close=False, auto_close_duration=None, non_blocking=True, icon=None,
-                       line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=None,
-                       location=(None, None), relative_location=(None, None), image=None, modal=False):
+def popup_non_blocking(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=True,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=False,
+):
     """
     Show Popup window and immediately return (does not block)
 
@@ -20692,17 +26699,51 @@ def popup_non_blocking(*args, title=None, button_type=POPUP_BUTTONS_OK, button_c
     :rtype:                     str | None
     """
 
-    return popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-                 button_type=button_type,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-                 line_width=line_width,
-                 font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_quick - a NonBlocking, Self-closing Popup  ---------------------------
-def popup_quick(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None,
-                text_color=None, auto_close=True, auto_close_duration=2, non_blocking=True, icon=None, line_width=None,
-                font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=False):
+def popup_quick(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=2,
+    non_blocking=True,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=False,
+):
     """
     Show Popup box that doesn't block and closes itself
 
@@ -20748,17 +26789,51 @@ def popup_quick(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=No
     :rtype:                     str | None | TIMEOUT_KEY
     """
 
-    return popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-                 button_type=button_type,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-                 line_width=line_width,
-                 font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_quick_message - a NonBlocking, Self-closing Popup with no titlebar and no buttons ---------------------------
-def popup_quick_message(*args, title=None, button_type=POPUP_BUTTONS_NO_BUTTONS, button_color=None, background_color=None,
-                        text_color=None, auto_close=True, auto_close_duration=2, non_blocking=True, icon=None, line_width=None,
-                        font=None, no_titlebar=True, grab_anywhere=False, keep_on_top=True, location=(None, None), relative_location=(None, None), image=None, modal=False):
+def popup_quick_message(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_NO_BUTTONS,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=2,
+    non_blocking=True,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=True,
+    grab_anywhere=False,
+    keep_on_top=True,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=False,
+):
     """
     Show Popup window with no titlebar, doesn't block, and auto closes itself.
 
@@ -20803,17 +26878,50 @@ def popup_quick_message(*args, title=None, button_type=POPUP_BUTTONS_NO_BUTTONS,
     :return:                    Returns text of the button that was pressed.  None will be returned if user closed window with X
     :rtype:                     str | None | TIMEOUT_KEY
     """
-    return popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-                 button_type=button_type,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-                 line_width=line_width,
-                 font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- PopupNoTitlebar ---------------------------
-def popup_no_titlebar(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None,
-                      text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=None,
-                      line_width=None, font=None, grab_anywhere=True, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_no_titlebar(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    grab_anywhere=True,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """
     Display a Popup without a titlebar.   Enables grab anywhere so you can move it
 
@@ -20856,18 +26964,51 @@ def popup_no_titlebar(*args, title=None, button_type=POPUP_BUTTONS_OK, button_co
     :return:                    Returns text of the button that was pressed.  None will be returned if user closed window with X
     :rtype:                     str | None | TIMEOUT_KEY
     """
-    return popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-                 button_type=button_type,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-                 line_width=line_width,
-                 font=font, no_titlebar=True, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=True,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- PopupAutoClose ---------------------------
-def popup_auto_close(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                     auto_close=True, auto_close_duration=None, non_blocking=False, icon=None,
-                     line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=None,
-                     location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_auto_close(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """Popup that closes itself after some time period
 
     :param *args:               Variable number of items to display
@@ -20912,17 +27053,50 @@ def popup_auto_close(*args, title=None, button_type=POPUP_BUTTONS_OK, button_col
     :rtype:                     str | None | TIMEOUT_KEY
     """
 
-    return popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-                 button_type=button_type,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-                 line_width=line_width,
-                 font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_error ---------------------------
-def popup_error(*args, title=None, button_color=(None, None), background_color=None, text_color=None, auto_close=False,
-                auto_close_duration=None, non_blocking=False, icon=None, line_width=None, font=None,
-                no_titlebar=False, grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_error(
+    *args,
+    title=None,
+    button_color=(None, None),
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """
     Popup with colored button and 'Error' as button text
 
@@ -20966,17 +27140,50 @@ def popup_error(*args, title=None, button_color=(None, None), background_color=N
     :rtype:                     str | None | TIMEOUT_KEY
     """
     tbutton_color = DEFAULT_ERROR_BUTTON_COLOR if button_color == (None, None) else button_color
-    return popup(*args, title=title, button_type=POPUP_BUTTONS_ERROR, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=tbutton_color,
-                 auto_close=auto_close,
-                 auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-                 keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_ERROR,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=tbutton_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_cancel ---------------------------
-def popup_cancel(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-                 auto_close_duration=None, non_blocking=False, icon=None, line_width=None, font=None,
-                 no_titlebar=False, grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_cancel(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """
     Display Popup with "cancelled" button text
 
@@ -21019,17 +27226,50 @@ def popup_cancel(*args, title=None, button_color=None, background_color=None, te
     :return:                    Returns text of the button that was pressed.  None will be returned if user closed window with X
     :rtype:                     str | None | TIMEOUT_KEY
     """
-    return popup(*args, title=title, button_type=POPUP_BUTTONS_CANCELLED, background_color=background_color,
-                 text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-                 auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-                 keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_CANCELLED,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_ok ---------------------------
-def popup_ok(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-             auto_close_duration=None, non_blocking=False, icon=None, line_width=None, font=None,
-             no_titlebar=False, grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_ok(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """
     Display Popup with OK button only
 
@@ -21072,16 +27312,50 @@ def popup_ok(*args, title=None, button_color=None, background_color=None, text_c
     :return:                    Returns text of the button that was pressed.  None will be returned if user closed window with X
     :rtype:                     str | None | TIMEOUT_KEY
     """
-    return popup(*args, title=title, button_type=POPUP_BUTTONS_OK, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-                 auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-                 keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_OK,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_ok_cancel ---------------------------
-def popup_ok_cancel(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-                    auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                    no_titlebar=False, grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_ok_cancel(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """
     Display popup with OK and Cancel buttons
 
@@ -21124,17 +27398,50 @@ def popup_ok_cancel(*args, title=None, button_color=None, background_color=None,
     :return:                    clicked button
     :rtype:                     "OK" | "Cancel" | None
     """
-    return popup(*args, title=title, button_type=POPUP_BUTTONS_OK_CANCEL, background_color=background_color,
-                 text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_OK_CANCEL,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 # --------------------------- popup_yes_no ---------------------------
-def popup_yes_no(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-                 auto_close_duration=None, non_blocking=False, icon=None, line_width=None, font=None,
-                 no_titlebar=False, grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, modal=True):
+def popup_yes_no(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=None,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    modal=True,
+):
     """
     Display Popup with Yes and No buttons
 
@@ -21177,11 +27484,27 @@ def popup_yes_no(*args, title=None, button_color=None, background_color=None, te
     :return:                    clicked button
     :rtype:                     "Yes" | "No" | None
     """
-    return popup(*args, title=title, button_type=POPUP_BUTTONS_YES_NO, background_color=background_color,
-                 text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, image=image, modal=modal)
+    return popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_YES_NO,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        image=image,
+        modal=modal,
+    )
 
 
 ##############################################################################
@@ -21191,10 +27514,28 @@ def popup_yes_no(*args, title=None, button_color=None, background_color=None, te
 # --------------------------- popup_get_folder ---------------------------
 
 
-def popup_get_folder(message, title=None, default_path='', no_window=False, size=(None, None), button_color=None,
-                     background_color=None, text_color=None, icon=None, font=None, no_titlebar=False,
-                     grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), initial_folder=None, image=None, modal=True, history=False,
-                     history_setting_filename=None):
+def popup_get_folder(
+    message,
+    title=None,
+    default_path='',
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    initial_folder=None,
+    image=None,
+    modal=True,
+    history=False,
+    history_setting_filename=None,
+):
     """
     Display popup with text entry field and browse button so that a folder can be chosen.
 
@@ -21247,8 +27588,10 @@ def popup_get_folder(message, title=None, default_path='', no_window=False, size
         try:
             history_settings = UserSettings(history_setting_filename)
         except Exception as e:
-            _error_popup_with_traceback('popup_get_folder - Something is wrong with your supplied history settings filename',
-                                        'Exception: {}'.format(e))
+            _error_popup_with_traceback(
+                'popup_get_folder - Something is wrong with your supplied history settings filename',
+                'Exception: {}'.format(e),
+            )
             return None
     elif history:
         history_settings_filename = os.path.basename(inspect.stack()[1].filename)
@@ -21268,14 +27611,15 @@ def popup_get_folder(message, title=None, default_path='', no_window=False, size
             try:
                 root.wm_overrideredirect(True)
             except Exception as e:
-                print('* Error performing wm_overrideredirect while hiding the window during creation in get folder *', e)
+                print(
+                    '* Error performing wm_overrideredirect while hiding the window during creation in get folder *', e
+                )
             root.withdraw()
         except:
             pass
         folder_name = tk.filedialog.askdirectory(initialdir=initial_folder)  # show the 'get folder' dialog box
 
         root.destroy()
-
 
         return folder_name
 
@@ -21296,14 +27640,37 @@ def popup_get_folder(message, title=None, default_path='', no_window=False, size
     else:
         file_list = history_settings.get('-PSG folder list-', [])
         last_entry = file_list[0] if file_list else ''
-        layout += [[Combo(file_list, default_value=last_entry, key='-INPUT-', size=size if size != (None, None) else (80, 1), bind_return_key=True),
-                    browse_button, Button('Clear History', tooltip='Clears the list of folders shown in the combobox')]]
+        layout += [
+            [
+                Combo(
+                    file_list,
+                    default_value=last_entry,
+                    key='-INPUT-',
+                    size=size if size != (None, None) else (80, 1),
+                    bind_return_key=True,
+                ),
+                browse_button,
+                Button('Clear History', tooltip='Clears the list of folders shown in the combobox'),
+            ]
+        ]
 
     layout += [[Button('Ok', size=(6, 1), bind_return_key=True), Button('Cancel', size=(6, 1))]]
 
-    window = Window(title=title or message, layout=layout, icon=icon, auto_size_text=True, button_color=button_color,
-                    font=font, background_color=background_color, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top,
-                    location=location, relative_location=relative_location, modal=modal)
+    window = Window(
+        title=title or message,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        font=font,
+        background_color=background_color,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        modal=modal,
+    )
 
     while True:
         event, values = window.read()
@@ -21312,7 +27679,13 @@ def popup_get_folder(message, title=None, default_path='', no_window=False, size
         elif event == 'Clear History':
             history_settings.set('-PSG folder list-', [])
             window['-INPUT-'].update('', [])
-            popup_quick_message('History of Previous Choices Cleared', background_color='red', text_color='white', font='_ 20', keep_on_top=True)
+            popup_quick_message(
+                'History of Previous Choices Cleared',
+                background_color='red',
+                text_color='white',
+                font='_ 20',
+                keep_on_top=True,
+            )
         elif event in ('Ok', '-INPUT-'):
             if values['-INPUT-'] != '':
                 if history_settings is not None:
@@ -21333,12 +27706,35 @@ def popup_get_folder(message, title=None, default_path='', no_window=False, size
 
 # --------------------------- popup_get_file ---------------------------
 
-def popup_get_file(message, title=None, default_path='', default_extension='', save_as=False, multiple_files=False,
-                   file_types=FILE_TYPES_ALL_FILES,
-                   no_window=False, size=(None, None), button_color=None, background_color=None, text_color=None,
-                   icon=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=None,
-                   location=(None, None), relative_location=(None, None), initial_folder=None, image=None, files_delimiter=BROWSE_FILES_DELIMITER, modal=True, history=False, show_hidden=True,
-                   history_setting_filename=None):
+
+def popup_get_file(
+    message,
+    title=None,
+    default_path='',
+    default_extension='',
+    save_as=False,
+    multiple_files=False,
+    file_types=FILE_TYPES_ALL_FILES,
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    initial_folder=None,
+    image=None,
+    files_delimiter=BROWSE_FILES_DELIMITER,
+    modal=True,
+    history=False,
+    show_hidden=True,
+    history_setting_filename=None,
+):
     """
     Display popup window with text entry field and browse button so that a file can be chosen by user.
 
@@ -21403,8 +27799,10 @@ def popup_get_file(message, title=None, default_path='', default_extension='', s
         try:
             history_settings = UserSettings(history_setting_filename)
         except Exception as e:
-            _error_popup_with_traceback('popup_get_file - Something is wrong with your supplied history settings filename',
-                                        'Exception: {}'.format(e))
+            _error_popup_with_traceback(
+                'popup_get_file - Something is wrong with your supplied history settings filename',
+                'Exception: {}'.format(e),
+            )
             return None
     elif history:
         history_settings_filename = os.path.basename(inspect.stack()[1].filename)
@@ -21452,56 +27850,68 @@ def popup_get_file(message, title=None, default_path='', default_extension='', s
             if running_mac():
                 is_all = [(x, y) for (x, y) in file_types if all(ch in '* .' for ch in y)]
                 if not len(set(file_types)) > 1 and (len(is_all) != 0 or file_types == FILE_TYPES_ALL_FILES):
-                    filename = tk.filedialog.asksaveasfilename(initialdir=initial_folder,
-                                                               initialfile=default_path,
-                                                               defaultextension=default_extension)  # show the 'get file' dialog box
+                    filename = tk.filedialog.asksaveasfilename(
+                        initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension
+                    )  # show the 'get file' dialog box
                 else:
-                    filename = tk.filedialog.asksaveasfilename(filetypes=file_types,
-                                                               initialdir=initial_folder,
-                                                               initialfile=default_path,
-                                                               defaultextension=default_extension)  # show the 'get file' dialog box
+                    filename = tk.filedialog.asksaveasfilename(
+                        filetypes=file_types,
+                        initialdir=initial_folder,
+                        initialfile=default_path,
+                        defaultextension=default_extension,
+                    )  # show the 'get file' dialog box
             else:
-                filename = tk.filedialog.asksaveasfilename(filetypes=file_types,
-                                                       initialdir=initial_folder,
-                                                       initialfile=default_path,
-                                                       parent=root,
-                                                       defaultextension=default_extension)  # show the 'get file' dialog box
+                filename = tk.filedialog.asksaveasfilename(
+                    filetypes=file_types,
+                    initialdir=initial_folder,
+                    initialfile=default_path,
+                    parent=root,
+                    defaultextension=default_extension,
+                )  # show the 'get file' dialog box
         elif multiple_files:
             if running_mac():
                 is_all = [(x, y) for (x, y) in file_types if all(ch in '* .' for ch in y)]
                 if not len(set(file_types)) > 1 and (len(is_all) != 0 or file_types == FILE_TYPES_ALL_FILES):
-                    filename = tk.filedialog.askopenfilenames(initialdir=initial_folder,
-                                                              initialfile=default_path,
-                                                              defaultextension=default_extension)  # show the 'get file' dialog box
+                    filename = tk.filedialog.askopenfilenames(
+                        initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension
+                    )  # show the 'get file' dialog box
                 else:
-                    filename = tk.filedialog.askopenfilenames(filetypes=file_types,
-                                                              initialdir=initial_folder,
-                                                              initialfile=default_path,
-                                                              defaultextension=default_extension)  # show the 'get file' dialog box
+                    filename = tk.filedialog.askopenfilenames(
+                        filetypes=file_types,
+                        initialdir=initial_folder,
+                        initialfile=default_path,
+                        defaultextension=default_extension,
+                    )  # show the 'get file' dialog box
             else:
-                filename = tk.filedialog.askopenfilenames(filetypes=file_types,
-                                                          initialdir=initial_folder,
-                                                          initialfile=default_path,
-                                                          parent=root,
-                                                          defaultextension=default_extension)  # show the 'get file' dialog box
+                filename = tk.filedialog.askopenfilenames(
+                    filetypes=file_types,
+                    initialdir=initial_folder,
+                    initialfile=default_path,
+                    parent=root,
+                    defaultextension=default_extension,
+                )  # show the 'get file' dialog box
         else:
             if running_mac():
                 is_all = [(x, y) for (x, y) in file_types if all(ch in '* .' for ch in y)]
                 if not len(set(file_types)) > 1 and (len(is_all) != 0 or file_types == FILE_TYPES_ALL_FILES):
-                    filename = tk.filedialog.askopenfilename(initialdir=initial_folder,
-                                                             initialfile=default_path,
-                                                             defaultextension=default_extension)  # show the 'get files' dialog box
+                    filename = tk.filedialog.askopenfilename(
+                        initialdir=initial_folder, initialfile=default_path, defaultextension=default_extension
+                    )  # show the 'get files' dialog box
                 else:
-                    filename = tk.filedialog.askopenfilename(filetypes=file_types,
-                                                             initialdir=initial_folder,
-                                                             initialfile=default_path,
-                                                             defaultextension=default_extension)  # show the 'get files' dialog box
+                    filename = tk.filedialog.askopenfilename(
+                        filetypes=file_types,
+                        initialdir=initial_folder,
+                        initialfile=default_path,
+                        defaultextension=default_extension,
+                    )  # show the 'get files' dialog box
             else:
-                filename = tk.filedialog.askopenfilename(filetypes=file_types,
-                                                     initialdir=initial_folder,
-                                                     initialfile=default_path,
-                                                     parent=root,
-                                                     defaultextension=default_extension)  # show the 'get files' dialog box
+                filename = tk.filedialog.askopenfilename(
+                    filetypes=file_types,
+                    initialdir=initial_folder,
+                    initialfile=default_path,
+                    parent=root,
+                    defaultextension=default_extension,
+                )  # show the 'get files' dialog box
         root.destroy()
 
         if not multiple_files and type(filename) in (tuple, list):
@@ -21512,9 +27922,13 @@ def popup_get_file(message, title=None, default_path='', default_extension='', s
         return filename
 
     if save_as:
-        browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder, default_extension=default_extension)
+        browse_button = SaveAs(
+            file_types=file_types, initial_folder=initial_folder, default_extension=default_extension
+        )
     elif multiple_files:
-        browse_button = FilesBrowse(file_types=file_types, initial_folder=initial_folder, files_delimiter=files_delimiter)
+        browse_button = FilesBrowse(
+            file_types=file_types, initial_folder=initial_folder, files_delimiter=files_delimiter
+        )
     else:
         browse_button = FileBrowse(file_types=file_types, initial_folder=initial_folder)
 
@@ -21533,17 +27947,46 @@ def popup_get_file(message, title=None, default_path='', default_extension='', s
     else:
         file_list = history_settings.get('-PSG file list-', [])
         last_entry = file_list[0] if file_list else ''
-        layout += [[Combo(file_list, default_value=last_entry, key='-INPUT-', size=size if size != (None, None) else (80, 1), bind_return_key=True),
-                    browse_button, Button('Clear History', tooltip='Clears the list of files shown in the combobox')]]
+        layout += [
+            [
+                Combo(
+                    file_list,
+                    default_value=last_entry,
+                    key='-INPUT-',
+                    size=size if size != (None, None) else (80, 1),
+                    bind_return_key=True,
+                ),
+                browse_button,
+                Button('Clear History', tooltip='Clears the list of files shown in the combobox'),
+            ]
+        ]
 
     layout += [[Button('Ok', size=(6, 1), bind_return_key=True), Button('Cancel', size=(6, 1))]]
 
-    window = Window(title=title or message, layout=layout, icon=icon, auto_size_text=True, button_color=button_color,
-                    font=font, background_color=background_color, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, modal=modal, finalize=True)
+    window = Window(
+        title=title or message,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        font=font,
+        background_color=background_color,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        modal=modal,
+        finalize=True,
+    )
 
     if running_linux() and show_hidden is True:
-        window.TKroot.tk.eval('catch {tk_getOpenFile -badoption}')  # dirty hack to force autoloading of Tk's file dialog code
-        window.TKroot.setvar('::tk::dialog::file::showHiddenBtn', 1)  # enable the "show hidden files" checkbox (it's necessary)
+        window.TKroot.tk.eval(
+            'catch {tk_getOpenFile -badoption}'
+        )  # dirty hack to force autoloading of Tk's file dialog code
+        window.TKroot.setvar(
+            '::tk::dialog::file::showHiddenBtn', 1
+        )  # enable the "show hidden files" checkbox (it's necessary)
         window.TKroot.setvar('::tk::dialog::file::showHiddenVar', 0)  # start with the hidden files... well... hidden
 
     while True:
@@ -21553,7 +27996,13 @@ def popup_get_file(message, title=None, default_path='', default_extension='', s
         elif event == 'Clear History':
             history_settings.set('-PSG file list-', [])
             window['-INPUT-'].update('', [])
-            popup_quick_message('History of Previous Choices Cleared', background_color='red', text_color='white', font='_ 20', keep_on_top=True)
+            popup_quick_message(
+                'History of Previous Choices Cleared',
+                background_color='red',
+                text_color='white',
+                font='_ 20',
+                keep_on_top=True,
+            )
         elif event in ('Ok', '-INPUT-'):
             if values['-INPUT-'] != '':
                 if history_settings is not None:
@@ -21574,9 +28023,28 @@ def popup_get_file(message, title=None, default_path='', default_extension='', s
 
 # --------------------------- popup_get_text ---------------------------
 
-def popup_get_text(message, title=None, default_text='', password_char='', size=(None, None), button_color=None,
-                   background_color=None, text_color=None, icon=None, font=None, no_titlebar=False,
-                   grab_anywhere=False, keep_on_top=None, location=(None, None), relative_location=(None, None), image=None, history=False, history_setting_filename=None, modal=True):
+
+def popup_get_text(
+    message,
+    title=None,
+    default_text='',
+    password_char='',
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=None,
+    location=(None, None),
+    relative_location=(None, None),
+    image=None,
+    history=False,
+    history_setting_filename=None,
+    modal=True,
+):
     """
     Display Popup with text entry field. Returns the text entered or None if closed / cancelled
 
@@ -21622,14 +28090,15 @@ def popup_get_text(message, title=None, default_text='', password_char='', size=
     :rtype:                          str | None
     """
 
-
     # First setup the history settings file if history feature is enabled
     if history and history_setting_filename is not None:
         try:
             history_settings = UserSettings(history_setting_filename)
         except Exception as e:
-            _error_popup_with_traceback('popup_get_file - Something is wrong with your supplied history settings filename',
-                                        'Exception: {}'.format(e))
+            _error_popup_with_traceback(
+                'popup_get_file - Something is wrong with your supplied history settings filename',
+                'Exception: {}'.format(e),
+            )
             return None
     elif history:
         history_settings_filename = os.path.basename(inspect.stack()[1].filename)
@@ -21652,14 +28121,37 @@ def popup_get_text(message, title=None, default_text='', password_char='', size=
     else:
         text_list = history_settings.get('-PSG text list-', [])
         last_entry = text_list[0] if text_list else default_text
-        layout += [[Combo(text_list, default_value=last_entry, key='-INPUT-', size=size if size != (None, None) else (80, 1), bind_return_key=True),
-                    Button('Clear History', tooltip='Clears the list of files shown in the combobox')]]
+        layout += [
+            [
+                Combo(
+                    text_list,
+                    default_value=last_entry,
+                    key='-INPUT-',
+                    size=size if size != (None, None) else (80, 1),
+                    bind_return_key=True,
+                ),
+                Button('Clear History', tooltip='Clears the list of files shown in the combobox'),
+            ]
+        ]
 
     layout += [[Button('Ok', size=(6, 1), bind_return_key=True), Button('Cancel', size=(6, 1))]]
 
-    window = Window(title=title or message, layout=layout, icon=icon, auto_size_text=True, button_color=button_color, no_titlebar=no_titlebar,
-                    background_color=background_color, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, relative_location=relative_location, finalize=True, modal=modal, font=font)
-
+    window = Window(
+        title=title or message,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        no_titlebar=no_titlebar,
+        background_color=background_color,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        relative_location=relative_location,
+        finalize=True,
+        modal=modal,
+        font=font,
+    )
 
     while True:
         event, values = window.read()
@@ -21668,7 +28160,13 @@ def popup_get_text(message, title=None, default_text='', password_char='', size=
         elif event == 'Clear History':
             history_settings.set('-PSG text list-', [])
             window['-INPUT-'].update('', [])
-            popup_quick_message('History of Previous Choices Cleared', background_color='red', text_color='white', font='_ 20', keep_on_top=True)
+            popup_quick_message(
+                'History of Previous Choices Cleared',
+                background_color='red',
+                text_color='white',
+                font='_ 20',
+                keep_on_top=True,
+            )
         elif event in ('Ok', '-INPUT-'):
             if values['-INPUT-'] != '':
                 if history_settings is not None:
@@ -21688,8 +28186,26 @@ def popup_get_text(message, title=None, default_text='', password_char='', size=
         return text
 
 
-def popup_get_date(start_mon=None, start_day=None, start_year=None, begin_at_sunday_plus=0, no_titlebar=True, title='Choose Date', keep_on_top=True,
-                   location=(None, None), relative_location=(None, None), close_when_chosen=False, icon=None, locale=None, month_names=None, day_abbreviations=None, day_font = 'TkFixedFont 9', mon_year_font = 'TkFixedFont 10', arrow_font = 'TkFixedFont 7', modal=True):
+def popup_get_date(
+    start_mon=None,
+    start_day=None,
+    start_year=None,
+    begin_at_sunday_plus=0,
+    no_titlebar=True,
+    title='Choose Date',
+    keep_on_top=True,
+    location=(None, None),
+    relative_location=(None, None),
+    close_when_chosen=False,
+    icon=None,
+    locale=None,
+    month_names=None,
+    day_abbreviations=None,
+    day_font='TkFixedFont 9',
+    mon_year_font='TkFixedFont 10',
+    arrow_font='TkFixedFont 7',
+    modal=True,
+):
     """
     Display a calendar window, get the user's choice, return as a tuple (mon, day, year)
 
@@ -21769,7 +28285,17 @@ def popup_get_date(start_mon=None, start_day=None, start_year=None, begin_at_sun
         for week in range(6):
             row = []
             for day in range(7):
-                row.append(T('', size=(4, 1), justification='c', font=day_font, key=(week, day), enable_events=True, pad=(0, 0)))
+                row.append(
+                    T(
+                        '',
+                        size=(4, 1),
+                        justification='c',
+                        font=day_font,
+                        key=(week, day),
+                        enable_events=True,
+                        pad=(0, 0),
+                    )
+                )
             days_layout.append(row)
         return days_layout
 
@@ -21789,22 +28315,69 @@ def popup_get_date(start_mon=None, start_day=None, start_year=None, begin_at_sun
     else:
         day_names = day_abbreviations
 
-    mon_names = month_names if month_names is not None and len(month_names) == 12 else [calendar.month_name[i] for i in range(1, 13)]
+    mon_names = (
+        month_names
+        if month_names is not None and len(month_names) == 12
+        else [calendar.month_name[i] for i in range(1, 13)]
+    )
     days_layout = make_days_layout()
 
-    layout = [[B('◄◄', font=arrow_font, border_width=0, key='-YEAR-DOWN-', pad=((10, 2), 2)),
-               B('◄', font=arrow_font, border_width=0, key='-MON-DOWN-', pad=(0, 2)),
-               Text('{} {}'.format(mon_names[cur_month - 1], cur_year), size=(16, 1), justification='c', font=mon_year_font, key='-MON-YEAR-', pad=(0, 2)),
-               B('►', font=arrow_font, border_width=0, key='-MON-UP-', pad=(0, 2)),
-               B('►►', font=arrow_font, border_width=0, key='-YEAR-UP-', pad=(2, 2))]]
-    layout += [[Col([[T(day_names[i - (7 - begin_at_sunday_plus) % 7], size=(4, 1), font=day_font, background_color=theme_text_color(),
-                        text_color=theme_background_color(), pad=(0, 0)) for i in range(7)]], background_color=theme_text_color(), pad=(0, 0))]]
+    layout = [
+        [
+            B('◄◄', font=arrow_font, border_width=0, key='-YEAR-DOWN-', pad=((10, 2), 2)),
+            B('◄', font=arrow_font, border_width=0, key='-MON-DOWN-', pad=(0, 2)),
+            Text(
+                '{} {}'.format(mon_names[cur_month - 1], cur_year),
+                size=(16, 1),
+                justification='c',
+                font=mon_year_font,
+                key='-MON-YEAR-',
+                pad=(0, 2),
+            ),
+            B('►', font=arrow_font, border_width=0, key='-MON-UP-', pad=(0, 2)),
+            B('►►', font=arrow_font, border_width=0, key='-YEAR-UP-', pad=(2, 2)),
+        ]
+    ]
+    layout += [
+        [
+            Col(
+                [
+                    [
+                        T(
+                            day_names[i - (7 - begin_at_sunday_plus) % 7],
+                            size=(4, 1),
+                            font=day_font,
+                            background_color=theme_text_color(),
+                            text_color=theme_background_color(),
+                            pad=(0, 0),
+                        )
+                        for i in range(7)
+                    ]
+                ],
+                background_color=theme_text_color(),
+                pad=(0, 0),
+            )
+        ]
+    ]
     layout += days_layout
     if not close_when_chosen:
-        layout += [[Button('Ok', border_width=0, font='TkFixedFont 8'), Button('Cancel', border_width=0, font='TkFixedFont 8')]]
+        layout += [
+            [Button('Ok', border_width=0, font='TkFixedFont 8'), Button('Cancel', border_width=0, font='TkFixedFont 8')]
+        ]
 
-    window = Window(title, layout, no_titlebar=no_titlebar, grab_anywhere=True, keep_on_top=keep_on_top, font='TkFixedFont 12', use_default_focus=False,
-                    location=location, relative_location=relative_location, finalize=True, icon=icon)
+    window = Window(
+        title,
+        layout,
+        no_titlebar=no_titlebar,
+        grab_anywhere=True,
+        keep_on_top=keep_on_top,
+        font='TkFixedFont 12',
+        use_default_focus=False,
+        location=location,
+        relative_location=relative_location,
+        finalize=True,
+        icon=icon,
+    )
 
     update_days(window, cur_month, cur_year, begin_at_sunday_plus)
 
@@ -21830,10 +28403,10 @@ def popup_get_date(start_mon=None, start_day=None, start_year=None, begin_at_sun
         if event == 'Ok':
             break
         if event in ('-MON-UP-', '-MON-DOWN-', '-YEAR-UP-', '-YEAR-DOWN-'):
-            cur_month += (event == '-MON-UP-')
-            cur_month -= (event == '-MON-DOWN-')
-            cur_year += (event == '-YEAR-UP-')
-            cur_year -= (event == '-YEAR-DOWN-')
+            cur_month += event == '-MON-UP-'
+            cur_month -= event == '-MON-DOWN-'
+            cur_year += event == '-YEAR-UP-'
+            cur_year -= event == '-YEAR-DOWN-'
             if cur_month > 12:
                 cur_month = 1
                 cur_year += 1
@@ -21859,8 +28432,25 @@ def popup_get_date(start_mon=None, start_day=None, start_year=None, begin_at_sun
 
 # --------------------------- PopupAnimated ---------------------------
 
-def popup_animated(image_source, message=None, background_color=None, text_color=None, font=None, no_titlebar=True, grab_anywhere=True, keep_on_top=True,
-                   location=(None, None), relative_location=(None, None), alpha_channel=None, time_between_frames=0, transparent_color=None, title='', icon=None, no_buffering=False):
+
+def popup_animated(
+    image_source,
+    message=None,
+    background_color=None,
+    text_color=None,
+    font=None,
+    no_titlebar=True,
+    grab_anywhere=True,
+    keep_on_top=True,
+    location=(None, None),
+    relative_location=(None, None),
+    alpha_channel=None,
+    time_between_frames=0,
+    transparent_color=None,
+    title='',
+    icon=None,
+    no_buffering=False,
+):
     """
      Show animation one frame at a time.  This function has its own internal clocking meaning you can call it at any frequency
      and the rate the frames of video is shown remains constant.  Maybe your frames update every 30 ms but your
@@ -21911,16 +28501,39 @@ def popup_animated(image_source, message=None, background_color=None, text_color
 
     if image_source not in Window._animated_popup_dict:
         if type(image_source) is bytes or len(image_source) > 300:
-            layout = [[Image(data=image_source, background_color=background_color, key='-IMAGE-')], ]
+            layout = [
+                [Image(data=image_source, background_color=background_color, key='-IMAGE-')],
+            ]
         else:
-            layout = [[Image(filename=image_source, background_color=background_color, key='-IMAGE-', )], ]
+            layout = [
+                [
+                    Image(
+                        filename=image_source,
+                        background_color=background_color,
+                        key='-IMAGE-',
+                    )
+                ],
+            ]
         if message:
             layout.append([Text(message, background_color=background_color, text_color=text_color, font=font)])
 
-        window = Window(title, layout, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-                        keep_on_top=keep_on_top, background_color=background_color, location=location,
-                        alpha_channel=alpha_channel, element_padding=(0, 0), margins=(0, 0),
-                        transparent_color=transparent_color, finalize=True, element_justification='c', icon=icon, relative_location=relative_location)
+        window = Window(
+            title,
+            layout,
+            no_titlebar=no_titlebar,
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+            background_color=background_color,
+            location=location,
+            alpha_channel=alpha_channel,
+            element_padding=(0, 0),
+            margins=(0, 0),
+            transparent_color=transparent_color,
+            finalize=True,
+            element_justification='c',
+            icon=icon,
+            relative_location=relative_location,
+        )
         Window._animated_popup_dict[image_source] = window
     else:
         window = Window._animated_popup_dict[image_source]
@@ -21936,8 +28549,15 @@ def popup_animated(image_source, message=None, background_color=None, text_color
 
 
 # Popup Notify
-def popup_notify(*args, title='', icon=SYSTEM_TRAY_MESSAGE_ICON_INFORMATION, display_duration_in_ms=SYSTEM_TRAY_MESSAGE_DISPLAY_DURATION_IN_MILLISECONDS,
-                 fade_in_duration=SYSTEM_TRAY_MESSAGE_FADE_IN_DURATION, alpha=0.9, location=None):
+def popup_notify(
+    *args,
+    title='',
+    icon=SYSTEM_TRAY_MESSAGE_ICON_INFORMATION,
+    display_duration_in_ms=SYSTEM_TRAY_MESSAGE_DISPLAY_DURATION_IN_MILLISECONDS,
+    fade_in_duration=SYSTEM_TRAY_MESSAGE_FADE_IN_DURATION,
+    alpha=0.9,
+    location=None,
+):
     """
     Displays a "notification window", usually in the bottom right corner of your display.  Has an icon, a title, and a message.  It is more like a "toaster" window than the normal popups.
 
@@ -21978,7 +28598,7 @@ def popup_notify(*args, title='', icon=SYSTEM_TRAY_MESSAGE_ICON_INFORMATION, dis
         else:
             message_wrapped = textwrap.fill(message, local_line_width)
         message_wrapped_lines = message_wrapped.count('\n') + 1
-        longest_line_len = max([len(l) for l in message.split('\n')])
+        longest_line_len = max([len(line) for line in message.split('\n')])
         width_used = min(longest_line_len, local_line_width)
         max_line_total = max(max_line_total, width_used)
         # height = _GetNumLinesNeeded(message, width_used)
@@ -21989,8 +28609,15 @@ def popup_notify(*args, title='', icon=SYSTEM_TRAY_MESSAGE_ICON_INFORMATION, dis
     message = output
 
     # def __init__(self, menu=None, filename=None, data=None, data_base64=None, tooltip=None, metadata=None):
-    return SystemTray.notify(title=title, message=message, icon=icon, display_duration_in_ms=display_duration_in_ms, fade_in_duration=fade_in_duration,
-                             alpha=alpha, location=location)
+    return SystemTray.notify(
+        title=title,
+        message=message,
+        icon=icon,
+        display_duration_in_ms=display_duration_in_ms,
+        fade_in_duration=fade_in_duration,
+        alpha=alpha,
+        location=location,
+    )
 
 
 def popup_menu(window, element, menu_def, title=None, location=(None, None)):
@@ -22064,7 +28691,7 @@ def _error_popup_with_traceback(title, *args, emoji=None):
             error_message = line
             break
     if file_info_pysimplegui is None:
-        _error_popup_with_code(title, None, None,  'Did not find your traceback info', *args,emoji=emoji)
+        _error_popup_with_code(title, None, None, 'Did not find your traceback info', *args, emoji=emoji)
         return
 
     error_parts = None
@@ -22076,12 +28703,12 @@ def _error_popup_with_traceback(title, *args, emoji=None):
         print('*** Error popup attempted but unable to parse error details ***')
         print(trace_details)
         return
-    filename = error_parts[0][error_parts[0].index('File ') + 5:]
-    line_num = error_parts[1][error_parts[1].index('line ') + 5:]
+    filename = error_parts[0][error_parts[0].index('File ') + 5 :]
+    line_num = error_parts[1][error_parts[1].index('line ') + 5 :]
     _error_popup_with_code(title, filename, line_num, error_message, *args, emoji=emoji)
 
 
-def _error_popup_with_code(title, filename, line_num, *args,  emoji=None):
+def _error_popup_with_code(title, filename, line_num, *args, emoji=None):
     """
     Makes the error popup window
 
@@ -22098,12 +28725,13 @@ def _error_popup_with_code(title, filename, line_num, *args,  emoji=None):
     """
     editor_filename = execute_get_editor()
     emoji_data = emoji if emoji is not None else _random_error_emoji()
-    layout = [[Text('ERROR'), Text(title)],
-              [Image(data=emoji_data)]]
+    layout = [[Text('ERROR'), Text(title)], [Image(data=emoji_data)]]
     lines = []
     for msg in args:
         if isinstance(msg, Exception):
-            lines += [[f'Additional Exception info pased in by PySimpleGUI or user: Error type is: {type(msg).__name__}']]
+            lines += [
+                [f'Additional Exception info pased in by PySimpleGUI or user: Error type is: {type(msg).__name__}']
+            ]
             lines += [[f'In file {__file__} Line number {msg.__traceback__.tb_lineno}']]
             lines += [[f'{msg}']]
         else:
@@ -22113,7 +28741,13 @@ def _error_popup_with_code(title, filename, line_num, *args,  emoji=None):
         max_line_len = max(max_line_len, max([len(s) for s in line]))
 
     layout += [[Text(''.join(line), size=(min(max_line_len, 90), None))] for line in lines]
-    layout += [[Button('Close'), Button('Take me to error', disabled=True if not editor_filename else False), Button('Kill Application', button_color='white on red')]]
+    layout += [
+        [
+            Button('Close'),
+            Button('Take me to error', disabled=True if not editor_filename else False),
+            Button('Kill Application', button_color='white on red'),
+        ]
+    ]
     if not editor_filename:
         layout += [[Text('Configure editor in the Global settings to enable "Take me to error" feature')]]
     window = Window(title, layout, keep_on_top=True)
@@ -22124,7 +28758,14 @@ def _error_popup_with_code(title, filename, line_num, *args,  emoji=None):
             break
         if event == 'Kill Application':
             window.close()
-            popup_quick_message('KILLING APP!  BYE!', font='_ 18', keep_on_top=True, text_color='white', background_color='red', non_blocking=False)
+            popup_quick_message(
+                'KILLING APP!  BYE!',
+                font='_ 18',
+                keep_on_top=True,
+                text_color='white',
+                background_color='red',
+                non_blocking=False,
+            )
             sys.exit()
         if event == 'Take me to error' and filename is not None and line_num is not None:
             execute_editor(filename, line_num)
@@ -22136,20 +28777,34 @@ def _error_popup_with_code(title, filename, line_num, *args,  emoji=None):
 # Animated window while shell command is executed
 #####################################################################
 
+
 def _process_thread(*args):
     global __shell_process__
 
     # start running the command with arugments
     try:
         __shell_process__ = subprocess.run(args, shell=True, stdout=subprocess.PIPE)
-    except Exception as e:
+    except Exception:
         print('Exception running process args = {}'.format(args))
         __shell_process__ = None
 
 
-def shell_with_animation(command, args=None, image_source=DEFAULT_BASE64_LOADING_GIF, message=None, background_color=None, text_color=None, font=None,
-                         no_titlebar=True, grab_anywhere=True, keep_on_top=True, location=(None, None), alpha_channel=None, time_between_frames=100,
-                         transparent_color=None):
+def shell_with_animation(
+    command,
+    args=None,
+    image_source=DEFAULT_BASE64_LOADING_GIF,
+    message=None,
+    background_color=None,
+    text_color=None,
+    font=None,
+    no_titlebar=True,
+    grab_anywhere=True,
+    keep_on_top=True,
+    location=(None, None),
+    alpha_channel=None,
+    time_between_frames=100,
+    transparent_color=None,
+):
     """
     Execute a "shell command" (anything capable of being launched using subprocess.run) and
     while the command is running, show an animated popup so that the user knows that a long-running
@@ -22199,16 +28854,27 @@ def shell_with_animation(command, args=None, image_source=DEFAULT_BASE64_LOADING
 
     # Poll to see if the thread is still running.  If so, then continue showing the animation
     while True:
-        popup_animated(image_source=image_source, message=message, time_between_frames=time_between_frames, transparent_color=transparent_color,
-                       text_color=text_color, background_color=background_color, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-                       keep_on_top=keep_on_top, location=location, alpha_channel=alpha_channel)
+        popup_animated(
+            image_source=image_source,
+            message=message,
+            time_between_frames=time_between_frames,
+            transparent_color=transparent_color,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            no_titlebar=no_titlebar,
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+            location=location,
+            alpha_channel=alpha_channel,
+        )
         thread.join(timeout=time_between_frames / 1000)
         if not thread.is_alive():
             break
     popup_animated(None)  # stop running the animation
 
     output = __shell_process__.__str__().replace('\\r\\n', '\n')  # fix up the output string
-    output = output[output.index("stdout=b'") + 9:-2]
+    output = output[output.index("stdout=b'") + 9 : -2]
     return output
 
 
@@ -22238,6 +28904,7 @@ def shell_with_animation(command, args=None, image_source=DEFAULT_BASE64_LOADING
 # Code to make messages to help user find errors in their code
 #######################################################################
 
+
 def _create_error_message():
     """
     Creates an error message containing the filename and line number of the users
@@ -22258,8 +28925,13 @@ def _create_error_message():
         error_parts = error_message.split(', ')
         if len(error_parts) < 4:
             error_message = error_parts[0] + '\n' + error_parts[1] + '\n' + ''.join(error_parts[2:])
-    return 'The PySimpleGUI internal reporting function is ' + called_func + '\n' + \
-           'The error originated from:\n' + error_message
+    return (
+        'The PySimpleGUI internal reporting function is '
+        + called_func
+        + '\n'
+        + 'The error originated from:\n'
+        + error_message
+    )
 
 
 #   .d8888b.           888    888    d8b
@@ -22279,12 +28951,21 @@ def _create_error_message():
 # settings.  They are automatically saved to a JSON file. If no file/path is specified then a filename is
 # created from the source file filename.
 
+
 class UserSettings:
     # A reserved settings object for use by the setting functions. It's a way for users
     # to access the user settings without diarectly using the UserSettings class
     _default_for_function_interface = None  # type: UserSettings
 
-    def __init__(self, filename=None, path=None, silent_on_error=False, autosave=True, use_config_file=None, convert_bools_and_none=True):
+    def __init__(
+        self,
+        filename=None,
+        path=None,
+        silent_on_error=False,
+        autosave=True,
+        use_config_file=None,
+        convert_bools_and_none=True,
+    ):
         """
         User Settings
 
@@ -22310,7 +28991,10 @@ class UserSettings:
         self.silent_on_error = silent_on_error
         self.autosave = autosave
         if filename is not None and filename.endswith('.ini') and use_config_file is None:
-            warnings.warn('[UserSettings] You have specified a filename with .ini extension but did not set use_config_file. Setting use_config_file for you.', UserWarning)
+            warnings.warn(
+                '[UserSettings] You have specified a filename with .ini extension but did not set use_config_file. Setting use_config_file for you.',
+                UserWarning,
+            )
             use_config_file = True
         self.use_config_file = use_config_file
         # self.retain_config_comments = retain_config_comments
@@ -22319,10 +29003,9 @@ class UserSettings:
             self.config = configparser.ConfigParser()
             self.config.optionxform = str
             # self.config_dict = {}
-            self.section_class_dict = {}        # type: dict[_SectionDict]
+            self.section_class_dict = {}  # type: dict[_SectionDict]
         if filename is not None or path is not None:
             self.load(filename=filename, path=path)
-
 
     ########################################################################################################
     ## FIRST is the _SectionDict helper class
@@ -22331,7 +29014,10 @@ class UserSettings:
 
     class _SectionDict:
         item_count = 0
-        def __init__(self, section_name, section_dict, config, user_settings_parent):  # (str, Dict, configparser.ConfigParser)
+
+        def __init__(
+            self, section_name, section_dict, config, user_settings_parent
+        ):  # (str, Dict, configparser.ConfigParser)
             """
             The Section Dictionary.  It holds the values for a section.
 
@@ -22345,10 +29031,10 @@ class UserSettings:
             :type user_settings_parent:         UserSettings
             """
             self.section_name = section_name
-            self.section_dict = section_dict            # type: Dict
+            self.section_dict = section_dict  # type: Dict
             self.new_section = False
-            self.config = config            # type: configparser.ConfigParser
-            self.user_settings_parent = user_settings_parent    # type: UserSettings
+            self.config = config  # type: configparser.ConfigParser
+            self.user_settings_parent = user_settings_parent  # type: UserSettings
             UserSettings._SectionDict.item_count += 1
 
             if self.user_settings_parent.convert_bools:
@@ -22364,7 +29050,6 @@ class UserSettings:
                         self.section_dict[key] = value
             # print(f'++++++ making a new SectionDict with name = {section_name}')
 
-
         def __repr__(self):
             """
             Converts the settings dictionary into a string for easy display
@@ -22377,7 +29062,6 @@ class UserSettings:
                 return_string += '          {} : {}\n'.format(entry, self.section_dict[entry])
 
             return return_string
-
 
         def get(self, key, default=None):
             """
@@ -22402,7 +29086,7 @@ class UserSettings:
             return value
 
         def set(self, key, value):
-            value = str(value)      # all values must be strings
+            value = str(value)  # all values must be strings
             if self.new_section:
                 self.config.add_section(self.section_name)
                 self.new_section = False
@@ -22436,7 +29120,7 @@ class UserSettings:
             """
             # print(f'*** In SectionDict SET *** item = {item} value = {value}')
             self.set(item, value)
-            self.section_dict[item]  = value
+            self.section_dict[item] = value
 
         def __delitem__(self, item):
             """
@@ -22450,12 +29134,10 @@ class UserSettings:
             self.config.remove_option(section=self.section_name, option=item)
             try:
                 del self.section_dict[item]
-            except Exception as e:
+            except Exception:
                 pass
-                # print(e)
             if self.user_settings_parent.autosave:
                 self.user_settings_parent.save()
-
 
     ########################################################################################################
 
@@ -22477,7 +29159,6 @@ class UserSettings:
             # rvalue += '\n-------------------- Settings End----------------------\n'
             rvalue += '\n'
             return rvalue
-
 
     def set_default_value(self, default):
         """
@@ -22515,7 +29196,9 @@ class UserSettings:
         if path is None:
             if self.path is not None:
                 # path = self.path
-                path = os.path.expanduser(self.path)  # expand user provided path in case it has user ~ in it. Don't think it'll hurt
+                path = os.path.expanduser(
+                    self.path
+                )  # expand user provided path in case it has user ~ in it. Don't think it'll hurt
             elif DEFAULT_USER_SETTINGS_PATH is not None:  # if user set the path manually system-wide using set options
                 path = os.path.expanduser(DEFAULT_USER_SETTINGS_PATH)
             elif running_trinket():
@@ -22568,11 +29251,14 @@ class UserSettings:
         :return:         The full pathname of the settings file that has both the path and filename combined.
         :rtype:          (str)
         """
-        if filename is not None or path is not None or (filename is None and path is None and self.full_filename is None):
+        if (
+            filename is not None
+            or path is not None
+            or (filename is None and path is None and self.full_filename is None)
+        ):
             self.set_location(filename=filename, path=path)
             self.read()
         return self.full_filename
-
 
     def save(self, filename=None, path=None):
         """
@@ -22598,11 +29284,14 @@ class UserSettings:
                     self.config.write(f)
         except Exception as e:
             if not self.silent_on_error:
-                _error_popup_with_traceback('UserSettings.save error', '*** UserSettings.save()  Error saving settings to file:***\n', self.full_filename, e)
+                _error_popup_with_traceback(
+                    'UserSettings.save error',
+                    '*** UserSettings.save()  Error saving settings to file:***\n',
+                    self.full_filename,
+                    e,
+                )
 
         return self.full_filename
-
-
 
     def load(self, filename=None, path=None):
         """
@@ -22644,7 +29333,9 @@ class UserSettings:
             os.remove(self.full_filename)
         except Exception as e:
             if report_error:
-                _error_popup_with_traceback('UserSettings delete_file warning ***', 'Exception trying to perform os.remove', e)
+                _error_popup_with_traceback(
+                    'UserSettings delete_file warning ***', 'Exception trying to perform os.remove', e
+                )
         self.dict = {}
 
     def write_new_dictionary(self, settings_dict):
@@ -22659,7 +29350,6 @@ class UserSettings:
         self.dict = settings_dict
         self.save()
 
-
     def read(self):
         """
         Reads settings file and returns the dictionary.
@@ -22672,15 +29362,17 @@ class UserSettings:
         try:
             if os.path.exists(self.full_filename):
                 with open(self.full_filename, 'r') as f:
-                    if not self.use_config_file:        # if using json
+                    if not self.use_config_file:  # if using json
                         self.dict = json.load(f)
-                    else:                               # if using a config file
+                    else:  # if using a config file
                         self.config.read_file(f)
                         # Make a dictionary of SectionDict classses. Keys are the config.sections().
                         self.section_class_dict = {}
                         for section in self.config.sections():
                             section_dict = dict(self.config[section])
-                            self.section_class_dict[section] = self._SectionDict(section, section_dict, self.config, self)
+                            self.section_class_dict[section] = self._SectionDict(
+                                section, section_dict, self.config, self
+                            )
 
                         self.dict = self.section_class_dict
                         self.config_sections = self.config.sections()
@@ -22689,7 +29381,9 @@ class UserSettings:
                     #     self.config_file_contents = f.readlines()
         except Exception as e:
             if not self.silent_on_error:
-                _error_popup_with_traceback('User Settings read warning', 'Error reading settings from file', self.full_filename, e)
+                _error_popup_with_traceback(
+                    'User Settings read warning', 'Error reading settings from file', self.full_filename, e
+                )
                 # print('*** UserSettings.read - Error reading settings from file: ***\n', self.full_filename, e)
                 # print(_create_error_message())
 
@@ -22723,24 +29417,20 @@ class UserSettings:
         if self.full_filename is None:
             self.set_location()
             self.read()
-        if not self.use_config_file:        # Is using JSON file
+        if not self.use_config_file:  # Is using JSON file
             if key in self.dict:
                 del self.dict[key]
                 if self.autosave:
                     self.save()
             else:
                 if silent_on_error is False or (silent_on_error is not True and not self.silent_on_error):
-                    _error_popup_with_traceback('User Settings delete_entry Warning - key', key, ' not found in settings')
+                    _error_popup_with_traceback(
+                        'User Settings delete_entry Warning - key', key, ' not found in settings'
+                    )
 
         else:
             if section is not None:
-                section_dict = self.get(section)
-                # print(f'** Trying to delete an entry with a config file in use ** id of section_dict = {id(section_dict)}')
-                # section_dict = self.section_class_dict[section]
                 del self.get(section)[key]
-                # del section_dict[key]
-                # del section_dict[key]
-
 
     def delete_section(self, section):
         """
@@ -22935,7 +29625,6 @@ def user_settings_set_entry(key, value):
     settings.set(key, value)
 
 
-
 def user_settings_delete_entry(key, silent_on_error=None):
     """
     Deletes an individual entry.  If no filename has been specified up to this point,
@@ -22949,7 +29638,6 @@ def user_settings_delete_entry(key, silent_on_error=None):
     """
     settings = UserSettings._default_for_function_interface
     settings.delete_entry(key, silent_on_error=silent_on_error)
-
 
 
 def user_settings_get_entry(key, default=None):
@@ -23090,7 +29778,9 @@ These are the functions used to implement the subprocess APIs (Exec APIs) of PyS
 '''
 
 
-def execute_command_subprocess(command, *args, wait=False, cwd=None, pipe_output=False, merge_stderr_with_stdout=True, stdin=None):
+def execute_command_subprocess(
+    command, *args, wait=False, cwd=None, pipe_output=False, merge_stderr_with_stdout=True, stdin=None
+):
     """
     Runs the specified command as a subprocess.
     By default the call is non-blocking.
@@ -23126,13 +29816,36 @@ def execute_command_subprocess(command, *args, wait=False, cwd=None, pipe_output
             # sp = subprocess.Popen(command +' '+ expanded_args, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=cwd)
             if pipe_output:
                 if merge_stderr_with_stdout:
-                    sp = subprocess.Popen(command + ' ' + expanded_args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd, stdin=stdin)
+                    sp = subprocess.Popen(
+                        command + ' ' + expanded_args,
+                        shell=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        cwd=cwd,
+                        stdin=stdin,
+                    )
                 else:
-                    sp = subprocess.Popen(command + ' ' + expanded_args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, stdin=stdin)
+                    sp = subprocess.Popen(
+                        command + ' ' + expanded_args,
+                        shell=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        cwd=cwd,
+                        stdin=stdin,
+                    )
             else:
-                sp = subprocess.Popen(command + ' ' + expanded_args, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=cwd, stdin=stdin)
+                sp = subprocess.Popen(
+                    command + ' ' + expanded_args,
+                    shell=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    cwd=cwd,
+                    stdin=stdin,
+                )
         else:
-            sp = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, stdin=stdin)
+            sp = subprocess.Popen(
+                command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, stdin=stdin
+            )
         if wait:
             out, err = sp.communicate()
             if out:
@@ -23141,12 +29854,20 @@ def execute_command_subprocess(command, *args, wait=False, cwd=None, pipe_output
                 print(err.decode('utf-8'))
     except Exception as e:
         warnings.warn('Error in execute_command_subprocess {}'.format(e), UserWarning)
-        _error_popup_with_traceback('Error in execute_command_subprocess', e, 'command={}'.format(command), 'args={}'.format(args), 'cwd={}'.format(cwd))
+        _error_popup_with_traceback(
+            'Error in execute_command_subprocess',
+            e,
+            'command={}'.format(command),
+            'args={}'.format(args),
+            'cwd={}'.format(cwd),
+        )
         sp = None
     return sp
 
 
-def execute_py_file(pyfile, parms=None, cwd=None, interpreter_command=None, wait=False, pipe_output=False, merge_stderr_with_stdout=True):
+def execute_py_file(
+    pyfile, parms=None, cwd=None, interpreter_command=None, wait=False, pipe_output=False, merge_stderr_with_stdout=True
+):
     """
     Executes a Python file.
     The interpreter to use is chosen based on this priority order:
@@ -23183,15 +29904,30 @@ def execute_py_file(pyfile, parms=None, cwd=None, interpreter_command=None, wait
     else:
         # use the version CURRENTLY RUNNING if nothing is specified. Previously used the one from the settings file
         # ^ hmmm... that's not the code is doing now... it's getting the one from the settings file first
-        pysimplegui_user_settings.load()        # Refresh the settings just in case they've changed via another program
+        pysimplegui_user_settings.load()  # Refresh the settings just in case they've changed via another program
         python_program = pysimplegui_user_settings.get('-python command-', '')
-        if python_program == '':        # if no interpreter set in the settings, then use the current one
+        if python_program == '':  # if no interpreter set in the settings, then use the current one
             python_program = sys.executable
             # python_program = 'python' if running_windows() else 'python3'
     if parms is not None and python_program:
-        sp = execute_command_subprocess(python_program, pyfile, parms, wait=wait, cwd=cwd, pipe_output=pipe_output, merge_stderr_with_stdout=merge_stderr_with_stdout)
+        sp = execute_command_subprocess(
+            python_program,
+            pyfile,
+            parms,
+            wait=wait,
+            cwd=cwd,
+            pipe_output=pipe_output,
+            merge_stderr_with_stdout=merge_stderr_with_stdout,
+        )
     elif python_program:
-        sp = execute_command_subprocess(python_program, pyfile, wait=wait, cwd=cwd, pipe_output=pipe_output, merge_stderr_with_stdout=merge_stderr_with_stdout)
+        sp = execute_command_subprocess(
+            python_program,
+            pyfile,
+            wait=wait,
+            cwd=cwd,
+            pipe_output=pipe_output,
+            merge_stderr_with_stdout=merge_stderr_with_stdout,
+        )
     else:
         print('execute_py_file - No interpreter has been configured')
         sp = None
@@ -23238,9 +29974,14 @@ def execute_editor(file_to_edit, line_number=None):
     :return:             Popen object
     :rtype:              (subprocess.Popen) | None
     """
-    if file_to_edit is not None and len(file_to_edit) != 0 and file_to_edit[0] not in ('\"', "\'") and ' ' in file_to_edit:
+    if (
+        file_to_edit is not None
+        and len(file_to_edit) != 0
+        and file_to_edit[0] not in ('\"', "\'")
+        and ' ' in file_to_edit
+    ):
         file_to_edit = '"' + file_to_edit + '"'
-    pysimplegui_user_settings.load()        # Refresh the settings just in case they've changed via another program
+    pysimplegui_user_settings.load()  # Refresh the settings just in case they've changed via another program
     editor_program = pysimplegui_user_settings.get('-editor program-', None)
     if editor_program is not None:
         format_string = pysimplegui_user_settings.get('-editor format string-', None)
@@ -23351,7 +30092,7 @@ def execute_find_callers_filename():
             print('*** Error popup attempted but unable to parse error details ***')
             print(trace_details)
             return ''
-        filename = error_parts[0][error_parts[0].index('File ') + 5:]
+        filename = error_parts[0][error_parts[0].index('File ') + 5 :]
         return filename
     except:
         return ''
@@ -23413,10 +30154,13 @@ available to make this process more atuomatic.
 
 
 # Dictionary of Mac Patches.  Used to find the key in the global settings and the default value
-MAC_PATCH_DICT = {'Enable No Titlebar Patch' : ('-mac feature enable no titlebar patch-', False),
-                  'Disable Modal Windows' : ('-mac feature disable modal windows-', True),
-                  'Disable Grab Anywhere with Titlebar' : ('-mac feature disable grab anywhere with titlebar-', True),
-                  'Set Alpha Channel to 0.99 for MacOS >= 12.3' : ('-mac feature disable Alpha 0.99', True)}
+MAC_PATCH_DICT = {
+    'Enable No Titlebar Patch': ('-mac feature enable no titlebar patch-', False),
+    'Disable Modal Windows': ('-mac feature disable modal windows-', True),
+    'Disable Grab Anywhere with Titlebar': ('-mac feature disable grab anywhere with titlebar-', True),
+    'Set Alpha Channel to 0.99 for MacOS >= 12.3': ('-mac feature disable Alpha 0.99', True),
+}
+
 
 def _read_mac_global_settings():
     """
@@ -23429,14 +30173,21 @@ def _read_mac_global_settings():
     global ENABLE_MAC_DISABLE_GRAB_ANYWHERE_WITH_TITLEBAR
     global ENABLE_MAC_ALPHA_99_PATCH
 
-    ENABLE_MAC_MODAL_DISABLE_PATCH = pysimplegui_user_settings.get(MAC_PATCH_DICT['Disable Modal Windows'][0],
-                                                                   MAC_PATCH_DICT['Disable Modal Windows'][1])
-    ENABLE_MAC_NOTITLEBAR_PATCH = pysimplegui_user_settings.get(MAC_PATCH_DICT['Enable No Titlebar Patch'][0],
-                                                                MAC_PATCH_DICT['Enable No Titlebar Patch'][1])
-    ENABLE_MAC_DISABLE_GRAB_ANYWHERE_WITH_TITLEBAR = pysimplegui_user_settings.get(MAC_PATCH_DICT['Disable Grab Anywhere with Titlebar'][0],
-                                                                MAC_PATCH_DICT['Disable Grab Anywhere with Titlebar'][1])
-    ENABLE_MAC_ALPHA_99_PATCH = pysimplegui_user_settings.get(MAC_PATCH_DICT['Set Alpha Channel to 0.99 for MacOS >= 12.3'][0],
-                                                                MAC_PATCH_DICT['Set Alpha Channel to 0.99 for MacOS >= 12.3'][1])
+    ENABLE_MAC_MODAL_DISABLE_PATCH = pysimplegui_user_settings.get(
+        MAC_PATCH_DICT['Disable Modal Windows'][0], MAC_PATCH_DICT['Disable Modal Windows'][1]
+    )
+    ENABLE_MAC_NOTITLEBAR_PATCH = pysimplegui_user_settings.get(
+        MAC_PATCH_DICT['Enable No Titlebar Patch'][0], MAC_PATCH_DICT['Enable No Titlebar Patch'][1]
+    )
+    ENABLE_MAC_DISABLE_GRAB_ANYWHERE_WITH_TITLEBAR = pysimplegui_user_settings.get(
+        MAC_PATCH_DICT['Disable Grab Anywhere with Titlebar'][0],
+        MAC_PATCH_DICT['Disable Grab Anywhere with Titlebar'][1],
+    )
+    ENABLE_MAC_ALPHA_99_PATCH = pysimplegui_user_settings.get(
+        MAC_PATCH_DICT['Set Alpha Channel to 0.99 for MacOS >= 12.3'][0],
+        MAC_PATCH_DICT['Set Alpha Channel to 0.99 for MacOS >= 12.3'][1],
+    )
+
 
 def _mac_should_apply_notitlebar_patch():
     """
@@ -23455,9 +30206,12 @@ def _mac_should_apply_notitlebar_patch():
         if tver[0] == 8 and tver[1] == 6 and tver[2] < 10 and ENABLE_MAC_NOTITLEBAR_PATCH:
             return True
     except Exception as e:
-        warnings.warn('Exception while trying to parse tkinter version {} Error = {}'.format(framework_version, e), UserWarning)
+        warnings.warn(
+            'Exception while trying to parse tkinter version {} Error = {}'.format(framework_version, e), UserWarning
+        )
 
     return False
+
 
 def _mac_should_set_alpha_to_99():
 
@@ -23475,12 +30229,14 @@ def _mac_should_set_alpha_to_99():
     # Final check is to see if Mac OS version is 12.3 or later
     try:
         platform_mac_ver = platform.mac_ver()[0]
-        mac_ver = platform_mac_ver.split('.') if '.' in platform_mac_ver  else (platform_mac_ver, 0)
-        if (int(mac_ver[0]) >= 12 and int(mac_ver[1]) >= 3) or int(mac_ver[0]) >= 13 :
+        mac_ver = platform_mac_ver.split('.') if '.' in platform_mac_ver else (platform_mac_ver, 0)
+        if (int(mac_ver[0]) >= 12 and int(mac_ver[1]) >= 3) or int(mac_ver[0]) >= 13:
             # print("Mac OS Version is {} and patch enabled so applying the patch".format(platform_mac_ver))
             return True
     except Exception as e:
-        warnings.warn('_mac_should_seet_alpha_to_99 Exception while trying check mac_ver. Error = {}'.format(e), UserWarning)
+        warnings.warn(
+            '_mac_should_seet_alpha_to_99 Exception while trying check mac_ver. Error = {}'.format(e), UserWarning
+        )
         return False
 
     return False
@@ -23498,21 +30254,30 @@ def main_mac_feature_control():
     current_theme = theme()
     theme('dark red')
 
-    layout = [[T('Mac PySimpleGUI Feature Control', font='DEFAIULT 18')],
-              [T('Use this window to enable / disable features.')],
-              [T('Unfortunately, on some releases of tkinter on the Mac, there are problems that')],
-              [T('create the need to enable and disable sets of features. This window facilitates the control.')],
-              [T('Feature Control / Settings', font='_ 16 bold')],
-              [T('You are running tkinter version:', font='_ 12 bold'), T(framework_version, font='_ 12 bold')]]
-
+    layout = [
+        [T('Mac PySimpleGUI Feature Control', font='DEFAIULT 18')],
+        [T('Use this window to enable / disable features.')],
+        [T('Unfortunately, on some releases of tkinter on the Mac, there are problems that')],
+        [T('create the need to enable and disable sets of features. This window facilitates the control.')],
+        [T('Feature Control / Settings', font='_ 16 bold')],
+        [T('You are running tkinter version:', font='_ 12 bold'), T(framework_version, font='_ 12 bold')],
+    ]
 
     for key, value in MAC_PATCH_DICT.items():
         layout += [[Checkbox(key, k=value[0], default=pysimplegui_user_settings.get(value[0], value[1]))]]
-    layout += [[T('Currently the no titlebar patch ' + ('WILL' if _mac_should_apply_notitlebar_patch() else 'WILL NOT') + ' be applied')],
-               [T('The no titlebar patch will ONLY be applied on tkinter versions < 8.6.10')]]
+    layout += [
+        [
+            T(
+                'Currently the no titlebar patch '
+                + ('WILL' if _mac_should_apply_notitlebar_patch() else 'WILL NOT')
+                + ' be applied'
+            )
+        ],
+        [T('The no titlebar patch will ONLY be applied on tkinter versions < 8.6.10')],
+    ]
     layout += [[Button('Ok'), Button('Cancel')]]
 
-    window = Window('Mac Feature Control', layout, keep_on_top=True, finalize=True )
+    window = Window('Mac Feature Control', layout, keep_on_top=True, finalize=True)
     while True:
         event, values = window.read()
         if event in ('Cancel', WIN_CLOSED):
@@ -23545,8 +30310,6 @@ def main_mac_feature_control():
 red_x = b'R0lGODlhEAAQAPeQAIsAAI0AAI4AAI8AAJIAAJUAAJQCApkAAJoAAJ4AAJkJCaAAAKYAAKcAAKcCAKcDA6cGAKgAAKsAAKsCAKwAAK0AAK8AAK4CAK8DAqUJAKULAKwLALAAALEAALIAALMAALMDALQAALUAALYAALcEALoAALsAALsCALwAAL8AALkJAL4NAL8NAKoTAKwbAbEQALMVAL0QAL0RAKsREaodHbkQELMsALg2ALk3ALs+ALE2FbgpKbA1Nbc1Nb44N8AAAMIWAMsvAMUgDMcxAKVABb9NBbVJErFYEq1iMrtoMr5kP8BKAMFLAMxKANBBANFCANJFANFEB9JKAMFcANFZANZcANpfAMJUEMZVEc5hAM5pAMluBdRsANR8AM9YOrdERMpIQs1UVMR5WNt8X8VgYMdlZcxtYtx4YNF/btp9eraNf9qXXNCCZsyLeNSLd8SSecySf82kd9qqc9uBgdyBgd+EhN6JgtSIiNuJieGHhOGLg+GKhOKamty1ste4sNO+ueenp+inp+HHrebGrefKuOPTzejWzera1O7b1vLb2/bl4vTu7fbw7ffx7vnz8f///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAAJAALAAAAAAQABAAAAjUACEJHEiwYEEABniQKfNFgQCDkATQwAMokEU+PQgUFDAjjR09e/LUmUNnh8aBCcCgUeRmzBkzie6EeQBAoAAMXuA8ciRGCaJHfXzUMCAQgYooWN48anTokR8dQk4sELggBhQrU9Q8evSHiJQgLCIIfMDCSZUjhbYuQkLFCRAMAiOQGGLE0CNBcZYmaRIDLqQFGF60eTRoSxc5jwjhACFWIAgMLtgUocJFy5orL0IQRHAiQgsbRZYswbEhBIiCCH6EiJAhAwQMKU5DjHCi9gnZEHMTDAgAOw=='
 
 
-
-
 class _Debugger:
     debugger = None
     DEBUGGER_MAIN_WINDOW_THEME = 'dark grey 13'
@@ -23575,6 +30338,7 @@ class _Debugger:
         #     # #    # # #   ##    #     # #      #    # #    # #    # #    # #      #   #
         #     # #    # # #    #    ######  ###### #####   ####   ####   ####  ###### #    #
     '''
+
     def __init__(self):
         self.watcher_window = None  # type: Window
         self.popout_window = None  # type: Window
@@ -23591,32 +30355,57 @@ class _Debugger:
         theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
 
         def InVar(key1):
-            row1 = [T('    '),
-                    I(key=key1, size=(_Debugger.WIDTH_VARIABLES, 1)),
-                    T('', key=key1 + 'CHANGED_', size=(_Debugger.WIDTH_RESULTS, 1)), B('Detail', key=key1 + 'DETAIL_'),
-                    B('Obj', key=key1 + 'OBJ_'), ]
+            row1 = [
+                T('    '),
+                I(key=key1, size=(_Debugger.WIDTH_VARIABLES, 1)),
+                T('', key=key1 + 'CHANGED_', size=(_Debugger.WIDTH_RESULTS, 1)),
+                B('Detail', key=key1 + 'DETAIL_'),
+                B('Obj', key=key1 + 'OBJ_'),
+            ]
             return row1
 
-        variables_frame = [InVar('_VAR0_'),
-                           InVar('_VAR1_'),
-                           InVar('_VAR2_'), ]
+        variables_frame = [
+            InVar('_VAR0_'),
+            InVar('_VAR1_'),
+            InVar('_VAR2_'),
+        ]
 
-        interactive_frame = [[T('>>> '), In(size=(83, 1), key='-REPL-',
-                                            tooltip='Type in any "expression" or "statement"\n and it will be disaplayed below.\nPress RETURN KEY instead of "Go"\nbutton for faster use'),
-                              B('Go', bind_return_key=True, visible=True)],
-                             [Multiline(size=(93, 26), key='-OUTPUT-', autoscroll=True, do_not_clear=True)], ]
+        interactive_frame = [
+            [
+                T('>>> '),
+                In(
+                    size=(83, 1),
+                    key='-REPL-',
+                    tooltip='Type in any "expression" or "statement"\n and it will be disaplayed below.\nPress RETURN KEY instead of "Go"\nbutton for faster use',
+                ),
+                B('Go', bind_return_key=True, visible=True),
+            ],
+            [Multiline(size=(93, 26), key='-OUTPUT-', autoscroll=True, do_not_clear=True)],
+        ]
 
-        autowatch_frame = [[Button('Choose Variables To Auto Watch', key='-LOCALS-'),
-                            Button('Clear All Auto Watches'),
-                            Button('Show All Variables', key='-SHOW_ALL-'),
-                            Button('Locals', key='-ALL_LOCALS-'),
-                            Button('Globals', key='-GLOBALS-'),
-                            Button('Popout', key='-POPOUT-')]]
+        autowatch_frame = [
+            [
+                Button('Choose Variables To Auto Watch', key='-LOCALS-'),
+                Button('Clear All Auto Watches'),
+                Button('Show All Variables', key='-SHOW_ALL-'),
+                Button('Locals', key='-ALL_LOCALS-'),
+                Button('Globals', key='-GLOBALS-'),
+                Button('Popout', key='-POPOUT-'),
+            ]
+        ]
 
         var_layout = []
         for i in range(_Debugger.NUM_AUTO_WATCH):
-            var_layout.append([T('', size=(_Debugger.WIDTH_WATCHER_VARIABLES, 1), key='_WATCH%s_' % i),
-                               T('', size=(_Debugger.WIDTH_WATCHER_RESULTS, _Debugger.MAX_LINES_PER_RESULT_MAIN), key='_WATCH%s_RESULT_' % i,)])
+            var_layout.append(
+                [
+                    T('', size=(_Debugger.WIDTH_WATCHER_VARIABLES, 1), key='_WATCH%s_' % i),
+                    T(
+                        '',
+                        size=(_Debugger.WIDTH_WATCHER_RESULTS, _Debugger.MAX_LINES_PER_RESULT_MAIN),
+                        key='_WATCH%s_RESULT_' % i,
+                    ),
+                ]
+            )
 
         col1 = [
             # [Frame('Auto Watches', autowatch_frame+variable_values, title_color='blue')]
@@ -23624,16 +30413,39 @@ class _Debugger:
         ]
 
         col2 = [
-            [Frame('Variables or Expressions to Watch', variables_frame, title_color=theme_button_color()[0]), ],
-            [Frame('REPL-Light - Press Enter To Execute Commands', interactive_frame, title_color=theme_button_color()[0]), ]
+            [
+                Frame('Variables or Expressions to Watch', variables_frame, title_color=theme_button_color()[0]),
+            ],
+            [
+                Frame(
+                    'REPL-Light - Press Enter To Execute Commands',
+                    interactive_frame,
+                    title_color=theme_button_color()[0],
+                ),
+            ],
         ]
 
         # Tab based layout
-        layout = [[Text('Debugging: ' + self._find_users_code())],
-                  [TabGroup([[Tab('Variables', col1), Tab('REPL & Watches', col2)]])]]
+        layout = [
+            [Text('Debugging: ' + self._find_users_code())],
+            [TabGroup([[Tab('Variables', col1), Tab('REPL & Watches', col2)]])],
+        ]
 
         # ------------------------------- Create main window -------------------------------
-        window = Window('PySimpleGUI Debugger', layout, icon=PSG_DEBUGGER_LOGO, margins=(0, 0), location=location, keep_on_top=True, right_click_menu=[[''], ['Exit', ]])
+        window = Window(
+            'PySimpleGUI Debugger',
+            layout,
+            icon=PSG_DEBUGGER_LOGO,
+            margins=(0, 0),
+            location=location,
+            keep_on_top=True,
+            right_click_menu=[
+                [''],
+                [
+                    'Exit',
+                ],
+            ],
+        )
 
         Window._read_call_from_debugger = True
         window.finalize()
@@ -23674,7 +30486,7 @@ class _Debugger:
 
             try:
                 result = eval('{}'.format(cmd), myglobals, mylocals)
-            except Exception as e:
+            except Exception:
                 if sys.version_info[0] < 3:
                     result = 'Not available in Python 2'
                 else:
@@ -23693,14 +30505,19 @@ class _Debugger:
                 result = ''
             old_theme = theme()
             theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
-            popup_scrolled(str(values['_VAR{}_'.format(event[4])]) + '\n' + result, title=var, non_blocking=True, font=_Debugger.DEBUGGER_VARIABLE_DETAILS_FONT)
+            popup_scrolled(
+                str(values['_VAR{}_'.format(event[4])]) + '\n' + result,
+                title=var,
+                non_blocking=True,
+                font=_Debugger.DEBUGGER_VARIABLE_DETAILS_FONT,
+            )
             theme(old_theme)
         # BUTTON - OBJ
         elif event.endswith('_OBJ_'):  # OBJECT BUTTON
             var = values['_VAR{}_'.format(event[4])]
             try:
                 result = ObjToStringSingleObj(mylocals[var])
-            except Exception as e:
+            except Exception:
                 try:
                     result = eval('{}'.format(var), myglobals, mylocals)
                     result = ObjToStringSingleObj(result)
@@ -23708,7 +30525,12 @@ class _Debugger:
                     result = '{}\nError showing object {}'.format(e, var)
             old_theme = theme()
             theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
-            popup_scrolled(str(var) + '\n' + str(result), title=var, non_blocking=True, font=_Debugger.DEBUGGER_VARIABLE_DETAILS_FONT)
+            popup_scrolled(
+                str(var) + '\n' + str(result),
+                title=var,
+                non_blocking=True,
+                font=_Debugger.DEBUGGER_VARIABLE_DETAILS_FONT,
+            )
             theme(old_theme)
         # ------------------------------- Process Watch Tab -------------------------------
         # BUTTON - Choose Locals to see
@@ -23757,12 +30579,14 @@ class _Debugger:
             if self.local_choices[key]:
                 self.watcher_window.Element('_WATCH{}_'.format(slot)).Update(key)
                 try:
-                    self.watcher_window.Element('_WATCH{}_RESULT_'.format(slot), silent_on_error=True).Update(mylocals[key])
+                    self.watcher_window.Element('_WATCH{}_RESULT_'.format(slot), silent_on_error=True).Update(
+                        mylocals[key]
+                    )
                 except:
                     self.watcher_window.Element('_WATCH{}_RESULT_'.format(slot)).Update('')
                 slot += 1
 
-            if slot + int(not self.custom_watch in (None, '')) >= _Debugger.NUM_AUTO_WATCH:
+            if slot + int(self.custom_watch not in (None, '')) >= _Debugger.NUM_AUTO_WATCH:
                 break
         # If a custom watch was set, display that value in the window
         if self.custom_watch:
@@ -23800,10 +30624,11 @@ class _Debugger:
                 print('*** Error popup attempted but unable to parse error details ***')
                 print(trace_details)
                 return ''
-            filename = error_parts[0][error_parts[0].index('File ') + 5:]
+            filename = error_parts[0][error_parts[0].index('File ') + 5 :]
             return filename
         except:
             return
+
     '''
         ######                                 #     #
         #     #  ####  #####  #    # #####     #  #  # # #    # #####   ####  #    #
@@ -23824,30 +30649,24 @@ class _Debugger:
     # displays them into a single text box
 
     def _display_all_vars(self, title, dict):
-        num_cols = 3
-        output_text = ''
-        num_lines = 2
-        cur_col = 0
         out_text = title + '\n'
-        longest_line = max([len(key) for key in dict])
-        line = []
         sorted_dict = {}
         for key in sorted(dict.keys()):
             sorted_dict[key] = dict[key]
         for key in sorted_dict:
             value = dict[key]
-            # wrapped_list = textwrap.wrap(str(value), 60)
-            # wrapped_text = '\n'.join(wrapped_list)
             wrapped_text = str(value)
             out_text += '{} - {}\n'.format(key, wrapped_text)
-            # if cur_col + 1 == num_cols:
-            #     cur_col = 0
-            #     num_lines += len(wrapped_list)
-            # else:
-            #     cur_col += 1
         old_theme = theme()
         theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
-        popup_scrolled(out_text, title=title, non_blocking=True, font=_Debugger.DEBUGGER_VARIABLE_DETAILS_FONT, keep_on_top=True, icon=PSG_DEBUGGER_LOGO)
+        popup_scrolled(
+            out_text,
+            title=title,
+            non_blocking=True,
+            font=_Debugger.DEBUGGER_VARIABLE_DETAILS_FONT,
+            keep_on_top=True,
+            icon=PSG_DEBUGGER_LOGO,
+        )
         theme(old_theme)
 
     '''
@@ -23872,8 +30691,6 @@ class _Debugger:
         old_theme = theme()
         theme(_Debugger.DEBUGGER_MAIN_WINDOW_THEME)
         num_cols = 3
-        output_text = ''
-        num_lines = 2
         cur_col = 0
         layout = [[Text('Choose your "Auto Watch" variables', font='ANY 14', text_color='red')]]
         longest_line = max([len(key) for key in my_locals])
@@ -23882,8 +30699,14 @@ class _Debugger:
         for key in sorted(my_locals.keys()):
             sorted_dict[key] = my_locals[key]
         for key in sorted_dict:
-            line.append(CB(key, key=key, size=(longest_line, 1),
-                           default=self.local_choices[key] if key in self.local_choices else False))
+            line.append(
+                CB(
+                    key,
+                    key=key,
+                    size=(longest_line, 1),
+                    default=self.local_choices[key] if key in self.local_choices else False,
+                )
+            )
             if cur_col + 1 == num_cols:
                 cur_col = 0
                 layout.append(line)
@@ -23894,9 +30717,12 @@ class _Debugger:
             layout.append(line)
 
         layout += [
-            [Text('Custom Watch (any expression)'), Input(default_text=self.custom_watch, size=(40, 1), key='-CUSTOM_WATCH-')]]
-        layout += [
-            [Ok(), Cancel(), Button('Clear All'), Button('Select [almost] All', key='-AUTO_SELECT-')]]
+            [
+                Text('Custom Watch (any expression)'),
+                Input(default_text=self.custom_watch, size=(40, 1), key='-CUSTOM_WATCH-'),
+            ]
+        ]
+        layout += [[Ok(), Cancel(), Button('Clear All'), Button('Select [almost] All', key='-AUTO_SELECT-')]]
 
         window = Window('Choose Watches', layout, icon=PSG_DEBUGGER_LOGO, finalize=True, keep_on_top=True)
 
@@ -23909,7 +30735,14 @@ class _Debugger:
                 self.custom_watch = values['-CUSTOM_WATCH-']
                 break
             elif event == 'Clear All':
-                popup_quick_message('Cleared Auto Watches', auto_close=True, auto_close_duration=3, non_blocking=True, text_color='red', font='ANY 18')
+                popup_quick_message(
+                    'Cleared Auto Watches',
+                    auto_close=True,
+                    auto_close_duration=3,
+                    non_blocking=True,
+                    text_color='red',
+                    font='ANY 18',
+                )
                 for key in sorted_dict:
                     window.Element(key).Update(False)
                 window.Element('-CUSTOM_WATCH-').Update('')
@@ -23923,7 +30756,6 @@ class _Debugger:
         # exited event loop
         window.Close()
         theme(old_theme)
-
 
     '''
         ######                            #######
@@ -23971,9 +30803,11 @@ class _Debugger:
             if self.popout_choices[key] is True:
                 value = str(self.locals.get(key))
                 h = min(len(value) // width_value + 1, _Debugger.MAX_LINES_PER_RESULT_FLOATING)
-                line += [Text('{}'.format(key), size=(width_var, 1), font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
-                         Text(' = ', font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
-                         Text(value, key=key, size=(width_value, h), font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT)]
+                line += [
+                    Text('{}'.format(key), size=(width_var, 1), font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
+                    Text(' = ', font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
+                    Text(value, key=key, size=(width_value, h), font=_Debugger.DEBUGGER_POPOUT_WINDOW_FONT),
+                ]
                 if col + 1 < num_cols:
                     line += [VerticalSeparator(), T(' ')]
                 col += 1
@@ -23986,9 +30820,19 @@ class _Debugger:
         layout = [[T(SYMBOL_X, enable_events=True, key='-EXIT-', font='_ 7')], [Column(layout)]]
 
         Window._read_call_from_debugger = True
-        self.popout_window = Window('Floating', layout, alpha_channel=0, no_titlebar=True, grab_anywhere=True,
-                                    element_padding=(0, 0), margins=(0, 0), keep_on_top=True,
-                                    right_click_menu=['&Right', ['Debugger::RightClick', 'Exit::RightClick']], location=location, finalize=True)
+        self.popout_window = Window(
+            'Floating',
+            layout,
+            alpha_channel=0,
+            no_titlebar=True,
+            grab_anywhere=True,
+            element_padding=(0, 0),
+            margins=(0, 0),
+            keep_on_top=True,
+            right_click_menu=['&Right', ['Debugger::RightClick', 'Exit::RightClick']],
+            location=location,
+            finalize=True,
+        )
         Window._read_call_from_debugger = False
 
         if location == (None, None):
@@ -24070,8 +30914,6 @@ def show_debugger_window(location=(None, None), *args):
         _Debugger.debugger = _Debugger()
     debugger = _Debugger.debugger
     frame = inspect.currentframe()
-    prev_frame = inspect.currentframe().f_back
-    # frame, *others = inspect.stack()[1]
     try:
         debugger.locals = frame.f_back.f_locals
         debugger.globals = frame.f_back.f_globals
@@ -24096,9 +30938,6 @@ def show_debugger_popout_window(location=(None, None), *args):
         _Debugger.debugger = _Debugger()
     debugger = _Debugger.debugger
     frame = inspect.currentframe()
-    prev_frame = inspect.currentframe().f_back
-    # frame = inspect.getframeinfo(prev_frame)
-    # frame, *others = inspect.stack()[1]
     try:
         debugger.locals = frame.f_back.f_locals
         debugger.globals = frame.f_back.f_globals
@@ -24180,14 +31019,18 @@ def get_versions():
     else:
         platform_name, platform_ver = 'Unknown platorm', 'Unknown platform version'
 
-    versions = 'Python Interpeter: {}\nPython version: {}.{}.{}\nPlatform: {}\nPlatform version: {}\nPort: {}\ntkinter version: {}\nPySimpleGUI version: {}\nPySimpleGUI filename: {}'.format(sys.executable, sys.version_info.major,
-                                                                                                                                   sys.version_info.minor,
-                                                                                                                                   sys.version_info.micro,
-                                                                                                                                    platform_name, platform_ver,
-                                                                                                                                   port,
-                                                                                                                                   tclversion_detailed,
-                                                                                                                                   ver,
-                                                                                                                                   __file__)
+    versions = 'Python Interpeter: {}\nPython version: {}.{}.{}\nPlatform: {}\nPlatform version: {}\nPort: {}\ntkinter version: {}\nPySimpleGUI version: {}\nPySimpleGUI filename: {}'.format(
+        sys.executable,
+        sys.version_info.major,
+        sys.version_info.minor,
+        sys.version_info.micro,
+        platform_name,
+        platform_ver,
+        port,
+        tclversion_detailed,
+        ver,
+        __file__,
+    )
     return versions
 
 
@@ -24305,7 +31148,6 @@ EMOJI_BASE64_HEAD_EXPLODE = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGX
 EMOJI_BASE64_LAPTOP = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjI3RUM1QzE3MzQwQzExRUQ4M0I0Q0I4NzYwOERFNjZDIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjI3RUM1QzE4MzQwQzExRUQ4M0I0Q0I4NzYwOERFNjZDIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6MjdFQzVDMTUzNDBDMTFFRDgzQjRDQjg3NjA4REU2NkMiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6MjdFQzVDMTYzNDBDMTFFRDgzQjRDQjg3NjA4REU2NkMiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz7XxuepAAASgUlEQVR42uxaa3Bc5Xl+zmXvu1qtdlf3q2XJt1iyLRtfAAfZBurgEgYooWRCyLQkE6YhSWkmmcmPtNPkT5uZJiUzhUwHGloIhEugNnc61AYbW8bYkmzJliVZ111dVnu/nj2Xvt85K9uSZSPaddLJ5Mwc79n1uXzP9z7v8z7vd8RpmoY/5I3HH/j2R4B/BPj/fBM7Ozuv+0MU0jFdyugfO+0CNDc0pb7arFbaBK2aE0w+u40vNZvhMIkQOA6CrEDO55HNZBGXJITpt2Agh+mMgom8hok03U4QjPsL3NWfzf2uZtIMrG4A9mxoxN6acrSsa7PWN64oszgcJojaDOxiBmYTQABBYEAAQQBBAJGTAAKJ2Tmgtw9TIwGM9l7AEUJ5YAY4TLfP/d4ANgvYusaHx27eJu699Y6VzrVbNsJS3gSoNOLsKJDuo88xQpMohHnR6LhFo2THBHySLjl0FHj7ffQcOY9fTkh4KkPz8TsD6OVgW2PD39+7V/zWnz20w1zdcTNgrQJi54C5g0Cyh8K0CMhyN3YuRRoUcYSBVw4AL+7H0d4gvtUn42PtegP0cyhdX+d84WvfvvG2fQ/cCd62CmcjOUzOHkU6dR6SxkPi7cQrO1TSOZlGKkO4ChaN6C3RWSqdldeP2W5FlvI5jRJTGipxuPdMDodfno2fPzry5W4JBxTtOgF00NzeUOd6ufyfX73z1j27IFAOvUm585sQU5vrpNuEQqSI2vMhbPzpV5ORA2/s6lFwvOgAGWNW28S/Kv3xE4/ve/gv4CNwXZRaT05Cj5OFz+ux0ndOJpbJJCgaeE2FyCkUK06PGBuUWjg2IiwU1FigGIrIa+xKkZhg0uN5MVQWAppIYtt3bzjR3d1/Ez06KxYTIN3fs2W9+L0/v0NAa/YQaX0SN0SexjfEcdiIkLxC6iBT4imy/smrMlTVAAiVALJyQofMH/MF7ed5DgovGpGguqAJohEu+tREmirBjLRmQTBqwcAFFzLucsR2WjtCfbjvbB7PFBWgn8cX7t4l1u/xjhMAGlLuBCqCL+HAG8Cp0zSdJJwKk3+lgFM1drbJqlEn1cIuCtABC0RpwqgDZHWP/W4qYBTpx6pK4It7gS3NQF+cfqMCGaJ6NFyDvxwZwX8UDaCdHtZWhfs6djTSaOpYNUds5Ah++CPg+JATXJkfHBsVTyPmeHA0co19igV+zScLx+mHhjEoKEXhU2PIJZqdNKOzQWVtNI79H87grx/R0LgSiKcAVxmwthWbPxhDa9EA0rO9rY3YUNG8gsLC8uICXvz3M+gadMK6vk2nExsnL+fBKYX6QKFRTZZFUqAtIfBE2XzOCC0zAakUFFb9KZRiUzMSs048/ewQvvsdMhQW44qWFtgqD2FL8SLIY2VrM2o5Vz0NXEBm9CQ+PJyFWL2KwJn1vBNkCemKJkzfsA95Wwm8vQdRdvYw5ZXp2oaZcje8ajvCa2+EORWF/9h+iP0nqDxwkHM5mLw+BAYD6O/PoGOzEXBGXZsN24oGsFpES/MK4p3oJXqmMdzdhbEZMpWtJTTzqj7IjL8BvV//OXKVFUwmMbX9T9H63E9Qdew1Crp1yfsKUgbB7fdg4P4fGElHDJ/ZdDvW/vRBiCNnoZFuKQSSd5TibAEgy3MnPbbBh1VFq0qUTs2VVawKuskwDaLnxARpND3FYtOlkdFyumMvchUEjjnlrOGSJ2+6zwC3xMoCR9fJVicmbv6SoTTsGro2XVuH0La7SIUVPWe1bAaa041xKkfEXt3LUvRQYoevaACddtQ6S2ignB1IfIL+cyQD9pIFuaSarAv9JisLRF+NKM1hiaUTAs3oq+fpousUhxucyaC2lpf043BCRDhs6Jhe+O1wFQ2gww6v1c6iJUGa6kFwmiWm89KY6Km+nv8CnyZOWY2iyZTWf+pdiNmkrqhX4CPgJso5H+WqXs/ZTtfySQm+/g/oe4HWjJN0/3TegvCcEUG2lbjgLFoOUn1ymMwUPWkcsekgYkQV3m25qIqqaEHJSA/WPv09TO68H4rVAW/PIdR8+LwR2aups8mMhnd+SeorIbJ2K6V3CjUHn4Nr7AzydA9IUeM8ymme2DA3l7p4LdHUUsxCz4MnyqR7KA80pCSinV6tLx+sBWX9R/Rdr4XkZBT6banoXYwi/R8TqKY3foH6d/+VjmU9p1WKHsdnL51H92KlKJm4TKAEnalFM7zUg8cIYBR5GkNe5g0bckVELJfVO9Oybs1AKmabnpOqPmTuoim4dGNVt3G5y1pfckty0QCS1crIqQm9Gb2oK1dbcmWKyf0vfD67Rlfbq19/+SMJbLZoIpPJIJTNUrJrSsEravqag8YotWgwLBp8PksUVZaPjc4VcmlddVleGsZVXQCenWM2X/opnkSqaACTKQTThQUDG2mNw6Lojagm5RaUCiYW8RUbMNH5oD5QIZvSbZgO9rJayGogyz1ByurnMGoHdtyL8Vu+TOeqhg+V5UvnEz05urfLacwnux3VxGTRKEqBGg1RDWqlSS2lWu92aJiQKPFJ9XhmEHljLlmelA50YXrTXgRuuheVH/0WnnNdsEanIFJJYF6VCZBstSNPrU/GW4vImh2Ybe8koFms/dUPIFD0VaqPWv5SwjEfAAJY5jUA6otVOUSLBjCjYXhiUu9UYaH6Xk2G5cxgVg+nEotAKPMZCxD0dBaZ1b/+EUZv/wZG9z6MkTsfgTk0RzUvTIPP6fWPORipxAfFQ3RO5VF57AAa3noSpmQUqsUKLUW1ky21MTRs8ij6DjEHn88YT5ocTzCG8aIBnMxjbHAEJKNws+/t64D3umPUJpVBmQvpyS84XboRZwNiFFyx/2eoOL4f4c/tRKRlK3KeckjM/dBgRaKlZ+AYSge79AjbpoahUuOr0LVaMk6TFrsoWBwrNRQun1uGz28ITYTYFIqgp3iFHhgbn8CFXBwbLARxYzs5ieeTSLIWh3JNS8QhE11ZceK4+S6WgzlyHNVnjqKajpknZYaA1Tkhm9ZzSrdrNCkSgdPfhJGI6W3TvKqyfCRPxk2NY+VG3Z7pqwLBAOWggpPFU1HSzDNjOB4IGDRdQc1nW4sChaaS91AHynwjUz2mrOQd2YxrlFMKFc28olHdpOJNtOOiIeqUw1CIfrJG7RD5B4UAaSw3mSKr2oJyw7nc+sq2NRdBe7sBjp0yNITQlIQzRQPIBH88htdP9hhfgjTOXbvowdFJ8HOzMLvd4EvLwNkcOljDvXBXtCSaTmFh6TrHfmNrMszFUD8kerwwcdRxDA1g/RoFDU2GEEfIjw6N42Oan4BQzDUZScOsT8MDu3fCPUZm204p11CnITIWQzIQBpfLEjBBV1XeauwcCQaotnFksziisrFfdkznclYbBItF3zlGcTLXYipG9A7AlQti94157NtndBCMKCc/Ad49ih9PyuguKkCasYwcgWtdEzrrqLGPxglgAwGt5HE6xGNDfQpV5hjEBE1xPAIlmqDuIgmeah1HFGT9HU+DZ70jKxe8XgOTEEg5+UQYlnQIPm0K9c4w1jUlkbaraPicgK98UTWWdWhPkXq++gqGumfxGFni4i4bykSP82n8/F+ewT0//Bu0sYTPS4WVM4eAz+9W0FqlYi5CaRaTkYjLiNBxPGY0qqx2yYaX1ploMRui4SImlHpInkm8KOXgKTWi9fhbVE6I6cxL6OylcL3zJvDxML4fUhEtiF9xt6iG2JELeOAffobX7r8fzWwNqsylkRBo+uwyAPOD/sx2VCtMFn0y18SAVfpVsDaUyID9rwIvvY/v9+Xw8rwUCbgOW0zF7GAIzwbPopYi2FpfA3EmJSCR49DeqGJxd8Rek7Ge9VP3gvVkr9lGwzw+GRHQuVbBzLiGF19E4M0ufLMviycWvHzZ6rPcJaVyf1Lsv7UgqZacvL5C31lejpXkboQE0XV1Lf0fRZEtpDF5Z0s0nbuMxVx1GYNgk8HK6W+PiJid0mBLKud6hvHCcApPEC2Di+8hbtiy9W6nv/IrPFu3ZD0VtGKC1O/GZp8dlDOPqHJQaZQXjryH+i2fxzmSvEhkHDW1Ru6JfOEFqGpcq+aNF6Bk5jPhMKLJJEITUUzOReVjKQmHJjI4TuxMXG3U4tTgueD6NRtR2boOzU2N1G6Ycb3+doYnmzUxMYHZuTBSU0NwlFjhvqkTr//qmbep9L1i9Vc+Kbv9RgEnF8MFhg73JZRHKdWyNCK2FpEg/PH0pTeLn7oJNdnUSt4s7PM0tsBE9sldUqJH0njLU9yduTOTKCBMoWCme/zjD9G4rROxoZNuM9lqwWZuNpEqmLUc7RKVDYmz28xOv13c6BdkT15FJKtiSv4MkypeyOOg4/zpQC5+a/UE1Z9AMLg8+jE6L4q0IHy6ZnEEjF3rbWzF8AfvIBOdQ+XqNn9oZvo279oOoqR0eY9Xl85kvxmLkeJTTaxORpRcePrUdCj+hiJrJ5je0KSlghKm5zScWIp34piMfu9s/PW5oTMP13TcBDmbXRY4O2l9dXU1HA4HJX4es7OzCIVCOoDlgDRZrfCtXIdATxfqNu3A9KvPQnCQ/RKEBY2vu4RKjMOFcCSKrMsnqGJJx6O7T3Rsajf8Olv/6e+H+k8v4NvdCfxCXUxRditSu0iJmn6oYm0HxxXe7uifS+wsai4qYm1tbdR7+WCz2eB0OlFOUslyLBqNXvXa+X1+lcricGL0+CECeCMiI+d0YbGU+oxlDr1zMHYrWTS7zUpipSAxE8LXbpvCpluoBpICV5Njau8AlwhgW9dZ/IbCE10AsNCsTnpysS+UN7XU2Mv8lIPXXitZtWoVuQo3FW1ZBzxPVfZbiq0TkNTx/LV9vEaSaXWXIjR4Vn+V5q6sRbDvJEobWiCQdAooLEsUJpXR30kTm4ol0OwaZa/HjD8ekY3X4vWVsB09DMtoCq8vXMtk3a9KXU1a+7ep3uPXfKnNqMkixiKoKMqiAWt6dCqosHHLtSg0L9XrNyHYewLeFashSmkEk1l86O3AW77tmDaXwaQpl+7Pko5oPBxYtNxIQGupPbtnNx4kJ7fmCoBsI2l6OXS+byZDvQZ/DbEQyQReTUzYIKyUWybWDi2j1KjEAAYsT81tjrr0ysaV6J5OotvTjqGSlfjPipsxZiqjPFL1JplNnMXtwUTIZvRnl88j0fvufXB0VOA73GKKFmiaKslLzWVez+bShmaoinJVgWD5thRI9n8SNapBUuL5iH5aCE02O9LhWcSDk6hq3wql6zUkV22FOjWC9o+egml6lI6HkZ6ZRC4yDYma4fTsNLauklBaXUAgGFR1+SgBg2g+1ofnyarGFgBk8+3iEXIqyYcq1m3mlxrcPABG0RKql6qqXlEmZmZmdDX9tBy8/E9AzHYSm66DqLthJ7Ijp+HIhuC5cArrHBrc5ZVQqYd01jXrPaPFaoZq8eLYKQE9x1NIRFRIZAHKqPPgqcuodMP63n8jFMjhgyvMNkUxWCYl95TVNzU4fBVLig0DyUTE4/HodJz/jYFjvw8ODurAl5uHzFRYSzyYGeiFiZpfW2UTJt59DVVUgswVdcizfpEoL1jtkJMxOGubYfNXkC2gOhquwmTvBfBeF/7x9C0In5lBoz+HqSmUnRzDU2z1ZgHAPAmiWYVaZlbvKl/TTnK9NEBW95gbYccsUkxN2ffz588jk8ksP3rzQqD7YAXB0yfQtGMPpk59REDrYKaSoeYyMNldkNMJ/e2RyeXRJ4XnNYjOUtSpp1D19Tvxt5tewfGS2+E+8jpiwwnP6Rm8lNMwe0U/OKVgf2jo7GQqNF1j9/gpF+UlPWUul8PAwIAuKPOg5wF/ZlNO3bt/5RqMHDtIYhNDddtmBAYHwJutkOJzsHrpeeR4LJ5yZCgXVXI1IqlpKhRBc30Wz4kPktMB/A1OPPbVMN5ywPLOOdwSz6BPWGLxKOOW5ZpSj2t7WVPLNcWGgWF0VPUZ5ZdfHpZ4GWO2O5CYDiBFglPdtgUjH7wNma2uJaLIR2dpDyEfmUF6fBDZwAjiE2OokU/j1kda8He2n0BSTfiS/BzukPejlWpk3yn4ewN4Wlxq2WE0h2fqz3zyaO3mnaLIVpFVtVirNguPNO6y7xxqSEX73ngBzTfugZcm19+8RgcrU+s+76JYueCpVM1NTsPS/Tjed+1DQrXr97hHfdm4sVMv/NXEpdIllyziQM/czOyvZ8527y2padBUWf6/odI0ZgntHC9ol95oa7xJ1C4+X1Y4mRdEjrfYzJMD/aq7oZWfnRjVvKvW51RJWvS6UOBVOWtRrDbtSHqjWuuaUNq1Hnm79pHEXqzFp2CamMUp4l7sfwQYAPG4fw5CIuG+AAAAAElFTkSuQmCC'
 
 
-
 EMOJI_BASE64_PARTY = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjIxMUE2MDI2MzQwQjExRURCNEM2QjE1MzA1QTRFQ0FFIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjIxMUE2MDI3MzQwQjExRURCNEM2QjE1MzA1QTRFQ0FFIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6MjExQTYwMjQzNDBCMTFFREI0QzZCMTUzMDVBNEVDQUUiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6MjExQTYwMjUzNDBCMTFFREI0QzZCMTUzMDVBNEVDQUUiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz5A1idCAAAUNElEQVR42tRaCZgU5Zl+q6qrqu+enu65Z5gDxoERZDiMQpD7jIrGjWPAmATM5bHBmOSJbgxJ9NFEl02yu8Yzqz7RJfFAsxgF5QqCAnKNzODAHMw9zNU93dN3nftV9UwEQcLKZIPFU1PNTPXf//t/7/d+7/dXQ9d1LF26FH/r4AD2erCPPlNYpT/qLU8uZ9ibBVzch4HLcr43XwZ8/tapS1YtK5yOYFe3yDbhvl3hxrcloP9iBsme741ZwISqRYvtXJ4fDt6K8fa8ch3IuciD+MkAq3Jcjm9NG5Mlculb9gPbd217Ixbp6UVndx8OJVqCNkC52AF+IkWn5Xiqnryh6oU7qwqfDSXlY04bj8defffG/Y0frFuyMr+yen5BlriW3fBsfdsth4FD+mctgndMKyqCrhVOKvX9/Koy//1NwXjqD1F5UyRP27vkgVwUlRSg2janco278q2ZYJZ9/P0zAMFxMUdw9Zt1r2XYeNIWCIGYVF/bH5WM39utnAMRFvL6PDjtDiytqPJXTBQ33PvCkdU7ZPWPI++/F5hvp9uXA6/GL0aANb2RFF3qP/57ndWh/ykfaq0LrJWBu9KNK1bk2H6bP+X5Nb+ucW+JK08Z990P9FHevrECqPsvoOGiV9GRI9rKIPGmB6yxNJoOfkmIJFbGhFlZlse/N/XJhYzwQ+O+SiBMl9zVwBcvSop+0qFIuiRrKnjZAnZGH7grArRMtE5JCbnBPKzNtD+SDOzD7UhowwbB+5mogyOHpmmSlmDATg2B/3objUD6KajQOnwI7nCiyOrHU6s/90jXGPc1+4BbdwMvfqYAshyTEm44CW5NIxiPTOA0aPsyIT9bCo8nF8JEFRNusGHGvVNnry/1XrIWOPyZAsj7tJhjOdHSQ6KqMVA350B6vAx6lIWQbUHut4iZsoy8YpH98Tcn/2g153nabzL1M5KDKUkeUkIsuF4XlNdzoB6iFDOqPEeCs6Id7Kwo8AGtW0KF/aQbt/iu/IYl9n5FvFhNynHt6KbW6AM9QPCiBRgeTMX61uUiJ1YINUHIdAZwKOC/0gFuXh+pEIEr1aG8x6JvO4t8qwdLtEuvGrsyiXHj3Ituuv3doY3B1CN0FwOTA4Y8QftUnk+kd5cJVtSnkqMGMJ6QI/EmCxgvT1OUwE4YgqW6k64RmipNmyfQPIfARjuUAcoBUUfUHYcvz4HDdUGUV1ju/K5guZFNy5NK0U8lZD3WH9eHBgaV5r5+ua4jgToqwvVkEAZP+/CxBOZu3014ZagFk2jlZtsX44XwOgLYNmoANegxLT9GKjoAYVof2Cqqg6KWBmela4SD8kwZ1KMpiOIQ6mLdyFspI7PAjS1bWvDztXmZFg+fCW3EOZgwoac0BEMq+gZk9PQp2HswfGJ3bWzPsU48f1LFloTx0R5OIlAPYLqtyIzeW9E7sCnSNqoUpWHj/KpWYOEg2CTNTGXSZCOQWr0L8h+KwDV74XAFsLv3GITlIUyfnYft/1OPcZcosNgMGkhnDMrwDHy5dBYKmGBhMG/e2LIjR4rK6o7tuXnDpqGdtW3KT5tC6k59W+wJiroXJ5WX8OvAfsj66OYgZVm/ylHGWGhghs4EB63VAXW3H+yBLIgpAd3xAN4JHsSYlUOYuciLnX9uhZTHomJZMQbjGvVYHP3TSMJ1U5+MHxaDrUkOsiogHvViy7Y1mDX5daxctR+zqrxz1r8cfPvVndLPPryr56HY30tk3HR/AVA9uN1JOlgKtFmgd9qhdVqhRHV0J/vxYaQZQ+WdmPc1B443WvGVtydhz/jvg/tcFXQKnM7hFIBEeDP8NLBFhSdowfxXKMS9mWjK5vF0eQ5siWo4K5JQv58QrFcceGjKYw869wSVH6t/D4BVdm7V2vsuWdOyO4DuNxth1xzQLBokRxRSdgT2KRLGL7ShoCIPe1+M4mbubvTcsiJNYekjOp71MELpI19nbPSUANuup4VwTKKaOvweF51fugYTFPu/TPjNPTV1Sf3lUQdYmi3OnbowC1O/yCISSiESIAUVOWobgZbaBLLG2DHQlkDNpl70Vc7AD2YE4FB/CUbTTUoLNFsWp+eMBJ7IyRIGHTLPg/uqgEEnj+kWAYosIMbbEJCtGIjRGXGCWTAPOTvGPdiyr/EtourQqAKsa0/88ts37ndUlNmuu3p1AdqOqnB4OcR7hhDti+CDbRI4qh4FxSLGdGwj0XmdJkk5N8wnWdHToqnq5M8ZMBQZp7FdN/yaJ6HhSB3HksiI9FoUGGRnCyirJKYkNRxtkcA4ndg9OVHeVIPrGlN4/vwAKue34XBQ02t72hJPLJjvu05NzkXVovGId+3AjgNvYutBBSHJSnFgIb2vmlewlKsMk84zZpibzCkc1fW/8pMxXpunZl4ZuhpbmhY1hs9PSuL2b+RCs/JgaLUqx1kwMY9f0dUmPx/Xz635aYC5llOLKRloJpOKZ/Ase6O4JAs3LV5+CfKWLDN6Jxxs6MJLWxOQCirB5meaAJhzpNr5HGosCk0mE8ELlOMWbK1tBPdcL1auzEYiySDDa0FpkTCNaZXz6fbukffl5k+C0+UrMgIXDvW2SKnIMMDbfBMwMWMO2Q4VM+xLsSX6IO7vPwOglVhUWcROySqkMaJGPTuO1146hIS7AHxmFs1MBi5094kWiOUtUEJBojK1YQ4XhOISHDpah9mdKeTkCiYJSkvF7Pz3Y+OJpibAqmkrvKtvW3+vaMXN5PUz+ntj72d5W7+T7iY8bAVmi49jsfMpvBN7Dw8PHDq7i0FBfq5QYPFmE/0Y9B87iPrmFDgvyZ+mYlQOg56CSOx2pekdj5oUH9Kp7DTEzd7aOHKyeNg5XDrytsFga+rRf1v4xLbNz62IRVP7MzIdcwb6G9l0BOtTtWhL3YmtsZ3YFqv7JHdgbPQWF4p+8NQA6SE0HjmC3hhNptBxSj4NB4IAM6pCdY+Hzp5/V8YaLDCsm9UKLRoxF05LJsE4PGhq7sWcOemJeDwcHA6uAvH0wra17DH2tk401G87UV/35+srLr1mdjy0oT79yY8Hm/GD0G+xOVp3LuuTz8Pn94nEcBKPeAvqj3ZAE6n8cxacyk1OSkK2exApmgCVpwVQpL/NTBIVVk4hkZmPWN44aqw5U12NYXXKR91qR19ARTSqmgnusBsA2eKzjVVbsyH0yn+v2qjQeOkICucnCQ4Wfo+HRIihdRk6iubWJClb9mldMycl0DttGVqWr4GUkQVHZwMq/nA/HF3HoPHWs4PTNDMBWr5wB07OqaZFscFXuxNlT94NNtBDQSR542wIhzmEQgrcLnJCVEb8NsZtN8zxJ8SEZbn/W0dP03DabBRBdQhKXyMCIUN5Ppq0EYGey69B0z/9CMLQADJrd5mr3filHyGVkWtS9mw5Z4TpxPK70DPrBjjaj8P74XuIFY5Da/U9JjsYVTXzMSZxiEQUeknyzzGw86zI6aPb8Iq8QBFMtiIWHkA8xZEg8Ok6RlGQ3H4odjcue/x2OLobiZop6ORIwqVV5t+ESOAs0VNNStr6OzBl3S2wBrvMsRSbC4NjJtLC5EAMdg/vyVoQjah/tXzDdn9UAUoKuRBEP4QkaUgpVPNsXDpPSEi4VBz5u182J60RMFVMi4/nxGFzcjp75taMThGyDXTA2XUcDL02xEUx8pFsnb9uF6RwKP1e8zM4pFL6qV2WzowmQBK4UCpBYiX10weOuEr9tGgYE9Y5y2l1zQB7ToExqCvaEImF0XsiAiZO97PUOzrJ3/K0cAx7Rv+o0UInFV022tFz1d6/CZDcgUjuoJJW0OpLBZzhUBcN6DR9o2AxFI5KgVESzEmcX5U3AKUXgzOjw1D0E8koWo8m4JXmYtYUckpeFjv3vYMW7MEYv51AMqaN4wmw8VIjezmQ1GPxC8lBcgd2cgd3kTtYRXk+LhCQYnH1u0DqLZJpKrSiDi1BBjiVIqrazgMfmW2GQyKnBLLDC1ugk8QoQM6FR5TsGZ8qx9jCChxnNpMC5+Kma6rxzIYIgvEjyCUzYSyM02kzASbIfKeSWvcF7YuSO0iSO/jVwz+fN2//3jfvs9oEYaC3TzYSQqA2wOvmTD+qEW11RTndSJ8rgsMi0nL1bdTz2Wk4CVY7NVNcJ0LhIbDJDLy1Ywf4IhlFjlKkSD2Ngm/jVbjcFtPnRqIawhG15YLaJXIHRoEytuQ6O1r3Pbhw9ncPTVbf/i2WF5YSZzC2RMTuEwloNurqw4PgfFnp5xQjrkbHx2jLmAXdUNhEQTkS/QmcrO2BTvTgDLoKfQiK72Gs9TLMn5GJSLuOBNVVowBD1ZBhU5CRYTGe+dBCKFAVvQGjJTKynMDb2x7elHWp0BkPaaX2LBaXVVJubA5TqciDPBiEHugHa6emlDObPLNendEmEUDZ6UbXjJux9Lka8JZb4fTaMBhnoeUdQYPaDC7uRbguB8+370cfsw95BTRmIoa8HA5uYo1GCHt7ZfVkCk2j2vAaFehYl3KAWHpVqd+Cygo7Cjz9aCP7bhhkPRaDmkiYRtxwO8yIB2WGGyjDSIsCBKJlRuNOHJiYCdueF+FRCjBE8m/l42jsr8dJIo0MqplCN3K8VGY8pUB7Ayrn2k2CGA10W7vUHtPQPOrPJvqj2o6jDeYuJTzk6GdOtUHr7wWXkUGuxpYGY1gvw2gTcPOUyEtKqfRJ/zfMgP/D3eidPhZyRRJhfStU2zuIsAdQnBODL6eG2pZuXFLkQFZBMdQ4/U6MY/x4u8n+8KCChpNSbYqYOuoAexTs23sg1muY8o5OCZdf6cEYRwhsezOsIgeL2w3G6SGwduJHupPQmY9aYJ1yKWzzI+AvQ9a+zcigeuYhY+61ueFzZ8Dn9cOXVYDM7AJYicocOSaxpxnz5rjN/DOGamtLoXdA2TjSoGXb8kdvX5T6gr5dRxKb21tTX9PIpIvkZO78Ti7e3BLEwSPHwerkRCwkOiKd1ElAIFkfpqxBXSMCrvajcLfVmq2RYeV0l9uMuiE2kJNgY0ky7THwegJ+6sxuWOVHRYUNhlAb6X2oJjZwUsImYz6LCq/1PD33iVULXp//m+bw8QsHaKxaV1j91YuvBb68elW2OBBSke3jMfFKF2olGVfTRHTq0VraBhAYJJ9JGhwjz5qUGHM/FKfuzxg5SSOKnEY1VYOT6qrHx5CYCCguFrGtmToHL49JE+2IJzTYbCw+qIlh/9HE09Q5dXtFH9bNfPyn+fb87z039+WCxz781W/+1PJSV0KJf3qAxtEi48jvtwytzc0VHr58pst8NKQbO2UWBuXlNhT7qaYZVoqEIxpTEaczldKQpOIs0dXYVTOiarghq5WFKLI0ebOBNXo8U6M4+rF3gHKWFFOhdDDAGdTcsHFwf31U/8XIo413T27f4ROrr5qRO+muWfnPztzeecdjX99x4/qOaKv+qQEagzcl8chjfww4r+uXf7JgfgYKqBEWCODAkIp8j05GXDcVL8NjQaaRO+w5dynM05B/mcAYAGOKhmhCxdQyu7kQhylyr2wc3LO9Vb4ppCNiGpFUALfv+urr/1n3r5v8Vl8ZDSHF5HjHCLhPDdA4kjTEviF9beCN8OG6hsRPqq92TSn1CjjcEcekYqsZFWPC5sQNAMbWpH6mm0uzNb0vakTNQjMyFqq2OU61XYeTqP3c7/sHdx2OPVkf0X9B4M7Y7K0frDUazYZREZmP77Y3Snhtjl9qzxQCv9u73dKQ62eueCMRKi7JE+FyseRZWQgCSxNnTM02ehBmuIvTqCMxwZOyyhKFJWZsSWgIEQv21UXDoV7l2FO7ghtPhLU/Bqgn/jQbdhcE0DiunQ7+0Xtw3/4ahN7rU27yBpC163ioPE9AOS+w4yinCiiaLqog9kwrO123O7NHtsaYZEJJJVN7ghKCZLsiVGb6QoNyfcuA2hqmakBS0fj//gj71OP718G37tt4ETwWELseMvNCNb8/2k828z3jqzKOsGbkbJHBvEoX+zu20JetGv0hcdLa35bq6JUe7NXQRNEJfGGxW16zrvTaBx5p/ktjU1y5cpJLPHQwrBNo6R8C8LntGFo4FVsXTQf3Hy/h17b0U3MjnRzFdlyWIbJfzPb75vEZ/lKGF0QST+7UjoNxlDgyS9k3ZFnR4v2DgYnZbN/i5TmXLV6e+0DPiVinwDMHr136/k8PEsDUPwJgIAL5Sw/il1+uRMTLeV67e6HmlmRNHxpS3INKZqljwgxYPD5wvPBR1uqnK4yqqVxoMMQlPEO5/U419y9vJFDkio7raIqMe/fPPSUzffqc8kqxZ/eJ1JrmJE6cNoEpn7PjtjWXY/0zVLhqahAMxEc9B1kJZZOvWPDQP/+wyo3gu1DCATS1J/Hv6znIGfmEQaY6KZ/WPY0EkdWNksCQPcuAjUx4c3sI994TwMrJTbj+C17MvTO7BA6uhJiMNfd1JDobperTIulyleCbK/+CG6sbMffKaQTwwr3oxx/GXJ5vv7X6hhI3ejaTCw7CInBmXdAYMV0xh3tDRSXFVNNPmlS6Gk94E5yQfopkNLPUUxYV5CIjy4O4wiEvi0/b16iKrDEils11X0MpMOFjUwia/erb29/HBwcjo2K2T/vWE+CdW2W/Ocd5IP1tFzZdCgYCCqKa+6/PEWTV2DFO4s7r6/HDG48gPzuBzc7L8WruIuz2Tk4/XtNV6g1JajMy0d7HQJLUjx5RyRrmft5lq8rivnbavtwHB3twpOUFjB1TCGPLZLQBljmYBcvmiX5oqSBZlYCi6NF4jFG7B3RVEbxDHEvyrzHBTFdq6JvLGpRLSwblkpyo9J1l9cql2QOJmC5IR51jlRpXeZLTtaCu60HRbg9HJavW3kfdfBIKEWCQOpdgUak4uORKxzLrqd9eDFO3dPcdd2Fs4VasWJV3tjn+rwADAJLTB06jQFIqAAAAAElFTkSuQmCC'
 
 EMOJI_BASE64_RAINEDON = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjcyRjZCQzYyMzQwQzExRUQ5MjA3RUZFMzQ4MkFCQjI2IiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjcyRjZCQzYzMzQwQzExRUQ5MjA3RUZFMzQ4MkFCQjI2Ij4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6NzJGNkJDNjAzNDBDMTFFRDkyMDdFRkUzNDgyQUJCMjYiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NzJGNkJDNjEzNDBDMTFFRDkyMDdFRkUzNDgyQUJCMjYiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz5YPJNEAAAa/0lEQVR42rR6eZxU1Zn2c6tu7dVV1Xs3DXQ3eyP7lqAoMRMlEMCIEog6I+qXSYxOInHPZLKY+UMxQ2YSJYmfUcPEBRVRISBIRIyCCyLI0s3SNN3Qe1dX177Xnee9VU2aphr5vt9v7u93urpu3Xvuec/7vM/7vOdc4H//GM72L2yvsL3HtoXtx2yThrrh7bffVjRNc7JV7d27V8l3jc1mw+HDh+U6O9uX2Ub84Q9/+N+zYuHChdi2bZuyePHi/lMGtrtLS0uPLliwQLvzzju1H/7wh9pdd92lXX/99dqIESNa+PsvZayD+/F6vSYOeCSb+7vf/e4Fz7Lb7Xj55ZfFOCvbNLYZsVhMnT59+qUN1uFwYNq0aZds3JIlS8AHGPgg2/79+8UwI9v/veaaa7Tf//732ksvvaS9+OKL59qGDRu05557TluxYoVmNBq38lqr9GOxWNDQ0CD9DGOr4f+6MYOPVatWgb9b2KazfSUcDltkDPkOw+AT8pBXXnlF2bdvn3opRo4fP16uN/A+pxj2xBNPZPh537XXXvt/brvtNjidTgSDQXR3d6O9vR2tra1oa2tDNBrF0qVLccMNNyzk9b/yeDzSj/Tn4veSSCTScf/994OfF0zmk08+aZJH5+C/j6iIb968+YKxTZ48GWo+4wgTgY1SVlaWuphxcv3jjz+u8NMjxh07dqybHqqpqqp66Fvf+hbS6TR6e3t14xKJBBTl/HAymUyYOHEi+Jy7Lrvssi0c/Fs8PZKthxCMDR60GMfxqXzeGH6tY/srrwnx2rxje+yxx4zqIOOkE4fAnDd6P/7444saJ5PB6938qh48eND/wAMPTKFn1tA4j0Dr9OnTEk/69YONkyOVSsFsNmP27Nk4ceLEgzt37kxwcvqqq6vbOHH5jDPyuTIBs9l2c4w9y5cvRzwezzc2gzhKf6o85NVXX1VyxpURFm0zZsyI0SNfZJyTBlWRQL66ZcuWW91u93SeM02ZMgWnTp3SoWkwGIacpEwmA1VV9f4YEmhsbNTo9aM89xz//y0viQ8ybhi/Xsu2h8bVX8Q4GVshv9YoBQUFYMAry5YtE1iOYutg7PTw3BcZ56Bxo/l5D2NqlcQbmVGPmaNHj+qfJJAhjRP4FhUVYdiwYTqpySSTMNDZ2Ynt27eD3tzKa5YTCREhLsZmGW9bxHaUE//h1KlTLzBOUENC0yeeX+ewtauffPKJwpvN/CK4Dovb82F6UAfCerX33nvv4qamplW/+MUvdGP8fj/q6+t1AhHPCQSH8lxJSQnGjBmje1C+J5NJ/TfGI+644w6QdBaRbX/K3PYQxycxfg1bC436SMhnsHFykHz6xzZTvM9x1Ku8Wc0ZZ+JNp/MxV/8hxMEOZDIm0RAjPbnknnvu0Y1hmpA40o3sH3S+Q7wk5MI40+8TZpU4lcmQCRQDhVHJwtixY8fttbW1T+cIxc9x7Vq5cqWWjzEFxhyfsOtUyXS89u0bb7xRU3N0W8oTH/Lm9FBxN4CeJ4ozCcsADZksA5XBdXV16fAST/Z7YyhoivfEmCNHjuDs2bPn/d7S0oKamhqdXceOHVtKhNxyxRVX7BFSYTpID2VcLkbH58LsL7w2QeGh50EJxiM8Ec1384AODByU3DyW7SOSiJOzbe+Ps56eHt3QL2pioCCEMgvNzc26Rwc2mRyZZGFgMioOHDggeXEXxxYfKh0I4/JzRC7u3ue1/v5rxYOf0dLIUHGX60AS+fBcB++yg9gPfvADTdhyIOXL4C/lEG8LhGVy8t0jhgpRkUkFwvUvvPBC8vbbbx+SMRlmJfz6D2yfcmwtA9lVXbduXfi+++7ThBiGYsxcB1ez7WcHZ3IddHCgIQ7QKTnO5XLps/7/clxsQmSAMhEdHR0nPvzww6EIDznGlNTRynsODCYgg4jffMZJB7l0UMCvX2M7wxsP9XfAPHkqEAjsFagJxffTvZDNpUD1Yk082NfXB5/P1ygIuwjhWfjvPEnlQkAy8YM5ZMgsnOvAlnN9gh2819+BxCRVToYw/Y9nnnkmJSwoOW3WrFmwWq36BPz/GNbvUbmfsSefjwp7DkF4EvyTcwz7F4ZYXj2at9YSkf3BBx+Y6MW5/Dqa7VUm8qAkfxHXlGUSk24SQogy62ZCad2tt95qE+YTzblr1y6Z/fNUTD+JCJzzybZ+yBIVOH78uOjXNTz1kNw6GFm5xC+ksoJtGw07xAxwQXoToZ/3kBzEwTjYvsZW9uabb+rxKI3/Sx1WyFbBvKcUFxfLLTIRb4wcObKdoln0ZJiyLVhYWBiiR0PMe0F+BhinKX4m+Rnjb/0tzhaWa6mqumj8bvZ141DIevbZZ2VsLrbvsS1iSAhH5L2WtWT+mZREu3XrViNhY5IOBxknndeEozFl4d+L2/6jMJdXq3OlzPCl31w+fNfuPaN2/+2jG/Z+fPDu3e9/UjeublqtKKFcG5WrIMQjZV9Ud7L2M/P5S9luu1gdmLtWVS5W9DLR6rGQmzmFhaaomOJENNxx24rlRa9v3jZ6kscwTDOqtUgm4pEU9rVE0VGmYJjdiLEOJ0YsWTKvtG5yXaXD5RoV6m2PxyIB7549e1PdXd54NIbevgC6icq2UAKNHWk0u8ywD7dQjahqlUFBRyiWOn0mgrZpM6ee2L1PH0tdTrY9z5DxigbOR5CEsZGeLVAusWJXXt24UQv1dl/24m/WfK3+0KGrTzc2TnWXV9QoBiNUhwuqzYEIa79x5k/DX/96maPA5YbLEYPF5IeVDzRqfijxTgpRST/ZwIonyCCBbIuQ2fd/hvDO41NMBdVjzZlUAqmgH2l+JiPRPpuKIzPnzd+9cMUtnWOnzX5985a/tKxc8a28slJQR2eIfh2jXIJxLKU2oru5ceqah1ev74imp1gK3LA6XTCoZqTjUWSSCb0Funuw9HITbv3hNMBLdo800RKLbhRizWSRyPm0puR4XPiQl52kg3787AzYKqphNJmhULOqVrswFFJ8jo63QE9gRt24Ves2v7vp80Of5x0v86MQpNSMfnUgc0oNJyw2WAaZTcbC9b/51a/6zO4pReXFWYPIeImgT2dEYUcQT2Z3KZrq/wY07AREjkqhbyqiq6g36YksnQ6mTmSv5Xlvu8yHh8aZdKO0dArJkJ8TSUMtRIHKmSgodL311vanOg4f+1Ska74VBhonzO8IhUL7VKkH165dqxDLxtdffz0tCnygUiCO7Z9/sGvp0VOnr3bUTEAmlcxOfSYNo9Rwiaz39CWIaACHjdW4RXuUsPTAbnIhmErDhxhiqum8rGTWEnRcmnYpMNFCk5H/R7ZCjR7mZLj08wZeYTAzFRsN0Pi8dIYpRkuhfMqXSka3td3R1RH82WBlk1NdUhDsff755xNSD8pJUQQmFpmhAbVV//LFqLc3vXJZ2uaSxyAjHtOXIAy6scFkhl5PMlGn4XcOw+HLb0bUtgAuQi/NC8OpIbJtf4rUBnzOXIiJTf+GMt8ZWBIR2NxOFJoyMCtGaJJTJY/yQgPDo3hY1QJ7R8PPIhcKE9HLZyhI2n/0ox9B6kFZl3PyRO/69eu1AbWVMOaE1sZG/2ef1U9pSapQ7G447Ba93otRbbT1+ODv7kX18BRii5YhM34mLnd5UJJ+F4VqGrFUFBFjQp8MFSkYM3EYRGDTMynYiOoMJ0FDXDEjqZkQr7YhuXolLC3HULJ7Ezo+OY1AQRkqSj3UuhYxDVEipqejF6G0ta7QiEmRNA6PYx7MKZspOdl2sL+ulRj08J8AT6TkRG4ZUFbKRrU3N1t/ftP8e0utrV9xak607Hei1V6D0toaasVe+HojWDquETcvCUI1HIJyKk6mpHOIxkRKQSygwenmZ1SDqDCzzYigLw0za26LzUJ2jEPCTQ6puqTRTmRsJihfc6Ch0oDHtyhoolaurGSZ5fMj2noCIwu6MaEs6aqbhM3bWjxL1qx5/DAhWsVuLmPbStmW6JdtYqB/06ZNei0oOM7VVrK4U9HW3BocV9b6zfsfIcf1htDUEsJLmzvw1v4WJEtqMdneiHhrN376U5JblF7JmGgYI8dsx7ips9HZfBpjpk5HV1srJVwSs666Gj3trUjS+w2HDqDzzFndKIGe0chKX29CFgYU2NOoqQxhbkk99njr0HqkG5c5jmPVPyYxmzW7tRw4+C5qCt6bcc11S5ccYS9XSl1LJHawgDgXCSpLkej3vve9zIC4kwJTVnw/fOflP80aPsFi64s74TCFUDsmjn+8AXAVtOHg8SAM/iB2dTKmK0fA4OHICEWFbCqassfhRvU/LMCx5haMnX05JoyfgCYarIyshSGZgvdMG1RnoR6eGnNphkbGKLjjjGvqOYSNJrL6GVQrp3HVpM/hNSSxarmG6ROyi/19UQ/U8jRKyoxfzi0jZojA/YOXXFQmxAzpdGDcSZB21R+t97720vqJkbUv4KeG6bAZwqjJnMb1he9gzrXbceDTo2jossE4jspMllclVWTpB6oxhbaTx9DA5yTUAhhPHMcYqqLDhw7pIjwtJRGvC4ybA0f7SVj6OpG2MCZVG8xRYjkSQjydgVI+jAVvGOkD3fj2LTb4xi7DvxivxkfKVPg0DzIjU/iGZ93MZMA3zeQqfIPQTA6uKFQpf2TDIxd3U/uD9L5770WkQJ18dvhV6E2X6Bc3WSfxjvnYkFwK1XwzFCcNIv0riRiUTIoUzu9aBglXKbrmsSguKMXId55DezSMTa+9pudLqeKlNDLweouvHU0Lv4+ihj0orv8ADoMGi5uppfUskow7jUaqnlJ4G7rxa9NDcDruRLu9FJ/lylczOT7sqaqMB3wnYS/oHLxYrBsoefCxxx6TuBuVE79vv7Th5cTWt7Zh3pWzx/Q6S7KJmEeIk7v9bBcsURvmsnfNadANihUPR9xThkRBMfyjZ8I3bjZiI4ah9G/bYQqxbHK4zpVMUk6dy4X8LVAzGZ3zFqO05QRGnDkIS/MRhLWPoJ45BlMsgrS9CDby/P5YKXzNXijDXLrWYzSggmTV7XCZWptPBX+8+kF9meMCA3N5sCiH40/oYt/dd98FduMos0ZKViqvoifjQReFfrtSi26jC9ZMJyQtZWQKMyTvVBzeiVehdSHLMxm/Ls2AYPUUpOkBp0GUjkFfL9VVjwA5nUSkfBSiZdUwMVcqo8bizOix8CVvRLVvNQqbDut9p5lMMxYrHIjCpxRIJsYENGKS6keNEkDafMy0+rZ/L952oi2v1JQ8KMnx8lxybBywYFMy33Ok5Aep5VQWHLfiwBnjBLyp1eG16FQ+hsRgsuiJ19ZzBqWf70TrV1dkpVcmSwTWQDecVB5Gkw0RGnfeQjCTt5m/myMBOIpdsPCnbk6aoceL0qaDUHhthnAWpZSyuVCVasbXtf/EHel3MJGGuah/EOvEsUwvlp7US60ht8/EOJVxt2/Qgk1JaSmKs4MxwEwiGY3j+Cftz/iJ934Y/T5kVHN2Rc3iQEHLEQzf+TwNTuu7fdaODkx454+wm5k6kskLVsQyjF1rbxsm7fojPMko/OwqFQiiduuTNLqPmtSahTX1aMzkxrd71uFfM7/Cl7GfKonwSLPFw5BNu0KPXk/m96BINNFtg9c0bExFJUUyASRyA3shNJHpgxBwgmOVUNJXHrK6TWfP2q1PoOTzvyJld8HT04JSjV4zmhGlYO6H5nnbZ44CjKl/F6HOk2g1WGHqOgt7ZxMhyaAzBPrX+Zn8WbWw2BRuSXDI5hQVZVoURRyufgN9GHJ/8ONt27b5ByZHOYapKHYLN/DBMLEqyJBpMlE9G8ST8iDzeRJTk6jnGVfzYb36cRYWUdqxRmR1km95UOSe2+3WS6JU0xG4maok6wvsdWgJPBXJjxnhMYTj2cnUCHmk/Nm0xAHYrDrnlOYrekmeBkMwGAw8+OCD6QsKRwUlDgftV116vCDlE7zIhEJCKa2puGDtSIQ4dZilsJjQKdATbr5NElmMEvaWFTjZYoumMvSa7Rzk5Xej5FaKBt0onpPhkXOQ3fLIoYH/y3yU2lBgvXBVUDZyHers2bNT+fYjOMEeW3Ed/T+dvRMuRjJY6AhLljRkzNoQK2NSk8lqlsRdNBwiii5cc3UWEMJWM7v1MaeHzsFX37BRlGwNLBqOg4hT9ciTIuyGaVFvsJJTrGN0Q1WGjct6wGHI8kmmv7alKhMo1Kr5jFt2w3JMNAcKtEwjc2Af8XGCbvPqUONkI874VoibTCzGes103pa0rHDLEfV2IWm0wj/pS+gbPYPpoFYnIzspuZqRHGKMRg59BLP/AIwkCwPjUVFMuGzSJCTZb2/TSerWdsSSad3AWCTrvaQQcTpIi48Tn0zbmbNgiJr4szmbnLJbcISoORtpeVbU1lARvP/f/8U6gLnIu523xXW8S+cs+8Dnw5hOUG2ESbAOKGTEfthZaHCgqwNnJ30VTYvuRKyqCgoVginUC5W5z8bnRhgf9RPnIXDlTbCfOY2q7U9j3KkPsWjpdSgpr4CZnvt45w6camiAaneyzEpCamp5vsS/Pun0HGKtejpiBjI+89snVXORB3eTS2TJn6ERI5revcDAOXPmYHRtNXZl4EzHe4mCxLm1k2TOuOMns1OquIqR9vthKi2Dg7AUaEZZRjVcvhIt81egqH4vRm/6NWzeMzCFBUpmFJeUwJ/SyIRGBCrHoWfq1Tj17YcR2/9XlOx7TVc6stjU03RKnzQhIVM8QA0LdHYC5UW5AloZuKGK1KyZs9XJc2er6//0p9SOHTtk3z8ha7Zqvp0fqc67WzubIkXR8zqSlS8vHzR8ONDQFGEiVpAMRCiponBXVpK5Y2jzjEDMUYhpv/kuKf9UlngMKmtEExwuO5LhIGJeLxzRCJxNn6Ny70Z6eSxCnJAjxeNg2/UKwj1dMJJgxECD2YxMTxCVI7NACkV0dZgdlnAQh+jwuLXCsnLj8RMn0/0vThyisO/Pg+cdsg668uabUNx19kSw9vyZCrLzQjfwjW+wXOlL4N3mKMyEpYtFXMbn1fcINTSj+uD7vC2DpCnHbQrFNT0TYAxLJUH0ZImFtCix7D51CBWtxyjFLEhQQJiEYITEJFWQVUodISy/ESgqzkJUWFwvlImqPi8nvG5OaPjokX233367Jps2gxP9BcfGl1+WXHZs3lik5xlw7k2C4gJWx5JjCdVvLAKa13cgUPRlsDiHl8olws4V4iUtg9NZNnLB4ll/SdW/EGNhqjA7PIjKhk1f18BNQtKtG2qgC4sXpFHGAjccprzy6AVMthvViM5ejaVV6ccnT51Kb9iw4YvfdOqn+l/+7OeHPj3q2B/14RwBFxVaUFVOHtSc8BQCyxcrKDMlECP7hTX6jHSmkSB0qT/koQxIRSY9ZchcRJno9ImR8stBYikuITmFcOW4DsyalU0TThLKyPL+HviXGnfPPmN68hWLN61duzbvIrB6kTcpkv8Z6P7dju1Pzr5upSxDs3LwXInK0kKED+2EnxCdMqsS7d42vLG5h4LawmRNqmcqkBFnsttF2ezc7znt74toBsaYg0rG6nIjwGQvFYNKkaARf8ZoEEYK+CpPCIsWQE9NKuesplJPjdlsx9jsbjfh2Nmav44bVvXBf69ff2nvquWW3yR4CkbOufLPz76KPYG+CqbM1XQtI92/FyOLWAF4KsmqFsyZ6UVlsQ8V9g5MtJxAkf84TB1NULvboAb79ESvpJKMtezbTgY2RhbsFjNcREqql/nyTCOMHc1w+1j54xjGF52FxRjCdUsBNyEpS7HiOf29vEy2EgEn86VX4qkF//STR158bWM6xEkaSmyf92IdFYCcK6S7fQ8/8kgycBb3Pf9SavedD+83wU9WDJ+G2V6GEWYPGpt7YFX7sHghsO+ggpXLNPR0p0jpKRJOBL7e7L6DxI6Ic12FaCKvKHQrKpk3GdDJNjjGx1m68KGEPckYn7CvEa0aJtZloVnO88WeXCBnN/6w70MNQfOidVGn64P1zz6Li1UT56ApJT8/deHK6iJ6vP6ouHjv+o09j84Yv/XfvvQVkStUKmopHGoIJfZutHZlUDeehHNawyf7gPlXsdKuzLe5mW0SnxZHESz2AgqFLqaWv1f4Rj6skzxzol7D9d/MMmaB04IRJfGcCBNoWhDodeC17c6jN//soV/c9J3vIBQKDmngOYZ86qmnsGLFCtFZlfRe66pVq1LylqDETDCJD1obMH/+XHN1QcWw7JJ1vA1Oa0xPHVE+fyTR+/4eUUL6BENelek3Spou/nUOKYBqraAyCSMR7mbayGRDNacz/7IVmDmTg6jQdwcwZuwkmD01xClhoFFlWErxu6fT8ctXrF25fsuWhi1vvH7RzSM9BmUfkLEnxrIn9MmrjAPXN/waEpOX3XP7038ubEvGZCSd+k6RkOXw0uzgyfa48gpg93v8iXmKISY8cF4zUcZZC0pEO1J+eWFSU9nfSPt2MuSevVmYThifTeplbjnP59mI1eKvs2yYize3cBIn3PmTmpkz33vuj09/4dafvuj06KOPIrcybJEXUfOtTvmgNc77yv13PrXuoY13fT+j6lzNZztJmkXMj17GWi2FwVnKw98/bcTIEQppPUUjaLw5m7tsLpZIBXZWEe3MmSG9cBYYhmIKOrpVWE1JrFiejVcxulzWEwJUJNE2uvIuHP7YjVOh8a/888MP/frmW25COBT6YgMfeOABLFu2zJ572eAIvZfKtzr1p+eexazf/PbNHQdrH6jYcGLtDTf9PY+LPvSFsmJ4ykTgo4YROKpcDiVMOSdvUCSy74WWV5Qh05WGt6uT5xJQmBZixHIf9VfE24fvf/UQbPQkb0OlJ+t1PfaMPpze/QR2vD//8+888syPXn9jU/r1TZsu6V0c2XM35l5gM7B02j9jxozMUC/jIfdy9VXFeOLnD+CuuVdJXZQFenN71sjebuDPO+ugTrgWBi3JuDLo8Ksk3lLwwO/tQHc8jYjRhqJkkLdmqHGTaG+ox/K69zH3iqzWHM+YFu/LrqfXa8ELb18RvO6ePy4bVjt859QpU/IuEQ7FovKuham3t/fo6tWrL2occgXXR71Y/egTsDxWiLkT6hDPJGTF3lQYT5uV7r6MIa6WBEyZZFxEe0Vh2HbdlT5bWblb2bO/J7mxvTC5xzXFGjXZtVHhs5gROBaym9Vk6bAqY1vAVdEdzBjdtkwmnY72mMxaLBw0WF57Z2JywT//9nee8qLdj69Zc8nGyfE/AgwA733D7RlNHd4AAAAASUVORK5CYII='
@@ -24321,7 +31163,7 @@ EMOJI_BASE64_WAVE = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2
 EMOJI_BASE64_DEPRESSED = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA+tpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxOSAoV2luZG93cykiIHhtcDpDcmVhdGVEYXRlPSIyMDIyLTA5LTIyVDA4OjEwOjQzKzA3OjAwIiB4bXA6TW9kaWZ5RGF0ZT0iMjAyMi0wOS0yMlQwODo1Njo0NiswNzowMCIgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyMi0wOS0yMlQwODo1Njo0NiswNzowMCIgZGM6Zm9ybWF0PSJpbWFnZS9wbmciIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6RDBCRDY1RDgzQTE5MTFFREEzQUVCMkM5Q0FGMjBGQkQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6RDBCRDY1RDkzQTE5MTFFREEzQUVCMkM5Q0FGMjBGQkQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpEMEJENjVENjNBMTkxMUVEQTNBRUIyQzlDQUYyMEZCRCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpEMEJENjVENzNBMTkxMUVEQTNBRUIyQzlDQUYyMEZCRCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PhwYyz0AABRRSURBVHjavFoLkFxVmf7uvf3unp7pmel5D8kkmSSTTB6EJEggQghEHrIoUUHAcq1lQcracq0SdFdrpSxdddfdVVylZFeWstR1WVFQnop5QCBgzIMMCckkmcwk8+h59fT7efve/c653fNIJtAThr1VZ/r2nb7nnu/8///933/OVUzTxLnHrl27MDo6inIP0UPh/G5gGLxeAOwKELTzd6b1W5XfszwZz/NcZdMA5Zx7xXdNwZyOa665BsFgcGY/swHcsmWLBDmXwwNUEs+CRg2tHhWLDBPNbg9qKnwIeJ3wVTuhEYgYs0LgeiYPYyyDdDKFcCKJCQ4jRKw9gzn0ZYCzHNVwZm74sHPnTgly+mHDRR5ejsZtor3ehuvqA7hx9QJ01NWjbfUav9bQXAsn0XntEfgcITjsOhT+XtMs0wirmmy6DiSTAAEil6NFI8DR48CZs+jvC+HU22fx0lAOz6cV7E+ZFzfOOQP0cpCNCq5udeNzG1bjQzfeVOFv71yI5mWrAX+b9aNsCEgd4+jDPDcsvzRn8UEeNarw2anLW28Q/o6WsWG09Pbi6h0v46Gde/HaiTB+HDLwRNJA/n0BKOKmVkVrhxv/uHkj7vro7W3K2s1XQa1bx8HWAvE+YGQvzfFnghq2ACk4P7jKPGoZSrVNwPqN0D5+Cpt/9TQ2/+EV3H8mji+dyOFVw5xHgALcKhu2rW3CY395X7D5mk/cAlRfRh9zAtHD9K0fEdgJsso0UEVgBWg8NSfPTX6zQS+Sk0LjGZP/n3HoxcajbSnwwP3A2hW48tmn8QfPMfzdIR3fN+cDoGCF1Rpurr1s+RObv3anp+ED1+KgXofRtIEXxuLojQTIiFuQ07zI2xwSRB52OXiDw7cAWnBmArRgCYAa/yO+iU877xafDuQY42mSVwqefApeVwrYHEOmM+Gu+9WB76175iXfwSy+abxXgPXAytq17T+t+cGLntzSS/AKqS1EQvjRID8Fzanr8b4d57p3BVuAg35QxxX42DfWPf306QMF/OKd3PUdAfo42YuCvu8nHni8+qb2S6BxEtO8/uhICdwsFufsl1xQfArLCKtp0n4FKz/yRp3/VUo5lOdm8bqw/gUPYS5SjO6w4bXP/RxXn974L42Hjr48YKL/ogC2qLh50TVtW7de5cXqzGG6awFxxtzXYztQ60yjQknAhYwEMtXybIVZAarF62YRYImJSq5bAjjVm4Ysn5Cko07kfYgZXvREfAjrfsQrG+HY1tGQefvo55kwH9DNOQAUJhcJudmP+7+8bRgdjpc4cz4recW/jU0GE1UX0D8AZGjJbM5qmeJnPm/lurxu9SW0RE4/58HFvCisaLdZ53Yaz8HmInc5HcXG88Uk6aXL+MMqek4cGIvyt2NApAF4uAV3dZ3EP/HyaNkAxWSw3/ZV7bhq2fpOjjIoNA9HfBgjp/vxvUeAN/YTUMFGmaXCVMR0iKZan8Juyjk5QjknoGYoKFNIKuvJ5lTSVDg7pkHLG3ksWwT8zWeB5haGCdFkRU6uJEGsROMbvdgaz+OXcwJIctmy8TIKluoOywyc4fTAa/j6t0zsO+6Aa9EiaJ4KOXBFUaSLTQIU1yZBKe8C0Dz/PJ+DKdyA96g2snBBx9He0/jaN2P46pdoPepCXpI/XUbLBv+IW3sIcDYvVWcDKMLco2HrmjUufmmwfmaGsOPZLhw4qsK1bDmMmkaYDjdMuxMm0wNs9qLPqVOgpLo2rEZLzGil6zMsKZQ3CYdNj8eQnwgjF4lCVx3Qlq/ESNKFJ3/LxxRHLcKgnsNbVI917KViNjadFWCFQgxBrGhoIScrVTLTmxOHsHtXEorfD8PHa3p+aoDTm6AQPStn3QJbRjXC36l53mNawBUHAVVWFYM3i8JoiBZjvqxrwDEqwHDYmksBkMNBoAYLaIqFKNeC2QKaa2vQHKjnQ8Ae1AxCx/ah+xQ7rq69oP5SCVrLJJFsbMfQlR8vuuU76w1xT7KpHQMf/KQEqmVTnBzGndtLoM4p4otFOLkBhKMK+vqKwr3o+c3NcDbTkGUDZLlT31CHKsVbYzlsrg8n3urFeJyxVeGf4VYK3U3LpeXAMtWN6PnoF9B17/fgiIxA5bV3E6OmZoN3sBvRRZfiwBd+itG11xEoZJ82R7GIFDGepSVVOwynBydPzAzpYK1Mke1lk0yLE43SeFqV5WbJgzj0ZoGde8nj7imA/MxV1CK2oFMOLLzyStgIqv1/voXawztQcLrLcE8SSYEs+d8P4eRtD+LoPd+BZ6AX9fufR+DwbtiPvG5VznRfg26vktjO9ieRzUxFgL9CfiwoPw8ydgOV4r/8Y6Rght9ET5/IHRwwZ1xQmODNsVVbMLz+BqSCbXAkJrDw+UdRt/8FOKPDZYGbBElSUfWcBFm/71mELv8w2y0YXbMV/oM70fDco3CEh2hFovL6EJkAJlg7iuJdzLWXrOpU0TBL7X5BJVPFSpz/pQXzvYiHBmUxqnh9k44v+qo+ugeVpw7IwdlSMVmqG2TTgsM9Z9lpstw3VRVVJ/ch0P0GCi6Kd18lCWYYWnRMurLCCllxuxGjDo7FaIV6y7hCDDBcK405APS5XcJF6ZLxQ4hEDUSZXJUa9wwlrBg67MmIPDfsznlR16V+RN+O2DgK6RilnCWtTAI0FbeUcdGoPpmz6QAIuuCuspVJMgKauAkGXSLVhSS5QjTFYT+PAQXJiJmflcHyGStdvBOLXuA3ZlE0qAQqPEMiFM8S7EJrCguWEIpLLhrYrpQP0DJ2hoGX65f6MifTmjpNRukYvOI2EswqMmhSsp5wVdG0bFp+FzE6sfwKSSLn2UqsPNEN+6++G7mqeqaXhAQrJs3qIykfFbr2U0g1t8trwh9NWMtwmfQ7KL8yXDSbE2NKHOKdeSmeJ2WYWZr5HDK1rTj1iS+i8ZWnUNO1C06mBvH8TKBZks/o+m1Y8R8PWhbS7Oexp51xO7r2evRf/yk07f5fVHX/ScayUEYJ5sahzR9DsmYhVu991pKCpfhnKxldDokGHs8iH9XLBxhPZ4oWhLV2eW7CFrHSuuOnzF9rMXjTdgxu2Q41bnG34XfI9Nn4+6dR+/YrKNhds4SbIkljyVPfZd58GL2338c4uA9aImWRVKUilyyWPPIVuEM9ZGXPpFKSyledAihEVTKHVK5ckuG94Xhi6rvLJZYuTBh6Qap7Ka7pJvZUBJ3/+QUMbL4d4RVXIeetlnLL2R+Seaxh3++KInz2ZC8myd/bhTX/fi8Grr5Durvu8rPfCXiPn0bTq0+i8vVnkHe4piZF6lpDMmcJYIalBXXA+GxUMCvAlIFQeGIqKZKZ4eEzEvQLI8V4K6YLg25nY+3S9uwPcckfH0feUylJx86cKGKpIKSWqr0jyRQ4eG/oFJb94uu834+C2yd1qehDTGROsl1xgkRfwop8RiljiUOsrdLYIaXcGOzPYDSYL5bbBFhJdVZJtRDnNJkaazQKQcVtuYywpHQfPtQRG7PoXF4rf8nVkNUIvYTABDkJs8h0IfrP56dYhM9VaUFBWoHA1P2xuPS6M2VrUZYjI6NjCJtZy4KBaqCGHZq0nlD6hdhEseyfXtCqMhkLVXIhl3z3ZF/qQ7PIRNSFgj2L/SkUEeJahcdEVZWV5MUxNk6vA06VDdCmShcNCUkkWZnuuaiNA0iTyu0UvLkcCpFxa1bVqSIXyvkrvYL6pRifrWWt1DLjftFEn+zbiEdncJsiyIB1opjw6uriFoBIJSFkhzD7wtOsfhQzkR0bwUnOzMpAvUWg69YAv3khRRfRpc40EnGpLFQGg2KzyUEp0yr6klXPbLsX8dblsgQ6v5JQmV5eRv3ep+imNivPCbMwfo10GmYuM9UX+9fEbxIxXNJhEZ/wXrGvEY2gX7mAi84KUKSTuI7XT/bg1vaV1oXODqHADYxwVhVvFUxmWiF+C1LWWwSgTLOCSORCT44suwKppZ2YdUdBMGEkjNrf/MBKDaYxMxuVwLEvxVshC2ktn0LHysmQRJiOFBrDCU5ttGySET/ksF899BbMG2+R63qoZUW5/lLgd3tGoInlCpKMmU5NuaWY/WlyQmrEWBjL//nTyFfVWYOf5UnO0TMoaI5ijlNmenhplYCxp1YGYA72oKHexKKF1s6UWIUbHJArbbsLxS2GstdFh4GuY93oS4xjoZPuwNSEbdcCv9+ZhB7qg62uBQWPFyY52iT7yXWWc1bRBGE4JobgHOu/MLEI4ijR/zlCQJQIKidSY57SYqPIj4xg3a2AqHRE7hPefPwYjKE8ds5p4Ve1JjJy5AxeOvI27tmwAThxkvmQ5eFHPgI899wAstFx2KtrUfBVwVC9cofXFJt8jB+zUFpcMiSrSma9YAFRXI0Tq2fC50QKEsA4CI16V83EoQz3QEklcPkmYPNV1MV0dxGOY8xK3adxJGni0JwAllZSInn87MUd+KvLLyeB0YtSGbH7CyxdCjzxTAZnemiZYTabC4oocN0sr1xuWaCZiiaJQVQF5rT10unuJ1TJ5EKT3O+m32XoERMjUATDMt7EYp2fHn7bneSBFcVtcTZmK7zVBfSN4ZdpUy6Tzn3pfsjAnt1v4KX9+3F96yKgd8DaiV3YCtSttGPQqeH69izVTAY9pzMIT0wgzvKQchJ502ZNsyxktWmLwtNiS8g+YWkC0yjqhVoSyw9VTUBrCz/J4DtOOVBBz1ncnrdSh2GtfjNPY++rGBop4L8ueneJkq1wNokvPvIT7PnyA6gQSwPC98WSvJhs4XkdyxUsZuCLcorMzkLUkk6xmI5IRJfnqeIWtV5crBW4BUF42J+XRvcTQGVl8ZyqyeezfhNPKXh92HoW8zs4n/K66Oe3TwGHB/H3YwUMvafts548DttO4DP/9jB+8fE74AjWye0gVHut2RR7E7livSgGXVdXqj7mfhiWjpb5TRjWmkwFfrcJr8uUbplgEfDUr4E9B/CtY1k8/p73BwV5HM/jSfUIto/9EI9c/yG0bNzIeFhI/xUvDIwpWNY0c4DzcZBzMJ5QMJFUcGVHQbrvW0eBF59H+rXj+IczOr5bzqPKUsRCdr6dwzNjAzh4+uf46r59uHvjRsO3JFjAobMaNiw1EKBFhevKaqa0jzKX1ZhpKk0szYvBv35KQ63PgCvFQHsMONCF5xkyD53I4U/zukdfAjmsY2BEx/29b+LhQ924uzWYvznvUjufMxTt0nZTkoGIKyGj7Pap1edyXFO4pVgaEdohGWNaOqugp4v/iBsnH9tt7hrL4GcDOnYn5+ghc36NREzcqIG3x5P4SncGD7lVo/NMH9Y88wI2tASwPFCBILNEFem9gmznYY52iNUKuzqzyNCLWYHEpLMKS5M4EozlyEQC4f4wTlEV/Zmq98BAFkeiBiLmxbr6xcaImMhIAXm2g1QSB/n18ZMhulgIdsYtCxqINUaPX4F7ZZXtiUzTshVyF0ouxWtwDR1PHR1JfILGYiQjTewJzkHaYI2bNjFvhw3zeIi3kVwK8n4NdU1OdBJL0E5Boim635GPMj5txV1rsaWdtV/iwXqSZCNFSyGl4+RgDm/SBXPzOaaLBuizrOhSrDdNVK8dba1OXF/lUm/11QTXu2ob3ZrHZy0KTO4TTiOV5mZ7tYmHUnJ1i/+IT2BxbPxUJBp9OZLDk2dSOMg7JkxLOYoslM/+fwAMqGheW4NvL2/FcqcDLj5ZIzmosSjaULfC4VuyEvaKAEWAvYx4Zm6LM+jCYegVQahN5mJ/Mrq4eujYZy6zR4Yo8ic8Trm7nRuLInnwDB47nsFPDPN9AijMdVW97fvf+Nfbti/vyMKR2I1YJIIByiamDjz9ph+u2iYUWKga+lQBWDAUKwUoxUVj8dKPacgVNyGPnHYbxsfHkaQ1s4oH7cEs7vs0Gmsq0biw0QrbKFXSoz/Gpkefw1undLxR9itocwJo4tLrbvnAX6zexDIo8iydJiKlVVtT8X1RlaVPafNc0j8DUlcR8HEybAwungtg4uWtYUc1ojafXEByMKfU19ejppqWZyLMGSoqmG4WNk/lyKoa4PbbgOZK/K3yfriomIkOP+654TqS/+CvLY5XrEAUeGgA2H3+aWlAgU018bEP9mJjxwjCMRd++VIbXh9rxf5gJ0LOarhYDl0ReRMdyT4wlaI6EEChoCJ53I5EfMYmgnwDacESYOsG3Nz1IpYwOE/OqwUZe/VXrsb2xfV7LAE6bRrTjP7RCRtsLJdMYSGCc9Jif31jNz70gbMI+LNY3BrB5z9yhNV4CkNKUJZTaVbyO2s2oNvTArup8z4DbmqyeN6L8TCmXu4rAaVwuGErKhZ7cJdNmWcXbbDhw9d9EPWaI3fOuom1GRmOeyVAIXmE9bZv7sP6zmEYOY01jReJmBO+yjy+s20XPut5kbWeZXoRh3urViGueeSap83OBKJWYohVRP6cRQJR9a1aBaxbjDucpnjJeJ4AOvmYpY24c/06zFw8UqyXn0IjNKpRAbvHDZ3BWOnJY1UbTVCwYvBHv+vAvu5aK44rdTx46R7UpYdlwhcdJOwVCNv9EqDGGLT7qzBI0ZBMn68u3FXApsuxLKhh07wB9KpYvGEVNtY0YvIdzhLALAH3syJLKnXQin5j1wyrY5KFjef33NCNS5eEWQJpcpS94Sq6p6u0NEXpk0VFIS3JRwAU+bM3ZEckPlt5A1y5EUqLH9u1+QLYaMNN7NQ32wsTURaz/f0ExfJ7erhM9+IFjXFUeZksbTq6jgXx+bduRdQTsJYqeNOmSBcCVDoFVv0ihTgr/BiPezA4bO0czXguvy9oA9YuxjZ6VuV7BuhRYF/agE8uW2rN3nTricp6bIJF8RBzWaBG7jzNWlPq1sbpG0cbcNfe29HlWip2QEnhBlbFuuHXk9CVKUJ3MbuP52twug+Ipc8BSDe1M9TXdmJRkx3XvNv4/0+AAQD0fv8c14mAqgAAAABJRU5ErkJggg=='
 
 
-EMOJI_BASE64_GOLD_STAR =  b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjAwNzJEQTBGM0VENzExRUQ4MTVGRDVBOTkzQTU1RkNBIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjAwNzJEQTEwM0VENzExRUQ4MTVGRDVBOTkzQTU1RkNBIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6MDA3MkRBMEQzRUQ3MTFFRDgxNUZENUE5OTNBNTVGQ0EiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6MDA3MkRBMEUzRUQ3MTFFRDgxNUZENUE5OTNBNTVGQ0EiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz6kluKgAAAWMElEQVR42txaeXAU55X/dfdcmlMzutABSCAhJC4BNgZscxmwTYztxFkSh/UVe02cquwmKW+cZJ3UVrIVx+tNNrUuO042l48tfIEhBmMb7IRgA+JGHBJIoPue0dzT09PT3fu+7tEBK2AMJH9sV33SHN1ff7/v/d57v/d6OE3T8P/5MI334VNPPYWGhoYrXqzS0PeHMyZy0FBUFNFnhcUW1WcXtFwVvJdOyKWvzDQsYy5N0RBpBHkOQz0SQqKCAL3uV3lE42P2XeCyA/Pss89i9uzZVwa4e/du1NfXZzWpFZhWDCwgcCvmVGCmy4kSXx4Kp0zkzAWFNjhsIiw8wLNBC+VoqLR4lSAqCiBJQDgCdPUC7V2IiCJ6O/rQ0TKI/QlaygBwiE4PZ7OWJ598MjsL5uTkXHaiHA62Yg73VObi4RtmYfGy5Q53eVUpSiunwV5YTltOJyU7gHgTIeghNLFsGeUmu7oHBlDd14tVR07gB3/Zi+bjrdjekcRvAxpOXs6hBEHIDuClDiddXwR8fno+nr5zhTBv9d3VqLphEeCdSaZxA9FWItx+AnaKCEgmydD3Mx10fiFRorAMmL0A+OIXUHXgEL65ZRs27DuJVzpT+PGggm5VuwYfHO/IF+Cos+Jny27BhkeeqEPJTavIlFVkKXIl/z5gaBd5VP8oKO4qwLGDXS9nBttUxv3bgeXzkPPGu9jwwftYe6wH32hIY3M2ILMCWMDDXePh317yyIJVj339DgjexeiRrTgdiKHDfwSxhJPWsw4pwYkUZ4FEnqkQT1MUU7QxKNnn7L0JaYo48sh3JjrbRO/ZZxaNXWUMG5KwawnYxQRc7jjMdyUwq1YqibzZ9yZ3sPXrx2T8+kpJ4IoAC0wwzXHxL3M//OUq60OPY1saSJPRtgSA9wPsjDVGfPxbHD4iRSE56tyAMPeZdS/O3/nxwBEFWy5nSf5y87HwXCXgG5EHn7x37gOPw5cyot+7QQLnvwYaXu1B99aIuuGcPOz79luCd+a0FyjYlV21BYt4lHiqC79b8dADWKL6walppNMhFPuP4XEuglyB6MOJsHIS0YkRcHikdMox9BwRkZGWG8fZGDFTZH5Of8dhmJxJfTb6r1nptRVx1Y6g4kScMu2g6EIoZofk8iB137qSijP/9p2+JP5R0a4CoJfHA19ZGilcX7IZnFxmWGvoddzN7QQoSQUpSUkpI5+l08ZIES5ZNl4Pfz4cd9L0XqVhMhv5UGcJz8I7sdxk/LdYjdemzGCfsUBjLzb4FhwCOsk1FDOHUJ4Dvy/HV5rP4tl+iqxZA8xw2lKRj/tXrSgGJ0wwtIdCGTl+ENu2AVu3A/2DGTAMiGoMfRXDq+cu4vDw5wyydlHoHI4WGmkfem8iYGwwgHYbMLMGePQhIJd0kUQgBTLZhJwY6uYg79h53EMAX8weIA2ac3bddMwsqq6mldsMbxWP4bWXQ3jpFVqHNx98QT6Bz5iDZArPGVJF4/jLA7wg9A2DNUByNDQys0zOLmeyRjQpont/N860JPH0d2jnLQYzZFroNFreBDfuPT2IF8cLNpekKCX0W26oo1jvqsxwKYW2Q3vx6pv0sqQMaunUkbQ1ulRjsTyFWY4WyYCqJsuFlhvO5mNzu5ImYCo0XoAqmKDR6pVgwOAzvedzC2Dx5aPjVANeeV3Egw+NukARLbSsCLOVQRTT7L1ZRVEW9R08bq2eTg4hFNAKiCfpVvxp5zlEZTM0JjNoQfoCxg66Iy9LiE+YiqHaRYhOrNUDE6fIxvlahor6a+N6PiUi5c5HvHgq0lY7+GScbseDz7FBI8tp8SiU/h5yA8qfpaU43Ugo+gz/ZBGdTkNxMYrIRauzpqiLh8VdgKr8CR4C59E3PN1zCAcPkX948qGZrQagi3eLgHSseBidtz8MxZ4DLqWgqP49VL7znHE+N2Y/GR3ps/ZVj6HvlnuRtrhhCfejfMevUHCcVJHdBTUehyYl9XPV8BA0Ty7CXQKamxXdcsOcKKX9JvVMehF/zsqCFDQKvbko9BW4DIAIovvMMbRTnOK93vETKlkuMmkG2tZ8DYqFbsfWRQzvW7IWA3WrIdD3F+TYtITAjCVoX/s4JE8hFKsNYulkNK/7PkQS7Lwqg3c4R3yXAVVpPi3HieYzF8lInx43arRsEz3VdPleD/J4J92AIw5IzTh7agBhkYU050VBIrMGolyweiHVT5zhYtYMP+jOQzU3j6M5NQzOvX1ULDC/YKnG7cTQtJvApWVwVqsRRjPUVgkkR/mvhygaiRglGPvKRXbwWFBh5rIE6BDg8XlpeXyOcffYYTSyXbOQX5ht4wJkRzJvoj5j7umDKN/6EnzHPtHfS7lFo5E1A041WSHmlemllau1EfmH/gRL0K8DlfJKjU2jAMOZRnWgliLB4HAhSEpqaMjAzvzQSsssdcPnEbL0wVIrct0u9i39SdNMkdOsGIVGM7Gbjud/7JDtbhR/vAVVm57RIymLih1tjyBQe6ux3SPWJhVDm6XY7Cj9YCOmbHsegpSAmD8JZ9b/EOkcxwg1ObPZ8EMGkJKulkPqJi0gEFBQXm7stZUCtdkCO4G16po+izzo1Gtenm6UbIboDyIYYWy9dCGsUOApOrID3qZ9urXSNqdO27I/vwZ323E9/I9YIpMvi/dtRsmnbxp+n+OGLdSL6tf+FfHSaiO9MIzDFmTXUDphc3OEJuAXR0EYqseqIUuAjIwW9g1ZAPHDiMXpH0kz3ScuWajyyG/42AgIGTA6LUkAeFobaMHmCxI+L6cI3FtGfmf3YdqU6G+JDcHStHdkDoyt0slEGtM59B3zwWHNwBstEUGPalkmek1jDivTLGITkrQnScYSx+XrImOhFwPnLgR3sTzjuMvOwXEXhglj0wQkEtkVIJcql1JymkWNVgI5aOhMPY3xV56QqRhNzbI9cZGiYYlfka9Y8jOQsjw6RaaJRYqCxeEsLEgwYsxqOkB8tr4py4WOvlaYxLBOW71qp43RLtKl3LD2VFXjHvQ/RflQ8hbB3ntuHHl36YMyCnPP1MX+d0mA3RLCxawRpin6/BTIYDGzt2ldJ3L8+FWuICfRducTkN1eeBvr4epqhDU8AEGMkZRN6ppzuHhitFUoKqdtLki+YtqYmQjV3gjvyX2o2vzvhljQiwt13JxrsYxaMJXSq5oE7WMqK4BxBdGhEFguYI6r6z02GDiVLZYle44bN3k7+lvRXXcj4mWVhsFodwUxQQBFA2CmOGRRUiUQCpvYlMFNmzhx56sXhef0/wHH0pQzI3KY11B6RG8UoXA6yzzIOs2hEEK0H3lsMSwnutiEYZqJFsVEMGd3jJvwc8/Wo3vpOox4A4vuOXbSpvYLiwgtM9QMsVjhGxcppZy4INBoqTFGITQMIFM5w4qR7TOL8KEkOtPZBhkqNAcpDPujmVBsJiyF+XSzZELPQUokZEiIi6yoUi7MbTkMZ1vTaJN+GIRiSLGRoQz3/kdb5Hmn9pD/nhstsag60eTUaD4gWvM6QAkFhaP3JWOwac5xWWtRDvHeIfQEQzC61HRl9TQWdBIUoTmjXgsNjeS/YaAsupmSMVS89wJVEunsu64EzjIYwOQP/5usx4/MqcZj+r2G5+eY40kiPA4NefnGHrNjcFAHcibrNBGhC9tjONHfP3rGrFpahJo00gApGjUWRTowoFtVS2fqPbY5VNP5iKbT3vgJyS9SG/YxjiCMeT0ssOl762A/al7+PnJ6WqBorHIQ9Q1UoqELWMKTtNPCIRRQiZrnMwpeZtjubkhU6JzLuh7kDFwHTp8FbrzFeA5URQX85BKahW7M5U2AlqBajbJtmmVcUhsc8xv96QrJNPpX8P7vYG08iJ47HkV4xmLIxClPXxcsySgGK2r04GPt74D30Ico2fFb2AbbITEhrwZHTTO2xUGhnDWoEA2jerHRtmC5MBrVhXcH6ZDWz9RVo4rkyOkmiJqMHI7uZ88DFswHzm7zQ5gwESoFDoiJUV9RLhTgLA87mg6gitKFOKECSarYv2w6BG86gt841kAOReDoaYY10E06lVIGUzvDdBzr25lAxlPq4RIR2E0p1M4w9oBpUD/Rs6UPJ+iKKJ9tucTOox1pbjyP0wM9xlkiBZzVK1i1TyVLfxfMvjzwuT5dxo+rUJgPUcWgUq4zDXSh9uAbWLM8Dyvv9WHBp7+H88QemCN+qigcVIJZRoENtzUyQYwjWvIFE2BmXZPOTlRWAWWlhvXY6eeImAkJH1zqOQ9/iTShC4Tzg9hxrMHwnZZ2VjEAn/scYfJ3QWhugE2Ow0IFqpBXAN5DO8ysyhqbw5JO75CRWqGVzJ9mR+39n0fVKi/mkz/nkJpXuNFi1vBRk17csZqP9+XD7PVRVjLDFuiC1ngcE/NF3Hnn6B6yZ4tNjYj2p/HRVXW26cK3du7GU6tXk50IXJjUzdJltINU127/MI721nMwqQTGQnmE1XA5lCxtZA3Brks0lVaR0niURjuw9As3wlFIoTimYfGdNhzoTOKkdTL5VYaClDM4ljcYTZPk38F+8BTAzKoIM4maFauA5VRWutyG9Vhh00TZ6HwHdse18QPMFQGKHBoOncCWT/fi72bMNgCy+9dOB9pEE3psAmp9MpxyFB1dUb2EiVDkTamZSpwsYqdxU6WEmevuouWr4FMaqld7sOCDELobOxBPKhC0tNGiUFJw2DRdWLBiv4TGqaAZKQuPxUtT8Lg0vZPOrMfW8clfoHXE8Yu4epXPJkiy4VQMP/jty7jt6e/Bx1roCdHYQSYwNDOHOXM5LCS/iFLNGA4bvZJQKI3gUBoh1ghvAxZ/bgk8pdMhaxECQkYuNuPGVTa0tgfAkVGJ5boyYcOTS8NtqCeWDnt3cujyEx0pKCh2A5yNgu2uXcDxU/hDj3Jpemb1+Cyo4Ux9K776i+fx5pfXw8LiCtPgbrumpz6WAllpxRrcBUXQG5T6cwjaAIkAth0gK3/pbt16oyFWw/TVLszdG8YkiswuUiWCxQDEYsvw83s184zDZmI+a9S+zE33/AV4dzv2nEjgm3HlGp8Psqc2Z2Rs5U/iS4EX8Kvb70Th/HnAtFIVNquGTqLkdNrtBOUjiSjMqiQGzsrEK5eLSbfVIb+8CumxQp8AOmkjatdMwbkDKgY7grQZYb2/bPfQtcyVacQIsD/GYUqhiuI8DQNkyY/Icnv2YsuxGL5KJIlclye8rKBsTGGLvw0Nfa/ix0cO40uLFmvCjUVpKolMCHmnwpY3GWXzSymQFMHqzoWr2A1Hfi5MvIUKZkLPj+nnaBJZvxKzH92AGY86kaBMHe2P6SDFQB8CLT2Itjcj1NGOPFlBVZ6KnR8CFAu6GrrxXLuMF8jvlOv6jJ6B7FdwnuTh+u7D+K/9J/FoTZGyckExX1G3xoOSFWQSjT1iI7lDRQgVNGAdlLT+sELTQelZSWUVyUQohU/Q+2JdEjh8Dji9fmgxE9QAUSBfQ6zciZ0vkyrqkFJbGnG0cxCv0/03DiroVz9DDf6ZfmXBjhjt21kF9VwK9U1x5J0LyEu4Hx78+dro2fKyW5m6sUATfOBNBSSOJ1Oyn0R3KaLPWMOYIoWtAmn7rVDCCajhPVD7TiPt74UaohEdooiqUuLWcHB3PP5OPX708QDep3s2JK7yB1kmXOWhGaI88EkQ7wwdRyP/XOSdOxTL9MnLrSSpBsgR+8AlG8hmnE5PzVxMqmYWku0RSOdegTLUOdLvNBKhCSZKtvGkhsN7ouHtx7FuUx8+lFVc08HjOhynY2j6z+PaHe/+h39/6y6KNKQ+wFtGptdMhVBdKwlQDGr3QdjLumFmjzx4qz44qiPNVhMSCRUHdkXatx6Vb/9N67WDuyYLjvw0iTcK8m4R/m1ntZfFn/rr7lM025TlNgJWCtW5goT5Ikri3RDEV5DyCxByTXAvtSDVIUNskaFFFcQp3m9/L469J5WGI2Gk3QJsxNYkS0XRvyXAPDMs5Wb8k8+H5R4niTMO5nM95FYcymjHp+5q49D2/QCe3rQeE+ruIbnG2vAJCKGNFGBEvaxKnJZgLhD0icxlJgwdl/Dz7w7gVBcPEjZri0xYW+rBSSpqA6T8hIAEORJHtNOPt1pSeO2vFmQY4Sot+M73/nnRj29Z6YUtuh8/ejYIvzYRrklTYCHBrVEyO71rOwaTtSjmnHpvgo9+BE5qoe+ItrxIODUkTklwLWDCmkdbRMahXi/KV95GvishFQoi3H5uZklpD57+lqbfN0Y02fQ27v7ZJsTOy9jyV/FBcpvKVcvKn7znkcXIy23AUcq2R844UbR4JXKnzYbVW0h13gBMVFXs3bFPn56TWyFEKYlxY7rbJPGk3jSkDqPL9qcdIiw2K9JhP2z5JcitmYuim5bjeKMVrVTGOphCouzz0IPAzZX4iYeD87oDZCfWePAv6/9+kgfhNzDU1IU3t6TgsiUhxyh46I+pFbjKp6No4TIc+vMpiNIQTLGtRM2EAZaA8Zkff7ISSiK+BZuTOH6cR8ktK+Eom5rpvcqQEzFYBRn/s4kIHjAqaAfJxAfuQ02lDY/z3HUGWC5g7j1L8ZXpFYfJ67vw9mZgTiXd1GOHyeHWBSRHoV4R44h1nEEylkJq8AOKQFTTsEfeOTyG2gnQgEwlI8eyAjSR8syxFJKJJGJtTVBYg5N8lP0KWcjxoGiCBVWkBTZvhtGlo6yybCmJ9xn4tpdDwXUDmEO7NS0PT913N93GHMfJT4HfceuReHgDCi1hRDvOjxS5qizBU1ZBGtKEfZvfAXKtSPjTqP/1AHY9H8ThegmHD5IskxTYnTx274wibppKNCzSrx0uy6MdzShyJBH82pN4KXAX2o8aTSozkfOL96C0woYN/PUKMqSp5yxbiHunziCmkLh+fvdEHH3spziWX4a7Kk+AJ7pyXA3JObJOLlX3ZtoHcp6+tn4c/8MQPtlK6sRRjq99W4PVweHEx0F88FEU86bGEQrTNW6PTk81ldRb9fqTXRICJ5esxR+9z8F23ym8+Po+PFMdoLmBRQuBhTOwoe0wXvKr8F+TBdkJtR48cfcdsLJfB20lo9TPegypsjK9+DzCz4dFMPopzK8UKYGhE/uRGupG6z6iX6+AhQ9WY/66yXD5BJ2e89f4sKf2YTzR/xia+51I955D8NRBsmCmmqW6yUJOdkC4CSrRMjFtBj4p/zIoOOtUZVZcuxplE8xYd80UJa6XLqnDfTVUIrUQTY6eJXou34gpyRa9M92/8qvo6e9Hqq8j0zo0w1M1B66q+VByzbjpHyZi/g0iVsxpy/Re0nj9k0pswq34dNaDqJcnoWjWPLim1Oophqc5xM4z6EqkEGCPAEj71klH8cuVf8RHB0lQZJqDixcDMyfjUctoD/3qAE6y47blN8OXEjn53R28+vm1nDrP0aRulO5Xa5KnNOv0KRAJfVqRNc0qaDlWSvepiCb1tqBqpk9OhAUpGjFL0ZhViomCuHFvTfhbZ++VYha7ZEmFpNSEKVKss1kTlLiWY5FVzWbW0hRJ43NuRs6kAtQlD2KjeL82O79Tvf02Tn33PU5VY5zkyOHk2xahhnxx3uXW/78CDAA3J5rmrHo4bgAAAABJRU5ErkJggg=='
+EMOJI_BASE64_GOLD_STAR = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjAwNzJEQTBGM0VENzExRUQ4MTVGRDVBOTkzQTU1RkNBIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjAwNzJEQTEwM0VENzExRUQ4MTVGRDVBOTkzQTU1RkNBIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6MDA3MkRBMEQzRUQ3MTFFRDgxNUZENUE5OTNBNTVGQ0EiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6MDA3MkRBMEUzRUQ3MTFFRDgxNUZENUE5OTNBNTVGQ0EiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz6kluKgAAAWMElEQVR42txaeXAU55X/dfdcmlMzutABSCAhJC4BNgZscxmwTYztxFkSh/UVe02cquwmKW+cZJ3UVrIVx+tNNrUuO042l48tfIEhBmMb7IRgA+JGHBJIoPue0dzT09PT3fu+7tEBK2AMJH9sV33SHN1ff7/v/d57v/d6OE3T8P/5MI334VNPPYWGhoYrXqzS0PeHMyZy0FBUFNFnhcUW1WcXtFwVvJdOyKWvzDQsYy5N0RBpBHkOQz0SQqKCAL3uV3lE42P2XeCyA/Pss89i9uzZVwa4e/du1NfXZzWpFZhWDCwgcCvmVGCmy4kSXx4Kp0zkzAWFNjhsIiw8wLNBC+VoqLR4lSAqCiBJQDgCdPUC7V2IiCJ6O/rQ0TKI/QlaygBwiE4PZ7OWJ598MjsL5uTkXHaiHA62Yg73VObi4RtmYfGy5Q53eVUpSiunwV5YTltOJyU7gHgTIeghNLFsGeUmu7oHBlDd14tVR07gB3/Zi+bjrdjekcRvAxpOXs6hBEHIDuClDiddXwR8fno+nr5zhTBv9d3VqLphEeCdSaZxA9FWItx+AnaKCEgmydD3Mx10fiFRorAMmL0A+OIXUHXgEL65ZRs27DuJVzpT+PGggm5VuwYfHO/IF+Cos+Jny27BhkeeqEPJTavIlFVkKXIl/z5gaBd5VP8oKO4qwLGDXS9nBttUxv3bgeXzkPPGu9jwwftYe6wH32hIY3M2ILMCWMDDXePh317yyIJVj339DgjexeiRrTgdiKHDfwSxhJPWsw4pwYkUZ4FEnqkQT1MUU7QxKNnn7L0JaYo48sh3JjrbRO/ZZxaNXWUMG5KwawnYxQRc7jjMdyUwq1YqibzZ9yZ3sPXrx2T8+kpJ4IoAC0wwzXHxL3M//OUq60OPY1saSJPRtgSA9wPsjDVGfPxbHD4iRSE56tyAMPeZdS/O3/nxwBEFWy5nSf5y87HwXCXgG5EHn7x37gOPw5cyot+7QQLnvwYaXu1B99aIuuGcPOz79luCd+a0FyjYlV21BYt4lHiqC79b8dADWKL6walppNMhFPuP4XEuglyB6MOJsHIS0YkRcHikdMox9BwRkZGWG8fZGDFTZH5Of8dhmJxJfTb6r1nptRVx1Y6g4kScMu2g6EIoZofk8iB137qSijP/9p2+JP5R0a4CoJfHA19ZGilcX7IZnFxmWGvoddzN7QQoSQUpSUkpI5+l08ZIES5ZNl4Pfz4cd9L0XqVhMhv5UGcJz8I7sdxk/LdYjdemzGCfsUBjLzb4FhwCOsk1FDOHUJ4Dvy/HV5rP4tl+iqxZA8xw2lKRj/tXrSgGJ0wwtIdCGTl+ENu2AVu3A/2DGTAMiGoMfRXDq+cu4vDw5wyydlHoHI4WGmkfem8iYGwwgHYbMLMGePQhIJd0kUQgBTLZhJwY6uYg79h53EMAX8weIA2ac3bddMwsqq6mldsMbxWP4bWXQ3jpFVqHNx98QT6Bz5iDZArPGVJF4/jLA7wg9A2DNUByNDQys0zOLmeyRjQpont/N860JPH0d2jnLQYzZFroNFreBDfuPT2IF8cLNpekKCX0W26oo1jvqsxwKYW2Q3vx6pv0sqQMaunUkbQ1ulRjsTyFWY4WyYCqJsuFlhvO5mNzu5ImYCo0XoAqmKDR6pVgwOAzvedzC2Dx5aPjVANeeV3Egw+NukARLbSsCLOVQRTT7L1ZRVEW9R08bq2eTg4hFNAKiCfpVvxp5zlEZTM0JjNoQfoCxg66Iy9LiE+YiqHaRYhOrNUDE6fIxvlahor6a+N6PiUi5c5HvHgq0lY7+GScbseDz7FBI8tp8SiU/h5yA8qfpaU43Ugo+gz/ZBGdTkNxMYrIRauzpqiLh8VdgKr8CR4C59E3PN1zCAcPkX948qGZrQagi3eLgHSseBidtz8MxZ4DLqWgqP49VL7znHE+N2Y/GR3ps/ZVj6HvlnuRtrhhCfejfMevUHCcVJHdBTUehyYl9XPV8BA0Ty7CXQKamxXdcsOcKKX9JvVMehF/zsqCFDQKvbko9BW4DIAIovvMMbRTnOK93vETKlkuMmkG2tZ8DYqFbsfWRQzvW7IWA3WrIdD3F+TYtITAjCVoX/s4JE8hFKsNYulkNK/7PkQS7Lwqg3c4R3yXAVVpPi3HieYzF8lInx43arRsEz3VdPleD/J4J92AIw5IzTh7agBhkYU050VBIrMGolyweiHVT5zhYtYMP+jOQzU3j6M5NQzOvX1ULDC/YKnG7cTQtJvApWVwVqsRRjPUVgkkR/mvhygaiRglGPvKRXbwWFBh5rIE6BDg8XlpeXyOcffYYTSyXbOQX5ht4wJkRzJvoj5j7umDKN/6EnzHPtHfS7lFo5E1A041WSHmlemllau1EfmH/gRL0K8DlfJKjU2jAMOZRnWgliLB4HAhSEpqaMjAzvzQSsssdcPnEbL0wVIrct0u9i39SdNMkdOsGIVGM7Gbjud/7JDtbhR/vAVVm57RIymLih1tjyBQe6ux3SPWJhVDm6XY7Cj9YCOmbHsegpSAmD8JZ9b/EOkcxwg1ObPZ8EMGkJKulkPqJi0gEFBQXm7stZUCtdkCO4G16po+izzo1Gtenm6UbIboDyIYYWy9dCGsUOApOrID3qZ9urXSNqdO27I/vwZ323E9/I9YIpMvi/dtRsmnbxp+n+OGLdSL6tf+FfHSaiO9MIzDFmTXUDphc3OEJuAXR0EYqseqIUuAjIwW9g1ZAPHDiMXpH0kz3ScuWajyyG/42AgIGTA6LUkAeFobaMHmCxI+L6cI3FtGfmf3YdqU6G+JDcHStHdkDoyt0slEGtM59B3zwWHNwBstEUGPalkmek1jDivTLGITkrQnScYSx+XrImOhFwPnLgR3sTzjuMvOwXEXhglj0wQkEtkVIJcql1JymkWNVgI5aOhMPY3xV56QqRhNzbI9cZGiYYlfka9Y8jOQsjw6RaaJRYqCxeEsLEgwYsxqOkB8tr4py4WOvlaYxLBOW71qp43RLtKl3LD2VFXjHvQ/RflQ8hbB3ntuHHl36YMyCnPP1MX+d0mA3RLCxawRpin6/BTIYDGzt2ldJ3L8+FWuICfRducTkN1eeBvr4epqhDU8AEGMkZRN6ppzuHhitFUoKqdtLki+YtqYmQjV3gjvyX2o2vzvhljQiwt13JxrsYxaMJXSq5oE7WMqK4BxBdGhEFguYI6r6z02GDiVLZYle44bN3k7+lvRXXcj4mWVhsFodwUxQQBFA2CmOGRRUiUQCpvYlMFNmzhx56sXhef0/wHH0pQzI3KY11B6RG8UoXA6yzzIOs2hEEK0H3lsMSwnutiEYZqJFsVEMGd3jJvwc8/Wo3vpOox4A4vuOXbSpvYLiwgtM9QMsVjhGxcppZy4INBoqTFGITQMIFM5w4qR7TOL8KEkOtPZBhkqNAcpDPujmVBsJiyF+XSzZELPQUokZEiIi6yoUi7MbTkMZ1vTaJN+GIRiSLGRoQz3/kdb5Hmn9pD/nhstsag60eTUaD4gWvM6QAkFhaP3JWOwac5xWWtRDvHeIfQEQzC61HRl9TQWdBIUoTmjXgsNjeS/YaAsupmSMVS89wJVEunsu64EzjIYwOQP/5usx4/MqcZj+r2G5+eY40kiPA4NefnGHrNjcFAHcibrNBGhC9tjONHfP3rGrFpahJo00gApGjUWRTowoFtVS2fqPbY5VNP5iKbT3vgJyS9SG/YxjiCMeT0ssOl762A/al7+PnJ6WqBorHIQ9Q1UoqELWMKTtNPCIRRQiZrnMwpeZtjubkhU6JzLuh7kDFwHTp8FbrzFeA5URQX85BKahW7M5U2AlqBajbJtmmVcUhsc8xv96QrJNPpX8P7vYG08iJ47HkV4xmLIxClPXxcsySgGK2r04GPt74D30Ico2fFb2AbbITEhrwZHTTO2xUGhnDWoEA2jerHRtmC5MBrVhXcH6ZDWz9RVo4rkyOkmiJqMHI7uZ88DFswHzm7zQ5gwESoFDoiJUV9RLhTgLA87mg6gitKFOKECSarYv2w6BG86gt841kAOReDoaYY10E06lVIGUzvDdBzr25lAxlPq4RIR2E0p1M4w9oBpUD/Rs6UPJ+iKKJ9tucTOox1pbjyP0wM9xlkiBZzVK1i1TyVLfxfMvjzwuT5dxo+rUJgPUcWgUq4zDXSh9uAbWLM8Dyvv9WHBp7+H88QemCN+qigcVIJZRoENtzUyQYwjWvIFE2BmXZPOTlRWAWWlhvXY6eeImAkJH1zqOQ9/iTShC4Tzg9hxrMHwnZZ2VjEAn/scYfJ3QWhugE2Ow0IFqpBXAN5DO8ysyhqbw5JO75CRWqGVzJ9mR+39n0fVKi/mkz/nkJpXuNFi1vBRk17csZqP9+XD7PVRVjLDFuiC1ngcE/NF3Hnn6B6yZ4tNjYj2p/HRVXW26cK3du7GU6tXk50IXJjUzdJltINU127/MI721nMwqQTGQnmE1XA5lCxtZA3Brks0lVaR0niURjuw9As3wlFIoTimYfGdNhzoTOKkdTL5VYaClDM4ljcYTZPk38F+8BTAzKoIM4maFauA5VRWutyG9Vhh00TZ6HwHdse18QPMFQGKHBoOncCWT/fi72bMNgCy+9dOB9pEE3psAmp9MpxyFB1dUb2EiVDkTamZSpwsYqdxU6WEmevuouWr4FMaqld7sOCDELobOxBPKhC0tNGiUFJw2DRdWLBiv4TGqaAZKQuPxUtT8Lg0vZPOrMfW8clfoHXE8Yu4epXPJkiy4VQMP/jty7jt6e/Bx1roCdHYQSYwNDOHOXM5LCS/iFLNGA4bvZJQKI3gUBoh1ghvAxZ/bgk8pdMhaxECQkYuNuPGVTa0tgfAkVGJ5boyYcOTS8NtqCeWDnt3cujyEx0pKCh2A5yNgu2uXcDxU/hDj3Jpemb1+Cyo4Ux9K776i+fx5pfXw8LiCtPgbrumpz6WAllpxRrcBUXQG5T6cwjaAIkAth0gK3/pbt16oyFWw/TVLszdG8YkiswuUiWCxQDEYsvw83s184zDZmI+a9S+zE33/AV4dzv2nEjgm3HlGp8Psqc2Z2Rs5U/iS4EX8Kvb70Th/HnAtFIVNquGTqLkdNrtBOUjiSjMqiQGzsrEK5eLSbfVIb+8CumxQp8AOmkjatdMwbkDKgY7grQZYb2/bPfQtcyVacQIsD/GYUqhiuI8DQNkyY/Icnv2YsuxGL5KJIlclye8rKBsTGGLvw0Nfa/ix0cO40uLFmvCjUVpKolMCHmnwpY3GWXzSymQFMHqzoWr2A1Hfi5MvIUKZkLPj+nnaBJZvxKzH92AGY86kaBMHe2P6SDFQB8CLT2Itjcj1NGOPFlBVZ6KnR8CFAu6GrrxXLuMF8jvlOv6jJ6B7FdwnuTh+u7D+K/9J/FoTZGyckExX1G3xoOSFWQSjT1iI7lDRQgVNGAdlLT+sELTQelZSWUVyUQohU/Q+2JdEjh8Dji9fmgxE9QAUSBfQ6zciZ0vkyrqkFJbGnG0cxCv0/03DiroVz9DDf6ZfmXBjhjt21kF9VwK9U1x5J0LyEu4Hx78+dro2fKyW5m6sUATfOBNBSSOJ1Oyn0R3KaLPWMOYIoWtAmn7rVDCCajhPVD7TiPt74UaohEdooiqUuLWcHB3PP5OPX708QDep3s2JK7yB1kmXOWhGaI88EkQ7wwdRyP/XOSdOxTL9MnLrSSpBsgR+8AlG8hmnE5PzVxMqmYWku0RSOdegTLUOdLvNBKhCSZKtvGkhsN7ouHtx7FuUx8+lFVc08HjOhynY2j6z+PaHe/+h39/6y6KNKQ+wFtGptdMhVBdKwlQDGr3QdjLumFmjzx4qz44qiPNVhMSCRUHdkXatx6Vb/9N67WDuyYLjvw0iTcK8m4R/m1ntZfFn/rr7lM025TlNgJWCtW5goT5Ikri3RDEV5DyCxByTXAvtSDVIUNskaFFFcQp3m9/L469J5WGI2Gk3QJsxNYkS0XRvyXAPDMs5Wb8k8+H5R4niTMO5nM95FYcymjHp+5q49D2/QCe3rQeE+ruIbnG2vAJCKGNFGBEvaxKnJZgLhD0icxlJgwdl/Dz7w7gVBcPEjZri0xYW+rBSSpqA6T8hIAEORJHtNOPt1pSeO2vFmQY4Sot+M73/nnRj29Z6YUtuh8/ejYIvzYRrklTYCHBrVEyO71rOwaTtSjmnHpvgo9+BE5qoe+ItrxIODUkTklwLWDCmkdbRMahXi/KV95GvishFQoi3H5uZklpD57+lqbfN0Y02fQ27v7ZJsTOy9jyV/FBcpvKVcvKn7znkcXIy23AUcq2R844UbR4JXKnzYbVW0h13gBMVFXs3bFPn56TWyFEKYlxY7rbJPGk3jSkDqPL9qcdIiw2K9JhP2z5JcitmYuim5bjeKMVrVTGOphCouzz0IPAzZX4iYeD87oDZCfWePAv6/9+kgfhNzDU1IU3t6TgsiUhxyh46I+pFbjKp6No4TIc+vMpiNIQTLGtRM2EAZaA8Zkff7ISSiK+BZuTOH6cR8ktK+Eom5rpvcqQEzFYBRn/s4kIHjAqaAfJxAfuQ02lDY/z3HUGWC5g7j1L8ZXpFYfJ67vw9mZgTiXd1GOHyeHWBSRHoV4R44h1nEEylkJq8AOKQFTTsEfeOTyG2gnQgEwlI8eyAjSR8syxFJKJJGJtTVBYg5N8lP0KWcjxoGiCBVWkBTZvhtGlo6yybCmJ9xn4tpdDwXUDmEO7NS0PT913N93GHMfJT4HfceuReHgDCi1hRDvOjxS5qizBU1ZBGtKEfZvfAXKtSPjTqP/1AHY9H8ThegmHD5IskxTYnTx274wibppKNCzSrx0uy6MdzShyJBH82pN4KXAX2o8aTSozkfOL96C0woYN/PUKMqSp5yxbiHunziCmkLh+fvdEHH3spziWX4a7Kk+AJ7pyXA3JObJOLlX3ZtoHcp6+tn4c/8MQPtlK6sRRjq99W4PVweHEx0F88FEU86bGEQrTNW6PTk81ldRb9fqTXRICJ5esxR+9z8F23ym8+Po+PFMdoLmBRQuBhTOwoe0wXvKr8F+TBdkJtR48cfcdsLJfB20lo9TPegypsjK9+DzCz4dFMPopzK8UKYGhE/uRGupG6z6iX6+AhQ9WY/66yXD5BJ2e89f4sKf2YTzR/xia+51I955D8NRBsmCmmqW6yUJOdkC4CSrRMjFtBj4p/zIoOOtUZVZcuxplE8xYd80UJa6XLqnDfTVUIrUQTY6eJXou34gpyRa9M92/8qvo6e9Hqq8j0zo0w1M1B66q+VByzbjpHyZi/g0iVsxpy/Re0nj9k0pswq34dNaDqJcnoWjWPLim1Oophqc5xM4z6EqkEGCPAEj71klH8cuVf8RHB0lQZJqDixcDMyfjUctoD/3qAE6y47blN8OXEjn53R28+vm1nDrP0aRulO5Xa5KnNOv0KRAJfVqRNc0qaDlWSvepiCb1tqBqpk9OhAUpGjFL0ZhViomCuHFvTfhbZ++VYha7ZEmFpNSEKVKss1kTlLiWY5FVzWbW0hRJ43NuRs6kAtQlD2KjeL82O79Tvf02Tn33PU5VY5zkyOHk2xahhnxx3uXW/78CDAA3J5rmrHo4bgAAAABJRU5ErkJggg=='
 
 EMOJI_BASE64_HONEST = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA+tpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTQ1IDc5LjE2MzQ5OSwgMjAxOC8wOC8xMy0xNjo0MDoyMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxOSAoV2luZG93cykiIHhtcDpDcmVhdGVEYXRlPSIyMDIyLTA5LTIyVDA4OjEwOjQzKzA3OjAwIiB4bXA6TW9kaWZ5RGF0ZT0iMjAyMi0wOS0yMlQwODo1NToxMCswNzowMCIgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyMi0wOS0yMlQwODo1NToxMCswNzowMCIgZGM6Zm9ybWF0PSJpbWFnZS9wbmciIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OTcxODg4QkEzQTE5MTFFREI5NzBDNjdEOTlGMzkxMzYiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OTcxODg4QkIzQTE5MTFFREI5NzBDNjdEOTlGMzkxMzYiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo5NzE4ODhCODNBMTkxMUVEQjk3MEM2N0Q5OUYzOTEzNiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo5NzE4ODhCOTNBMTkxMUVEQjk3MEM2N0Q5OUYzOTEzNiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pg/oPlIAABXCSURBVHja3FoJkBxXef66e+5jZ2d2d/ZerXYl7eq0TmxhW8g2xuIyTgKB2KZIKVTiFAmQqlBU7CqTAxMoSCioQAyGIk6AgDE2tjHGcWxhO5J1WLJs7UrWtfd9zM599pHvvZ695JW0Qi5Slal6O9s93f3ef33/9/+vgf9nn927d8OyrLnheLsncHFoQJMHqGtwod600MBTESgIayoqHA6oHG6es0olFHUDhmkiweMZjpgKDI8UMZYHRk2OwlWu56oF5ILgB6I1Kt4ZcuO2ja3YVhtBS1OzWrumoxqR6gA8bgOaPs5r83A6OWl5VgoIXQclBCgkcjlgKgacPkfJxjEyOoX+rn4cShXx7KSJgxkgToX9bgRUhFkUbGh148+2tOH2W2/VWq7Z0oTmjk74Gjr4ZIpdnOKqzwD5Pv7PG4zyzdaChyhvffb7xR8TDakYGgaHsPPo6/jsc7/Bue5+/HyohO9OmehZrqDKbyNcWEV1mwv337ARe+/4g6h/x8074W/ZTv9spkA0QfwIkDzE//ts0yi/5Uz0dTjte+PU1YFXgEefxMyJ8/h2bwlfmdaRWioG9+3b99sJqPLqTgduWBvB9z75J4GOPXe+D2jYScuEgAz9KvZrCnaMfrfAf9+ujxCWgT3FaR75BfDc8zhyNo29p0roWmjNCwVctotqFG6TA7fWrW/5+d337gpuvuX30Ws1I5ZjcEwzYKjigvFhFJWPo+D0oUTVF4gljD56pEIPdcnvpePY4q+FshwG7yrwuDg3vMjBb2Xgy2fhbchAvyuFFRsTO0o/OvqM0jv1oa4ijl11DNYC66o3tv8o8O3/Cg6vbcNThLlJgsR3RoCBnFjlB/H2Y/JFLFnD8QGuqfPVpmvufe9Pxs9N7Z4ERi4Ggpf9BBQ42msC/5L9/MM113e2wUWBMgytb43PCvc7THSWBCAgC4yv2Y6uT39/9ZaI+6sBdWn3WJbOm1XcUfPe6266ftdKXFPop7uadMnT+MPkG6hxZxFS0wyPgnStRcMqcFZTuqaTgemYC05rEQSU5K8ajyxeraKgzD5NOK79f54jYQQQ1/1ImAGMZANIpiqR2xSG5x3rPrbiv197sNvEy1csoE+B1lyJv/jSLWfQ4XiUq2GONumbyQfwUW0M6QFiy4ydz0ReKzIdFMpDF3mOqcHgyOgL5LoQyhU7N4qh0QUr+O0iY3BzKje/HURSJ89Fq3ksaAPDo4cOmeMcTgLPq+tV9Zv78efE1JetKxXQq2D95rXYuWbrBq60kqvhI4pdiI+M4bv/BrzCjJBI2YJYYqVyqLZ1FNtC8rw8voTbCTtb5eWJb8uc+194gZOPDHP6m3cBez/O0z56KRXooOJWt5lY24L3vNGNRiLq8BUJWKvhtndeC5dSudaeWLWQHdmPLzwAHOwi52pphlIbpCwMAgpizQqolENcylkW9CISKlggmPw25f8WXWD2Dp3PHE/M4OGfDWFy2sDH7+bT+XiRIrwUtqMDVXXd2MXD/1y2gAxcNFTg5vWbKnhlrTAFzw7imcdO4cgJFZ5162BWVHE95rz/zfqIaUDVi1C4Aot+Zzpcl8QNIZSq2zFqCr9TeU8uDSMel56guD3Q6lfA6/fh+ZfeRGenhXUb7ZAQemlro/uquNWlXIGAxJLK1jp0NDRVCf4iJzInj+HFF/NQw9UwAxE70C68z9BhuLyIr9oO0+OBd3wI/rGzFNK5JLdQjRJ/cyPV1C7d1DfRD7XEQPP4YDkzMDNpWIU8jEIOSrSe5DeIg4eTWLvBvl/EeDVTx8oIrnGpMpEYyxKQymmprUGDr4bRbTHiHVmy36M4Rwam1tNyS6CGQsvpvgqcuvsBxNdvl/Jo2SxWPvEtNO5/BIawziJllJAP1+PMR+9DsnWTNEdwoBtrHvlHeKeHYAVDMJngxVRWoQAjm4EzUo2+viSmp8mHI7aAIZKpYAWa0rqsXgaXlQcbnWhsbCA+u6kehdov9ODk8UEkC1SSv2I+ZhZao1TAyPUfQXzTdptg0xCG24fe938K2WirdNvFCjHR+75PIb5xu3Rj08l0sGErzn/wM3bUupwcHnsuEeMUEIEKzKQU1lV2HIqfBOqGw6j2aoKTLDPR+xWsqI8KO1faiJg6huOv024ePyw5qXlBMDGPOV2Idey0k7HwSLcdZEbQh1TzOmnhha6Zq2qUriyV4SgP/p9s24xsdYuMS9XrncsnFoPOVB0wXVTa+cXTV1dBbXKjbtkxyDXWRcLiKtrfTKE0fgL9Q5zH57eR0jIWW4MC674QihXVUPMF1B14Cu7EBCY33YI0Ya4Qil4wgYFSsAqlUCWvzyNy6iAByYGZjmuhBwLQ/SEok320oHsu5Yh7TMOC6vZieDgji5XZTzBIxWQWW/ByaSJSESxbsNSD6dEJxASocfKl4dBijLmlm3Y+fD+irz0rF9bw8k9x+q6/g6k5L1CIBd0TYGinse4Hn0fkzQPy+um1N+D0nX8r3VVYXyEKi2HNomypCI1KTiSmkGIO9vvLpEQYOoPIsgWkf/tdrjLDzRxBPG4hnuSE1d6lSQlvUBnxbb/8Jqq6X4TuDc7F5epHv4wirWU43PP6YCrQClms+tlXaL39c9dXnfwfrP33eyl4gu6oyZQhKU5ZQEmZPF5kWCNmMrblZLvEzkSB5acJhUsWUWpQqlw3uR9xRldlU8VaAmAsuq1YlFisuQAtLaYHRzYpf7PU+SkFqASH30QFUXNWOJnUGeOh3uNSAcJlpXuqC+BCxD4VlSOA0bPnvFfowK4ar4RsK7wr10PJRpFM20+x1EuXD3JRF55TtYtcTDKuvjU3vsWdFXXOa6RyuYaSoZDzWnMCzkPHMlGUAWzIh6aPS0ARrGGea15h9+eSXRNlmddhMaXjOUOfP23YmJdftoB8TrZQ4F2FoTnW/3/3ubxCS3aKzVxJwRtLpecPPJ6y/5OeWaZ5Ua3YyfwqLCyeQWBamGcXzSc0LasMa64FKT4523bxKxFwIp6YP6iosP1W+IW1MLrnWImOQqSeMH89VPqzXOQVCCruF6gqyMDUppuRrWuXvFbOuYAgiHgU51wOS9aMsx6bykiBxpctIGN/cHJ6PnRDFNDvNqWzm7msnZcWCGkRkNwzY5jcchtO7v0K0k1rpTXFogV5FrxTLF7QM/nNY3FeK+bkNYIkjG/dg+Of/j7Gt70X3qlBmSIszifGXBgKUKI/+lgmiTEr4EwMGCpgctkoOlTCGOtaroaKoFxVZDUR5vyMsB5h2kwmoJH4zllJ5BUuuv2Jr6Prk1/Dsc89jPCpI6g6sQ+B4dNwpWK2hYQHEGkNtx/FQCVyta2YWbUD8TXbUayrQeToK1jz03+gF+RZTbhgUZkSQaQy6Zo8h+Q0BN8QXmXa5aPoLMRzbkwtW8CMidGJSd5gICquDJMENZLp9femoNRXwpyagMLAVP2BchUu4N0FR2YGmx78NHr33IORXR/GzLYdDBBOxtLfkUtJy1lMA7qXdEys0Gt7iHt4Aqt++E+oP/iYZDmC14rVi3JpkSuLjE72E23krV47/4uETx4+7tAwuiwBRbFbqWJoaAx9Dz6E6C27SEz5wNYWVvKnmPE1GlVYITYlZ1A4kyJZhyqJuKqTvfzia6g//CSmr9lNC13LsqgOJVEg8zqFFtEKGQQGziIwchbh0wdReeYwXOSugu6ZQmG5HIxMStaCs8ACCq0JbeQzaFs9n+ATxIrJGfSHlMUouqSAQQ2u66Oubzgc7o0Fl6flN/Hd2Pf1fQhHNGRSOrzmNIqMHd3LgjSdhJGYYYQnJF+UjEO0L1S7XeE5dQhN3QfQSGUIqia4pxRQAkoOTum2Gbl2obBCGUAkas4i52ycC+TknAorfb9Tl1V8uYoCnQkjWRxRjGU0nVQTneH29fe46luRPN+NqpXNGB2pR7q6k35KbZ5/Cho1rUbbWYCmbTifXdQFWWvujFWClu6HZplQZn+nMCYVYSplrDP1xalgIUpLeuaAxnCwegexYgVQX2fTUoGkPb0yw+9XltP4bXSjxhEMQ/P4OLySvTs8LjidhGWfB03NXAtd01lIQYvWs3wKzFeeFy5wdgjXJSe1hPtxiG9xLIn0hdfOuuNsd014BAtsR7QOjnQMFsFNhLXIgWLaLDGovw8TDL7XltUX9akIqmIjb3aSBa083fKgfZUTFaESjh7vhqumBla4BoaPlQKJnVUsyG6YjHyRu6wrTPhCOOHqdFfF6ZS1IMMdGmMaQ2ep2GnsYH18zSbbekLIXlpvcAwHeNeYshwBBaApS5BjSw5NdqI/8YkS2totvPDiBNK9DAAH4YxVgBJgVeAm5aGlLZldFHs7WQgr48pa3NkWOU3EpGq3HVXFkoWzbGblmWtjY9AIKE6zgFAVcOsfAdu3l1uGpq2PE28AfSn82CinyMsKaMnKR12SQilUWTbnkLXXzTcDZ4tO9PQB2ypzSE/nMDk1hQRTbV7XZL5ShFuK6kJUB8IiwlXLMScEkQlc9D/lVm9JphCZxJ2mzHG1TazzmH+7Zlxo77Swe1cJmZwtnHAy0Zc5fAwnR3Q8c9m9CbFF1unF7SEVH7NUJ7Vkx4e6oN0nLKsbqvS+vFiLpcBbpWDPbQqiQQvTYv+T5WNs2uDIIRbLIZm0t6eLJcny5sBR6FC0S4WyRD4LkUSIFkkVLRWpspN4Nevz3kkFp55VUTSMuT6ocM0Sn/X0U8CZadybs5C+rIBCuC3btz1hMgEnek9SJAV6NoVkz0mbAAsrCIvQ9cTiXJTf7RD4bpctwhgVIeZPLnJl6+KwEq19sbi3CFjehxBhtzBcZdowy3v4uqjWLATKpaywnIi/xx9jTn4DD/SW8MSy9gc9Cv7YVdsMd90KpHp/glDHZjh8QeQnR2Q9mDjzOlykVXrKIV2jbSWwusHEmyMa4hkFdSFLatUwLjKZZm+iXOD1Ughdv8g9FGYqqcKgEtc0mjK8exkSTz0J63AXvkjh7jesZbyEwOSOSMAVTfadQXVtCzTyMoMJNdC8Cl4GgkDGUiaJ+MmjmDgfm/7XBxF7141Y3brGRA0FO9avoaPJlEIY5tLguRCUlwOm4lk6n3VsQENL1CSzMvD448BLB9B1bhr3nSviSXO5b1k4TPgramojjoowJg49h3wgisz4MNLjv4KvqhbBtrXSmtXbdtGYJdfkmbN/9f3H0NoetfaGakpbe2MqDvpVrG8z5WaIcDvrKkpCEa+iB3T0tIrJPloua5Qe2o/Dpybw8IiBn2Stt76AcEkBLdGNcji9lXTL3PigfJEg5fIix1Im19cNb7QBmtvmm5GOLcGB3t53dqX1+3qG8GBo1Nza6DZvHOjGrtYqtPn9qCdAVIfDdjkjmIbHPb/pVG4OSVeW2zYCsJjmCgWbNM/MsFBJYZIce7Q/Zp4tlczfDOWxP2ng9exVvSdjERLpG17GoZNQnR8eRpEwF1m3Fa5QhAvR7ZxF39GcjqjQAic0sjqOjHIoGfxz1wxcTHX1XHhNHfmAT0MFj4MuBU0hr+vzpUhDaC4HEoqdMyNj8bz+5ZKFGHNYPGsgOVZCirqYZIIfSc72ha72TSdOlzALuYwsLjmxg2quIUspUK0hwqJV3rMTeUwn/zRz+e6liEDSkk34fjGmTElBm4V3MPWM1oRotIrgfJBRYa60mZ9K45WUSZi3kOXpvuyS/bGrFJAOnZ+KxY9XpePrHHLPz4CXxNZHZmKKClwp4zj9LDNwLj+QxdNLtsKd8NY58I6QhtsjFZ5bnRWVbaqTlS1XLkzhKyUX31Df0rolah3SqVhFL+bVUqEvnki8FC/gMXrFoZkS4m+LBXU+ZTKZ/1JN16t7Auuvj5QYFOaCxo9CNuL0+hkcE+g7d+YbdNaBTS7cQ6q4lknaz/U7SUICPlPpDDY1rfMTfZ1V9XAGQljMiqy3tAOLTJDT5JjZTNajWmZnKJfsrJwZ/9PGkYFzadM4qbllI0nnkjIs8nsGdfwopi9uTSwvBjW10pg4m/T7RiNVlQbCgTw8Lksm3HRe5D4PpifE2xOGb3s1fvjZz7zjw2vW5OAuvonJ6RImuIyDh4E3rU0IsBo1BfE2bZcXeczkcGjmfCda7OrSD91UXm11NRLOBOLxOEqBCK93YHtt/6rdN2JVNRlOY43oqpNvE/++/hBuf2YA78lb0K9IQFKt+77wObSu35CGy1supmYVruro6UljjAX8r57GX/pqdmLPXtYsoy/Id1YayRlj9L7zPRa6SQwt2Vo0ypCvIuQvIVJRwPCUj4GowMXnTTtDyDh8qCrGETBzCBN2PR4qMTaDFPNEqNbC1s3ko+HyC0BUzMqNdJ1B3PTa97Cnz8Avr0hAp8NS17HWcxHaUXhr5ejmemv9DJtqoOM6ksX+hxi8OVsRmv2w8SmV+dI/t3eRL2rYsGIGd97Sg2g4h9fPRfDD51bhefcmnA63o6S6ESlM492xI6ihoB7Wn3X1HpKKPAbGyYfN4tx28yzwvPsm4GdP41Njw3g6b126L7lIQBahjme0nXSPKFKKV76AY5ZJtnhVJ06Xdepp9AXPYe3084yK3HzJbIluG+M47oXW6JOxKzZqNrdP454PnCZgleTitq+fQMhbxKsvd6JkuuXKY+4wnq2+FrdPvAw/n+kkP/NVVCLV78RMooiaqoXtayq5BbhxB256aQgbOOWJZQuYCdZqd4ceRwaVS9f6okNI161v/THuSN61eEtB9EWmxbsrPjiZ3QUnravMY++es6wUmNiSbozPeLEimsbqtjgexqP42MtOvOpaK1sVCWcljlZ04KbYMaKtxdLSi0zJy9jOYM3KcjGzwFa3vAvuR57Dnccy+Bv9EjZUF0rq1DQF6uU3IExosjpYKJxgI+PEtZwVguZyyjhbWZdCKJSXr5/0jAbxnac7JFhZJQ3t7THcVfOqXfPIB5gYd1XBKKcjF0uVlF4h3vxdPFfZXdetYw26Gr9HDPQvy4Ii/dYoeceO4gHEvE10T02+PyZwTpEFkmhHsJY3mQsKZ0SFtEjAPCcdHuXczqhsMdjlkF1KmawfO5oT+OuPdCHo1Zk2SH+STryRrC/zNkNu00WLM0RWQ770owmm7Y8QuXtkgRsKLO5kuVgrXrcDa359Atf26njhsgKWiN3B7Bh+kHkfvB4XCoZ7TkAhnFjs4AQrilweh/oNFGoX+0yC5ebgsAJ3uGYOYNT5bh9cZPO14Zx9XDTx9/tuwH8UbiBJFeSBaSI/jusSXdKC4n6NuVPzV6B3WMNMyrAFXPihTq7dBqXup/jQYAIv6Jdz0flOGORLqEFymzDzaxVi/J5BCALKM3BQw+KFp5I+bz1Ry00w/gYng3CHwnPkQFOtxQUsRzqj4f7nbsQXYx+E7rG3s6P5KazJDCClzW80aFyLi4x9ZMaPkTGbiC+KeYJNK4vqze24w2O/Qbrk538FGABNjrQEuybAYgAAAABJRU5ErkJggg=='
 
@@ -24346,13 +31188,81 @@ EMOJI_BASE64_WARNING = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAAGXRFWHR
 EMOJI_BASE64_JEDI = b'iVBORw0KGgoAAAANSUhEUgAAADgAAAA4CAYAAACohjseAAAWwElEQVR4nM2aeYxd133fP79z7n3rvFk55FAkRXERJZGUTG025VCihDpybMCNHWfkukUSoC7gwKqT1C1ctzVM0QKSxq3hJHUKJ06AFG2d2lRqeZUly1pja6loWRspbpK4zZCzb2+5955zfv3jvtm4iZH7R8/g4g3enDnnfH/793cuXGgocsHvl83Rt5/z/8G45CF36ed6eiluil2xN0SqDdLxM0y98ZL86dS56+wBOQAyshu5Zg6Z3EjYuhUFuO++/HN+3HcfcuAAsnUk3//Ak+hW0L0szFP+H43lABVB0Jv133YVvf/tmlRuWUPPlrX0raxQNKNMTbzJ6OFxbfw8TZNvPVP58vE9ivmiISBtxYflC17WMEsOonDHHUQrn0T35av9UmDPA7ibPbZF81M28IFV1NbfyMZVO9lSXkmPPcwp9/d6cOqgnD5eN+7nTdb+yYvye0dhYyccXb8SNm8wXNnVRV+xSKct0CNQRjAoBQGn4FTJAky5hOm5BlOn5jh1At50cBQYAxSTQxtU7C8DNFoEt8cge0OqczdKsLcY6CpT7L2S/soW1hZW0UOEscdkuPMYZ/unR6duqjz9w6/+5pUhbN5w9KYNG6WvVuuM1q3v44oBS0e5TpERrHHIEg0FheAhy6DRhNFxeOskTM6iZ0eZffV1DoyN8+yBcX58Gp7YJzRgAah/xwAHOSD7gEBUVXUdSFQuERf6qNkuU5USMb3U6MzKpWiqtb737MTmmzcqn/7bu1jVfw10DwCJMncwMHcw0JgUfIAg5/u55NbcZ9B1BrnJYlAMLTrTOjtPDbHzJ0/rHzz1DG+8foRvnPZ8fZ9wQhQUDOc4wuVpsD2MwwRDjBIbrC0Sm5gIEIlDJCUi01krUOlcS1W2h6lmp64687rxb3wbmXtNjHcWg0V4mxDWHgqaH1yNgUIZ3XgdYeNW7D8blI2PPimf/8Z3+d3Xj0RfeilL/jPGhD2qZu9lgjwPoOKNIEYQYxGxGCTIQiAQa7C2hEsdSX3IJMf/G370EN4CJkJtGXTeaQRpu8585pElrmQIIPl3hiCKIi6IZGpEoVLV8I8/quGGq1nxw++nX3qqKncfVX57r8jw5YI8D6DgQiA2WAMBEUWEeTPLjzIXYs5kFQ4m3TzCH+OK60hsRKYxjghFyIgJmIV1PRa7xIUEpUDaPoQjJlt4CqSUaVLSpik1Wia6qqHxp+p+4raR9/X81z97+IPHp+/eK3JGVUXeJvgsANzHvoDuMdC4iqAO1JD6mAiDkQXZe2DOW8a0m4ZZyUnzK6isuDxz/IeO+TUjBCXiQ2Sbu2+9/trPf/gbg6PX/tp9ewYde/fCJUAualDQ3YpNPANY46TpigQtSilSCUie5xRPQAjEmlHWBiv1LIlGlLRJjF/QxrxJFkkRWb5/qrl2BcVhccQ4tSQUcUT5DmrwavBiUbF4DDoi8dFdH3LRP/+ju676yr+7d+8X7//KIJeOrueZKFYcqDDd6in0CCboEr9RLBk9Zop+OcUameLD8kds5wwhBIxvpysNqNIOeWE+iABghLbpCmI0V5MYEAFjUGPIpEBmivioyJxWGG9VOD1T4a2pCs2RLpNeb/W19eazVx5xf7NPmGxL84JaPA9gQFQnm7U4SToLkWAUWXQlRUMgazimh5q0Ts/yre+N89AL0zQtZAk4D96Dc4s7Zi6PlABxlGMRwNr8iSKILRQKUIihGOefHVXYvhV23g5YeG0aLJhqBf/NHQwcOcbHTihf2w32SXBvC3Bu/7DYm3vVnJ1dWekpilir+MU8FlRxARqpMDZbYHSsg+NvDsChCOnIlxIR8rAkqJj2d0uE6+aja1vLIbRTRUB9HhQ1KAQlpAnRt6fZ9R74N79nSEvQSoUE5Ybrva5+nMGXx/jaE+AvFgKWAey4ebU2/Vxsp1qryleUIZglcTDXSADERphKGWpgV6/HbOmGoqASoSLIvLouFd/aJ1IxSPCIehQhNOYQ58BabKWCTWZ54rnXqX495WP/RHCp4lLMipXIurXs7B1jjQin28XdeWlj6fm5k/sC42mllLT6bGRBrchSC0XbP4AK6gJmfAqPIYvK0Gpi5mbQzKFpimaXeNIUzTLs7ASapjhTAOeQ+hzpxATZ6CjJ6dMkUY2Oazbws+fg+AkoFsF7pFRG16+n0g+3Aew+B8sFNbg3tuHdz/5WX7WMMZHV3OBkwYfDErXkZuYYev/HGer+IGlPH7VTB1j/0NfpPP4KvlBa1OQFhopg0yYjO+5m6M6P0+y6gsrEW6x77Bt0/vRBMqfgHX7kDLa/n2aIeeXVjHVX5v4sgr9yLVFvmR00eWDuIolqKcAcxXijtzIgmMiqaO5SS45F0Byo8SnT/ds5uvbe3L0dTN6wk7nV17Ljv3yC0sQQIYovCFLFECV1xrfezsFP/Md8Zwfpqn5mNuzg+qlRqi88gi9W0SzBO4909nLk0FnS9wnWKs5Bfz90dbCFJrwA7kIIz1NrVE+6yiWDEqkoSJ4CF3SX83hFbURj5UakFSDJC0ozk5H1dzO6431EST0P/xfWH2oMwzt/Iw+LjQy8YuYyQjnm7O33IMYupJrQamG6uhgahsnJPOp6j+nshChmPXn2aeecCwPMtZd5sUlai4p5xptX33zS1rYGc62YPECQ2wsIKiAEfLHazgsXjm2iSjAxvlxFfECNBRHUCBICrtIJ5UoeYcUQWk0oVWikwslTShTl7looQq3GaqB4sUrqHBHvMyYLlSgSgoqIKosRvh1gRAkiWJdSmJ0glGz70B6NYzQzdB9+nhAXQS9cC6ux2LRB17H9aCmv4kUDKhaNDd3H9mONyfUi5OTRRiShwMjZPHeq5p+1Kt1A8cLwzgX4l48acaFgrVlQ6qKB5vWMtvlNMBHdR1+g+8ALYEFji3FNNjz45/QceR5XrCIXASga8MUKa578W1Y88zgaG7RgIIKBx77H6me/g+/oXpJuPMF7KFeYGAfX9jZjoFjClqFyMYDLK5mhSTHr1Yoh9ynCEoDtvdrJWY3FNqfY/tf/ipl17yLt7KPj1CEqZ44SCuWLgltYxFhs1uK6//7vmf7ZzTT71lA5+yZdb76ERjHYdsmjuUDVB0yxxMxUXhm16wlii42h3JzXwjnZdznAbcBcrjfVLJ+7LIzq4v9rHmgQoefQs4ASogL+Epo7F6TaCBS6Dz1HT/CojQiFEiCILFlD27YURTSbecvjctnL+YQ3Mpq3yDyxicn5Ui7IFE+Kw2vImyvt0sqVOpCQ5SYloJI7yVJyu/DrfAWDLKjBlyoYl7UBKxfqBiggRshcvrU1+VQf8Bkk5+yyMJb74ODW4KuFkIrFInRRpSZlDBZFmdUGU9ogdSmaOCQJoILJEpKeK0i6VhI3Zojrk0RJHZMliMsQ75DQfnyGcSk2bRI1ZojnJjDOUR/YhJpooSq/aI2gi3JShSQlNKF5kdnnavC+oPGvt7zLaxiDyX2wvdpCodbeXQA1QpQlzK67jmMf/gx9rz1Ndegw5bFTFGfGiJozSJYiwYMIwUaEQpmso4dW9wDN/vVMXXsLgQI3/MWnFo8Slpu5AOoDcWXRa7yHZos6lw0wtsE/9OFm5gXbpgDnJnk9x+oMSohiqsNHySrdnNn9obzkTUCcw3gHGjDeoSKojVAxaBSjcR45KUL/k48Qteby6Dt/+hDyUNkuLnCOajVPDyKoS5CZGUag3fu4BMAFlYRSoZ5mUBEQXe4Muf5CPjm0WazmwaU8epzaiQPMbdgCKTmQKMLH+RbLKPd8rMoU03KEENNz+DnE+0UfdekSaRqsNfhWi66unFN6jzbr0GoxBLiFEvmcsdwHg+LL8Vya5UIX5n/am2peySwbmteWNmmy+pm/Q9uA5sM7bW6Hbz9hiYmHQCjHlIdOsuLlx3HFCtL+e2g1Fx3NGsQaTFJnxUqwVjEGnZmBLOM4wCDYC2lwGcD3ua910VdptnLhiZwzQaXNCFXbv7fJrSq+XGNg/w9Y8X8eR7siRAPSJrM5GhazlCriHVq0SAhs/s6XiVuzEBfAGrRZR5MWGAtB85osSyjZjDVrIc0gjuHsCMzMcBTgjYvQpWVfZgzVTV95qhXEawCD6FIvXDBQ7/Nd2ryOkPtZEMM1/2svq556CC1btGohWkwHiIAVKBq0M6IwM8a1f/U5en7xGJkawuw0fmIMPzG+KBgNSLkCc7N012DNGsE71HuiU8Mw7ngFgY0X6ZFG7bMLgtZxq03VWlcsTIUgfTkbXCp4bVuegvOEep0wdhaygNi8YWRCYNOffpKeJ/4Ro7s+wsyW9+A7evKCGpAsoXzmDbpfeoxVP/kflM++SVKqQZheNGtj8icEsJaoVMQfH2PzTdBZg1YLkgRODzE3Cy8C7Lt002mPwF4t4tY7ExVCR2HSOfpMaaltkWuvzRzQsGBueSmVd5qC5AS595nv0vP8D3G1XrKuflylhnhPPDNGPDOGrc8QCiWyUkeeQiAHteC7ebli+lYSpXVwdXbsEFSVKCKMj2KHz/DCCJxt051LaLA9BMkgiNaKc5kTUMO5hFcJ7VZYcUm9GJbJTwRctRNRxTZnieamFpiFGovaCNfRhQTNI+c88SNvHRIXkFIZW64QhyatQ8fYuhGu3pJrr1qFo8dgbIJHEditl9lVSzJnjGCp2JabtZkocV7vzpcPimpA0hTjEiQyRL09hNQTQkCdJ2RZ3jSZr0hsRLDxEiEu+bQWTIxEESaOMTa/EcFn2FYde/okOjvN9qvhnkEwonjQNMX84hXccMp3EHjyEncU5yR6wKkQmSClqKlB4pyTSW45okRWMVYxvkk8c5Zw9DV8KGI6qthCASkU0FK57Uc2/zynJlXIzTIEcBlkCdqYJTQamKRBOUpy1l6Guz8q3L1L8QHSFKoVwhvHsEeO8uNT8Ooe5ZKXMMsAxoA3FkIwUojT4ETbHU7aTDC/jYmEYpfl3TvhqtMpZ08mjIzNMD4GcxOQeXDB4EPeflfMQjtRCFgJWFGsCcRWKRehrxf6r4YVq2DzBnj+dMxzb0UMrE8xeBoJxDHqHHz/IXR0gj8EOPA2vOIcHyyowbeRWI3iglOI59eYZ/SqUDBCrdvw3l1C5JVWJqQpJIkyPQ31uUCzGWg1F7vdxkBkoVCEchkqVejqhEpViGMoFkCMUjDw+rQSsvzxHqIILZXwf7eP6KWX+cOXhb9HMW9367sMoKIxBFExKqqq3ouaoIEgKhBCgBAweJJg6Z6eIZ1WmgasUeIoP2R3V95vMkvS38IeuiRQhnZjW5UQoNXMi51yAerNvJ2/slu1UsWPTRA9+L+JHn+Krz2f8R/2gNl7kdRwAYB724V1OB6QOYGQaqtIwUYRBc3pksNFio+gUlBGHD6emJOqUZkWEe/z0scvkecl2qLnROd5AUMhQhspHBq24YZNnpWdap95hujhR5l+/TB79ytfAWTvMvb9dgDbzPSn8scndupnR9KkqX3P2uJr488zsDmWG3uuoTLQycj0uDZfmaSxqi419fbFEzE3FaHWC0bwqoTg8+jf1pKoLntJZP5MaiS/vReDGsnjkc/dUx5/NcI31cYjjq/+OZMHD/OtiRZfOSQcageVywKXQ1vcV/awR77L6LpVjf6PXP/F1pce+97D8URrWne9d5fExZiXXn057Nh4Pa1PDZw+3HzlWPd9P+vf0JrYeMUayn090NeT56i4fUs0nx3MEnzz4S64vFmWpdBswuQUjE3A6ATZsVMy7Gf1Z1OTPPZixg+aMIS8szctlqdxVRERVdXS57/w+YmHHnqoPHxqWG99961yww03cHrotB8+edquvfO6r/7VfX/26U9nWnwAVhXhum7Y1FljbSGm11qpmoiihY0hLtyshfI8t1PxmUircVyVnwel5Z3OZRnTcw3OTjvemIXXI3jz1DyJXQSmXCIdXGwsj6IiunvP7ujOO+90N95043et2HuiOArr16+369at01OnTtpaT1erUt3wn8iU5C9uDmd+d/8JhRMgMAtLrMfeBR9lY/c3W/2bVVwqwca+XB+LGDn8o8fr/Mv2RL8g6zax3fMFzIF9FCp1THEFfvV+/DsBdx5AgHu33Wvu2XtPev/99x8eHxuX4eFhv2nTJuuyjAMHXudj9wxmfa8+0b8VzvzlJ3+eAuzZg3lkr24pFvhgoUvutMXqVomjsgYti6aURg7PW0okGtD+7t+6e6X5kIhR0vqItlrPM6M/SlKeeFKY2ruXwDxLP85ii/Yy/e6SAGlL9IpNmx6udXT8i45qdVV/f79OTk5KFEWsXj3Q8c0H3npu1ZrOAxvczP+ca1B+6k/Mnf3XDeysDawrlletw3Z0Qfs0QfNG70KPUwQRU5mdm6tMTk6A92sKWetGNzXyyeLU2NCus5M/qtQ4EgLqHWm9TuMNx/NjwovvBORFLmQkbEGv3fYrNz8yXelbe/DVVxgcHBRjDCeOH2dkahomp7l77S941/WeH/y4SLJlkGr/Cu/TFA1etH31Ygni2nfyRjQHDGqs0Gi0GB8f11aSBFOsWHPiNfnVTUfYeI2wskspxTCXwtNPk377YT623/Pg2710cAEwy8fg4KCActN1qz+79eb3rJucmPBpkrRrY0u1s4tqwWojREEkuDtux61c5XyaqIakadVlVlWNVS9ekbNazfsf6mk2FQ2KcyqNupdKuShXrF5ters6I81SUZ/ptnfh7r4L9947cDftwt3xa2Sf+30KW6/hfqDwLf2H+eJ5APc98IAHJCqXN9VWrtauzpoUS0Uq1SoaAs3Tb1AOTrprYp48uj768lejaHK2bIvVUp77RIgIJET8kKv5Ntv4iWwi8cK2rcpn/jX8we/Dtm1Cva4YA319faxevYrUVOXkKaJSRKRNIj9LlI0Q227CB+5i+1XwATHo4OCF+y+XA3DeZOOoXF3ZbCWiIQgI3jmcc5T6BujoHyDF0hy4mqcO9jM81kGhHBNUiQg0KPB9tjBEN+A5Rj8/5mp+/SPCtdco26+Hz3wG7rgDGg1QDVQrZaTYzZkxSDKdf6sEGwEZ+v7d6I1X8gkU5l+0fUcabA+LjTqSLMvrTyCKIoy1RJUq5Y4a1ho0OEwEUu7GxAWMBlrEPMwmRqkBnoDBknFKe/inf7OZ4VHJC28Lv/M7cPXV0Erye8VSdzdjE8JMvX0ybb9X08L0rkVuu4X3d8B1e7+YXzL/MgBFA7ZYLFKulCWKIowx1Ot1VJW4UKBS7QDvMCFQqNVQEWI8J+iihONWTlFA6SDBqyEuOfYf6+WR/R1YG0jT/Kb29tvzisaIUOqocGaqwvgEy+59FASLu/sOCjdU+TgKg4OXd/1yUSkoOaEQMTjnaCUJcRzjGnM0zpwkShsUCJgoIqp2g/ekRKxnCkvgCL30M0tKhDFK1orZ0DfJHdfVUTVEbS86cSIn9iEECpUSk0knw2fBhcXzWwM0Mdu3wvYt/AYQPfAAl3XHdDGATnw209lZk2KhKL29vQwPDTE1OYl6R6HWRamrlwSDjQoUe/rRkLfmizh2c5wuEs7QSSaGkFk2Vyb43qePsmF9WLidffBBePRRKJcF75VSqYiLezj2JjSS/PjzjCQ4jO1Cb93Btj7YpQKDl2Gm507QPV/4ggHS6ZGhn2Zjwy+vWbdu7L233UZHRwe1zk46+gew5Q5KtS6KWZPIJUip3L4uAxAOsoITdLdb/IaN5Sm+c+9Rtl0b8EEIAY4dg9Wrobd3kWLFkeDLvbx5UpiYVubrA2hnd8Hfcj1sr/GbBBjZ/fYa/L/yOX4JryMlpwAAAABJRU5ErkJggg=='
 
 
-EMOJI_BASE64_HAPPY_LIST = [EMOJI_BASE64_HAPPY_STARE, EMOJI_BASE64_BLANK_STARE, EMOJI_BASE64_HAPPY_LAUGH, EMOJI_BASE64_HAPPY_JOY, EMOJI_BASE64_HAPPY_IDEA, EMOJI_BASE64_HAPPY_GASP, EMOJI_BASE64_HAPPY_RELIEF, EMOJI_BASE64_HAPPY_WINK, EMOJI_BASE64_HAPPY_THUMBS_UP, EMOJI_BASE64_HAPPY_HEARTS, EMOJI_BASE64_HAPPY_CONTENT, EMOJI_BASE64_HAPPY_BIG_SMILE, EMOJI_BASE64_PRAY, EMOJI_BASE64_GUESS, EMOJI_BASE64_FINGERS_CROSSED, EMOJI_BASE64_CLAP, EMOJI_BASE64_COOL, EMOJI_BASE64_UPSIDE_DOWN, EMOJI_BASE64_OK, EMOJI_BASE64_COOL, EMOJI_BASE64_GLASSES, EMOJI_BASE64_HEAD_EXPLODE, EMOJI_BASE64_GLASSES, EMOJI_BASE64_LAPTOP, EMOJI_BASE64_PARTY, EMOJI_BASE64_READING, EMOJI_BASE64_SANTA, EMOJI_BASE64_SEARCH, EMOJI_BASE64_WAVE, EMOJI_BASE64_KEY, EMOJI_BASE64_SALUTE, EMOJI_BASE64_HONEST,EMOJI_BASE64_WIZARD,  EMOJI_BASE64_JEDI, EMOJI_BASE64_GOLD_STAR, EMOJI_BASE64_SMIRKING]
+EMOJI_BASE64_HAPPY_LIST = [
+    EMOJI_BASE64_HAPPY_STARE,
+    EMOJI_BASE64_BLANK_STARE,
+    EMOJI_BASE64_HAPPY_LAUGH,
+    EMOJI_BASE64_HAPPY_JOY,
+    EMOJI_BASE64_HAPPY_IDEA,
+    EMOJI_BASE64_HAPPY_GASP,
+    EMOJI_BASE64_HAPPY_RELIEF,
+    EMOJI_BASE64_HAPPY_WINK,
+    EMOJI_BASE64_HAPPY_THUMBS_UP,
+    EMOJI_BASE64_HAPPY_HEARTS,
+    EMOJI_BASE64_HAPPY_CONTENT,
+    EMOJI_BASE64_HAPPY_BIG_SMILE,
+    EMOJI_BASE64_PRAY,
+    EMOJI_BASE64_GUESS,
+    EMOJI_BASE64_FINGERS_CROSSED,
+    EMOJI_BASE64_CLAP,
+    EMOJI_BASE64_COOL,
+    EMOJI_BASE64_UPSIDE_DOWN,
+    EMOJI_BASE64_OK,
+    EMOJI_BASE64_COOL,
+    EMOJI_BASE64_GLASSES,
+    EMOJI_BASE64_HEAD_EXPLODE,
+    EMOJI_BASE64_GLASSES,
+    EMOJI_BASE64_LAPTOP,
+    EMOJI_BASE64_PARTY,
+    EMOJI_BASE64_READING,
+    EMOJI_BASE64_SANTA,
+    EMOJI_BASE64_SEARCH,
+    EMOJI_BASE64_WAVE,
+    EMOJI_BASE64_KEY,
+    EMOJI_BASE64_SALUTE,
+    EMOJI_BASE64_HONEST,
+    EMOJI_BASE64_WIZARD,
+    EMOJI_BASE64_JEDI,
+    EMOJI_BASE64_GOLD_STAR,
+    EMOJI_BASE64_SMIRKING,
+]
 
-EMOJI_BASE64_SAD_LIST = [EMOJI_BASE64_YIKES, EMOJI_BASE64_WEARY, EMOJI_BASE64_DREAMING, EMOJI_BASE64_SLEEPING, EMOJI_BASE64_THINK, EMOJI_BASE64_SKEPTIC, EMOJI_BASE64_SKEPTICAL, EMOJI_BASE64_FACEPALM, EMOJI_BASE64_FRUSTRATED, EMOJI_BASE64_PONDER, EMOJI_BASE64_NOTUNDERSTANDING, EMOJI_BASE64_QUESTION, EMOJI_BASE64_CRY, EMOJI_BASE64_TEAR, EMOJI_BASE64_DEAD, EMOJI_BASE64_ZIPPED_SHUT, EMOJI_BASE64_NO_HEAR, EMOJI_BASE64_NO_SEE, EMOJI_BASE64_NO_SPEAK, EMOJI_BASE64_EYE_ROLL, EMOJI_BASE64_CRAZY, EMOJI_BASE64_RAINEDON, EMOJI_BASE64_DEPRESSED, EMOJI_BASE64_ILL, EMOJI_BASE64_ILL2, EMOJI_BASE64_MASK, EMOJI_BASE64_WARNING, EMOJI_BASE64_WARNING2, EMOJI_BASE64_SCREAM]
+EMOJI_BASE64_SAD_LIST = [
+    EMOJI_BASE64_YIKES,
+    EMOJI_BASE64_WEARY,
+    EMOJI_BASE64_DREAMING,
+    EMOJI_BASE64_SLEEPING,
+    EMOJI_BASE64_THINK,
+    EMOJI_BASE64_SKEPTIC,
+    EMOJI_BASE64_SKEPTICAL,
+    EMOJI_BASE64_FACEPALM,
+    EMOJI_BASE64_FRUSTRATED,
+    EMOJI_BASE64_PONDER,
+    EMOJI_BASE64_NOTUNDERSTANDING,
+    EMOJI_BASE64_QUESTION,
+    EMOJI_BASE64_CRY,
+    EMOJI_BASE64_TEAR,
+    EMOJI_BASE64_DEAD,
+    EMOJI_BASE64_ZIPPED_SHUT,
+    EMOJI_BASE64_NO_HEAR,
+    EMOJI_BASE64_NO_SEE,
+    EMOJI_BASE64_NO_SPEAK,
+    EMOJI_BASE64_EYE_ROLL,
+    EMOJI_BASE64_CRAZY,
+    EMOJI_BASE64_RAINEDON,
+    EMOJI_BASE64_DEPRESSED,
+    EMOJI_BASE64_ILL,
+    EMOJI_BASE64_ILL2,
+    EMOJI_BASE64_MASK,
+    EMOJI_BASE64_WARNING,
+    EMOJI_BASE64_WARNING2,
+    EMOJI_BASE64_SCREAM,
+]
 EMOJI_BASE64_LIST = EMOJI_BASE64_HAPPY_LIST + EMOJI_BASE64_SAD_LIST
 
 EMOJI_BASE64_JASON = EMOJI_BASE64_WIZARD
 EMOJI_BASE64_TANAY = EMOJI_BASE64_JEDI
+
 
 def _random_error_emoji():
     c = random.choice(EMOJI_BASE64_SAD_LIST)
@@ -24362,7 +31272,6 @@ def _random_error_emoji():
 def _random_happy_emoji():
     c = random.choice(EMOJI_BASE64_HAPPY_LIST)
     return c
-
 
 
 '''
@@ -24393,7 +31302,6 @@ MMMM                          .88
 '''
 
 
-
 '''
 
 90 x 90 pixel images
@@ -24416,7 +31324,6 @@ RED_X_BASE64 = b'iVBORw0KGgoAAAANSUhEUgAAAFoAAABaCAYAAAA4qEECAAAQ5ElEQVR4nO1ca3S
 GREEN_CHECK_BASE64 = b'iVBORw0KGgoAAAANSUhEUgAAAFoAAABaCAYAAAA4qEECAAAJV0lEQVR4nO2cTWwc5RnHf8/M7Dq7ttdxIIIUcqGA1BQU6Ac9VSkp0NwoJE5PJJygKki9tIIEO7ND3ICEeqJUJYcqCYdKDoS0lWgpH21KuVShH/TjUolLkIpKguO1vWvvfDw9zOxH1l8zjnc3Xs/vFEXy7uzPz/7f93nnGUNKSkpKSkpKSkpKSkpKzyFMYDKC2e0L2TjYGN2+hN5DkXoVP1s4wdjgDwB4jEw3L6u30CguAJzCCV4YUp4bUuzC94BlZaclHx9hPwb78bELp8jJQaa1yrx65OQljhSe4DguLy8uOxUdhzAuDE5HkvvlEWbVRcgSYDKnHnn5CXbhSR5fXHYqemXCSj6Nj1M4Qb88wrR6EMkUpC47Jy8yFsm2sa58kZSlUYTTUVw4hRPkjIPMBC6ySDwoioHPJrEo65M8W3qJx8hwHBdS0UujTZVcLJwkLweY0cUlN35GEQJyYlLRJ3BKP2UEk9P4qejFWTyTibGFq1V2ViwqPMXRqRcYwUgzupXmha9YOJlIMoSZ7ROQEZBgJ6DsQNKKbmZBJsvBFeOilQCPQbGo6Ens0qNRdARpRddollwsnAwXPq0mkgwug2Ixq69glx7Fjr4ZoGlFhyzM5KSVrLgMSIZZfQWndKBWyYBCuo9erhlJIrnKgJGhrKdwSgeYwGSiIRnS7V1Dci2Tp9XDuLLZWJZaJdcyOTw6DZCGZNjIFR0eEDVJNsKFL4lkIsllPVVf+BaRDBu1olfTjCzEpX/pTG5lI1Z0Q7JdOEVeDqwik0PJtUweWZjJrWws0VfbjISv4TJghJlcLB2sL3yLxEUzGyc62tiMsEwl19gYFd2OZiRGXDSzESq67c1IHHq7ojvUjMShlyu6Y81IHHqzojvcjMSh9yq6C81IHHqtorvSjMShd0R3sRmJQ29ER5ebkTjEE21j8EWE/fhr8aZrTFhvgoaZbBxgJqgiZBO8xsJMXqNKblzkStgYOAQL/n2tUB9UKfy8W81IHJbPaBsLh4DRgS8wVvgWDkHrBE5Xscni4Bk69H2GjEeY1fluNCNxWLqid2FxDo9nCp8ny/v0yQ1U/L04M2d4mQyPhxM4XSOaAio4N391Wqbf0ECHUQzixuEaNiNxWLyi7Ujy6OBtZHkPU25gTj2yxgSjAw8vNlvWUWwsjuMOjt30tWlj5k019HoChPiL+5o2I3FYeGFhXHg8PXg7A/I2yHaq6gMGJoopwpz/MOMzZ5tnyzpGdH2FwzffM52f+Y1qsAUXH4n9iMOaNyNxuFJ0TfIPB29jSN5BZDvz6iFR9SoayTZw/YdwZs52NEai68uPfu7uSt/sO4oOJ5KsTZVcLB1sx+5iKRqiJzDZj8/TQ7eQ1z9iyk3M68IP0ZAtzLGP8akz0aJUbeuVRpKH7G1fKlmz7yoMJZdsZKgEHcnkVsKMtuuT7LeS1/eXlAy12TLBVyXHBIcH9uJQbeszHJHk3OEbvzJllkPJVYLYkgO8cOELGs3I/s5JBpDGE0XDOzD9NzBl+5KSm1ECTMACZoN9HJt5vS2ZXYuLseu/XO5z30T1uqvO5A7FRTMG1JoQ/2fkje1UtIoR40MIBj7gAXnjDKMD3+Y47ppWdiQ5Yw/dVelzf5tYsi6x8HVYMoSig7Cqze9SDi6QkyxBzFY7lB2OqW4yXmds6KHlHphJxGNkcPAyo1t3ehbvqOr1CSV3rBmJQ6Oldib/ic9ufP2EPjHR2LKlIZtXGRvYy+O49cfEVkO0T87bW+9ys/PnFN0SO5MVRZlnQLJUgsYpXAcXvsVIvutYilpmmyjzwXc4OnOmfmyZhFpcjA7d7fbxFnAdbszrCKfthYJAqfNbuOVodIb78bGxeH7qI6b1XlQvRJXtxXolwcADAkyxjBMjE3YmPIBPcObdLHkTb5JMsk8WEZVJqyRPUiwdBOhWJrdypQQHDxuLF6b/w4zeh+oFsmLFjhEDAx9fTcm99u8Xz47YI1mKaCzZtWZpdPhOt4+3UN2aSHIGUzAuDTK4xytefimKLqFLmdzK4mcD9Q89eBsZOYcl2xLFSEDAgBjGvPHruz++Ze8H2z4If1FLHbHWK3n4TjfrncOQYaoxF76G5MlBb2BPyfn4zx1poBKy8uldmNl/wkwoO9paSdX45b4P79t7esfpsLJaZdclb97pZv3fIxK/rQ4IyGJIwPRgMLS75Fw435Xzlxgs/ZU+F8XI81MfUeLrBPoxfSTZjWSYVVezwYOv3vm718SRULA2/XJr3xw7f5e7Sd9GjPiSw0w2BJnMycCuknPhfG23Euv6OkycOyxXnuaJbGdO/VhNTUhY2WX9lRZLD9ZFFzFx8Hgqv5NB6y2QrVQTZrLIpZybeaDsXPxL/TqvUeLeM2zIzsu7GHJTbCnQfGp2ln+V9rEDwcHjUP8d5M0/APE7vkgyyKWcl9tTcT45f61LhiR3weuyC7eS5z1MuXE1mY2rZxgt7cUevgPLfw9hc+yFL8pk4HK+2n9f+eh/P1gPkiHpuMHVNzUeebGoBOdAbiebYIGtVzKXM17fva7z6d/Wi2RYzVzHSjcHViIgICcGnoIbdXIr0ZTJltu323X+9+F6kgyrHaBZ7HbXfIJJzXDnIkiMRkbxyYiJcDE/n9lTPnpx3cRFM6ufVGptavpkG+UEMRKHmmT4LFPJ3O8eu/Z3F0txdSNhTU2N5PmFCvfgaxDd9r86wn2yic9UxjV2ueOX/75eJcNazN5F00uCYBS3OH7OO0I54XBhK7WFT+Qz5oxvMD75j/UsGdZqyDE8NDLEEc90ho94m3yHirooVuL3UHyyYgKfUuYBjk2tq93FUqztNKmNJQ6e6WwZ9Tb5R6moF8mOR9PCl5njAXd86q+9IBnaMbYbyRZ782iQ11B2gLXiO9UkazBJ1byXdZ7JrbRjPlqww3MMoyF7+RipLXyBTlK1dvVCJrfSvkH0aILJKBaeCXIyHi2QC2XXFz4uMufvZny25yRDOx+tiP6iYVAs/YiKHiYvGcLhhMYdj3omy6e43v29Khk68WhF7SD+SOEQ/XIsWiBNlCBqRi4xL9/stUxupf0PCx2PRnyfLT3HrH+YnFgoLhlMVC9T9nb3uuTOUptgOlI4xI+HlKOFixzqvwNoejwiZW2oCS0WnuBw4Z4r/i9ljWkePUj/ZHubsbFSySkpKSkpKSkpKSkpKSkpKW3g/3+PYisYNf7zAAAAAElFTkSuQmCC'
 
 
-
 '''
 M""MMMMM""M                                           dP
 M  MMMMM  M                                           88
@@ -24436,8 +31343,6 @@ MMMMMMMMMMM
 '''
 
 
-
-
 def __get_linux_distribution():
     line_tuple = ('Linux Distro', 'Unknown', 'No lines Found in //etc//os-release')
     try:
@@ -24450,11 +31355,9 @@ def __get_linux_distribution():
                 line_tuple = tuple(line_split.split(' '))
                 return line_tuple
     except:
-        line_tuple = ('Linux Distro', 'Exception','Error reading//processing //etc//os-release')
+        line_tuple = ('Linux Distro', 'Exception', 'Error reading//processing //etc//os-release')
 
     return line_tuple
-
-
 
 
 # =========================================================================#
@@ -24483,7 +31386,6 @@ def __get_linux_distribution():
 # M#########M                .88                         MMMMMMMMMMMM
 #                        d8888P
 # =========================================================================#
-
 
 
 # =========================================================================#
@@ -24548,12 +31450,32 @@ def __get_linux_distribution():
 # MMMM
 
 
-def _github_issue_post_make_markdown(issue_type, operating_system, os_ver, psg_port, psg_ver, gui_ver, python_ver,
-                                     python_exp, prog_exp, used_gui, gui_notes,
-                                     cb_docs, cb_demos, cb_demo_port, cb_readme_other, cb_command_line, cb_issues, cb_latest_pypi, cb_github,
-                                     detailed_desc, code, project_details, where_found):
-    body = \
-"""
+def _github_issue_post_make_markdown(
+    issue_type,
+    operating_system,
+    os_ver,
+    psg_port,
+    psg_ver,
+    gui_ver,
+    python_ver,
+    python_exp,
+    prog_exp,
+    used_gui,
+    gui_notes,
+    cb_docs,
+    cb_demos,
+    cb_demo_port,
+    cb_readme_other,
+    cb_command_line,
+    cb_issues,
+    cb_latest_pypi,
+    cb_github,
+    detailed_desc,
+    code,
+    project_details,
+    where_found,
+):
+    body = """
 ## Type of Issue (Enhancement, Error, Bug, Question)
 
 {}
@@ -24586,10 +31508,15 @@ def _github_issue_post_make_markdown(issue_type, operating_system, os_ver, psg_p
 #### GUI Version  (tkinter (`sg.tclversion_detailed`), PySide2, WxPython, Remi)
 
 {}
-""".format(issue_type, operating_system,os_ver, psg_port,python_ver, psg_ver, gui_ver, project_details)
 
-    body2 = \
-"""
+#### Project details
+
+{}
+""".format(
+        issue_type, operating_system, os_ver, psg_port, python_ver, psg_ver, gui_ver, project_details
+    )
+
+    body2 = """
 
 
 ---------------------
@@ -24633,27 +31560,41 @@ These items may solve your problem. Please check those you've done by changing -
 
 
 
-""".format(python_exp, prog_exp, used_gui, gui_notes,
-                cb_docs, cb_demos, cb_demo_port, cb_readme_other, cb_command_line, cb_issues, cb_latest_pypi, cb_github,
-                detailed_desc, code if len(code) > 10 else '# Paste your code here')
-
+""".format(
+        python_exp,
+        prog_exp,
+        used_gui,
+        gui_notes,
+        cb_docs,
+        cb_demos,
+        cb_demo_port,
+        cb_readme_other,
+        cb_command_line,
+        cb_issues,
+        cb_latest_pypi,
+        cb_github,
+        detailed_desc,
+        code if len(code) > 10 else '# Paste your code here',
+    )
 
     if project_details or where_found:
-        body2 +=  '------------------------'
+        body2 += '------------------------'
 
     if project_details:
-        body2 +=  \
-"""
+        body2 += """
 ## Watcha Makin?
 {}
-""".format(str(project_details))
+""".format(
+            str(project_details)
+        )
 
     if where_found:
-        body2 += \
-"""
+        body2 += """
 ## How did you find PySimpleGUI?
 {}
-""".format(str(where_found))
+""".format(
+            str(where_found)
+        )
     return body + body2
 
 
@@ -24663,10 +31604,11 @@ def _github_issue_post_make_github_link(title, body):
 
     # Fix body cuz urllib can't do it smfh
     getVars = {'title': str(title), 'body': str(body)}
-    return (pysimplegui_issues + urllib.parse.urlencode(getVars).replace('%5Cn', '%0D'))
+    return pysimplegui_issues + urllib.parse.urlencode(getVars).replace('%5Cn', '%0D')
 
 
 #########################################################################################################
+
 
 def _github_issue_post_validate(values, checklist, issue_types):
     issue_type = None
@@ -24695,14 +31637,16 @@ def _github_issue_post_validate(values, checklist, issue_types):
 
     checkboxes = any([values[('-CB-', i)] for i in range(len(checklist))])
     if not checkboxes:
-        popup_error('None of the checkboxes were checked.... you need to have tried something...anything...', keep_on_top=True)
+        popup_error(
+            'None of the checkboxes were checked.... you need to have tried something...anything...', keep_on_top=True
+        )
         return False
 
     title = values['-TITLE-'].strip()
     if len(title) == 0:
         popup_error("Title can't be blank", keep_on_top=True)
         return False
-    elif title[1:len(title) - 1] == issue_type:
+    elif title[1 : len(title) - 1] == issue_type:
         popup_error("Title can't be blank (only the type of issue isn't enough)", keep_on_top=True)
         return False
 
@@ -24714,14 +31658,12 @@ def _github_issue_post_validate(values, checklist, issue_types):
 
 
 def _github_issue_help():
-    heading_font = '_ 12 bold underline'
     text_font = '_ 10'
 
     def HelpText(text):
         return Text(text, size=(80, None), font=text_font)
 
-    help_why = \
-""" Let's start with a review of the Goals of the PySimpleGUI project
+    help_why = """ Let's start with a review of the Goals of the PySimpleGUI project
 1. To have fun
 2. For you to be successful
 
@@ -24729,8 +31671,7 @@ This form is as important as the documentation and the demo programs to meeting 
 
 The GitHub Issue GUI is here to help you more easily log issues on the PySimpleGUI GitHub Repo. """
 
-    help_goals = \
-""" The goals of using GitHub Issues for PySimpleGUI question, problems and suggestions are:
+    help_goals = """ The goals of using GitHub Issues for PySimpleGUI question, problems and suggestions are:
 * Give you direct access to engineers with the most knowledge of PySimpleGUI
 * Answer your questions in the most precise and correct way possible
 * Provide the highest quality solutions possible
@@ -24742,8 +31683,7 @@ The GitHub Issue GUI is here to help you more easily log issues on the PySimpleG
 * A way to track the status and have converstaions about issues
 * Enable multiple people to help users """
 
-    help_explain = \
-""" GitHub does not provide a "form" that normal bug-tracking-databases provide. As a result, a form was created specifically for the PySimpleGUI project.
+    help_explain = """ GitHub does not provide a "form" that normal bug-tracking-databases provide. As a result, a form was created specifically for the PySimpleGUI project.
 
 The most obvious questions about this form are
 * Why is there a form? Other projects don't have one?
@@ -24758,13 +31698,11 @@ If asking nicely helps... PLEASE ... please fill out the form.
 
 I can assure you that this form is not here to punish you. It doesn't exist to make you angry and frustrated.  It's not here for any purpose than to try and get you support and make PySimpleGUI better. """
 
-    help_experience = \
-""" Not many Bug-tracking systems ask about you as a user. Your experience in programming, programming in Python and programming a GUI are asked to provide you with the best possible answer.  Here's why it's helpful.  You're a human being, with a past, and a some amount of experience.  Being able to taylor the reply to your issue in a way that fits you and your experience will result in a reply that's efficient and clear.  It's not something normally done but perhaps it should be. It's meant to provide you with a personal response.
+    help_experience = """ Not many Bug-tracking systems ask about you as a user. Your experience in programming, programming in Python and programming a GUI are asked to provide you with the best possible answer.  Here's why it's helpful.  You're a human being, with a past, and a some amount of experience.  Being able to taylor the reply to your issue in a way that fits you and your experience will result in a reply that's efficient and clear.  It's not something normally done but perhaps it should be. It's meant to provide you with a personal response.
 
 If you've been programming for a month, the person answering your question can answer your question in a way that's understandable to you.  Similarly, if you've been programming for 20 years and have used multiple Python GUI frameworks, then you are unlikely to need as much explanation.  You'll also have a richer GUI vocabularly. It's meant to try and give you a peronally crafted response that's on your wavelength. Fun & success... Remember those are our shared goals"""
 
-    help_steps = \
-""" The steps to log an issue are:
+    help_steps = """ The steps to log an issue are:
 1. Fill in the form
 2. Click Post Issue """
 
@@ -24786,8 +31724,7 @@ If you've been programming for a month, the person answering your question can a
     t_exp = Tab('Experience', [[HelpText(help_experience)]])
     t_steps = Tab('Steps', [[HelpText(help_steps)]])
 
-    layout = [[TabGroup([[t_goals, t_why, t_faq, t_exp, t_steps]])],
-              [B('Close')]]
+    layout = [[TabGroup([[t_goals, t_why, t_faq, t_exp, t_steps]])], [B('Close')]]
 
     Window('GitHub Issue GUI Help', layout, keep_on_top=True).read(close=True)
 
@@ -24800,90 +31737,182 @@ def main_open_github_issue():
     frame_type = [[Radio(t, 1, size=(10, 1), enable_events=True, k=t)] for t in issue_types]
 
     v_size = (15, 1)
-    frame_versions = [[T('Python', size=v_size), In(sys.version, size=(20, 1), k='-VER PYTHON-')],
-                      [T('PySimpleGUI', size=v_size), In(ver, size=(20, 1), k='-VER PSG-')],
-                      [T('tkinter', size=v_size), In(tclversion_detailed, size=(20, 1), k='-VER TK-')]]
+    frame_versions = [
+        [T('Python', size=v_size), In(sys.version, size=(20, 1), k='-VER PYTHON-')],
+        [T('PySimpleGUI', size=v_size), In(ver, size=(20, 1), k='-VER PSG-')],
+        [T('tkinter', size=v_size), In(tclversion_detailed, size=(20, 1), k='-VER TK-')],
+    ]
 
-    frame_platforms = [[T('OS                 '), T('Details')],
-                       [Radio('Windows', 2, running_windows(), size=(8, 1), k='-OS WIN-'), In(size=(8, 1), k='-OS WIN VER-')],
-                       [Radio('Linux', 2, running_linux(), size=(8, 1), k='-OS LINUX-'), In(size=(8, 1), k='-OS LINUX VER-')],
-                       [Radio('Mac', 2, running_mac(), size=(8, 1), k='-OS MAC-'), In(size=(8, 1), k='-OS MAC VER-')],
-                       [Radio('Other', 2, size=(8, 1), k='-OS OTHER-'), In(size=(8, 1), k='-OS OTHER VER-')]]
+    frame_platforms = [
+        [T('OS                 '), T('Details')],
+        [Radio('Windows', 2, running_windows(), size=(8, 1), k='-OS WIN-'), In(size=(8, 1), k='-OS WIN VER-')],
+        [Radio('Linux', 2, running_linux(), size=(8, 1), k='-OS LINUX-'), In(size=(8, 1), k='-OS LINUX VER-')],
+        [Radio('Mac', 2, running_mac(), size=(8, 1), k='-OS MAC-'), In(size=(8, 1), k='-OS MAC VER-')],
+        [Radio('Other', 2, size=(8, 1), k='-OS OTHER-'), In(size=(8, 1), k='-OS OTHER VER-')],
+    ]
 
-    col_experience = [[T('Optional Experience Info')],
-                      [In(size=(4, 1), k='-EXP PROG-'), T('Years Programming')],
-                      [In(size=(4, 1), k='-EXP PYTHON-'), T('Years Writing Python')],
-                      [CB('Previously programmed a GUI', k='-CB PRIOR GUI-')],
-                      [T('Share more if you want....')],
-                      [In(size=(25, 1), k='-EXP NOTES-', expand_x=True)]]
+    col_experience = [
+        [T('Optional Experience Info')],
+        [In(size=(4, 1), k='-EXP PROG-'), T('Years Programming')],
+        [In(size=(4, 1), k='-EXP PYTHON-'), T('Years Writing Python')],
+        [CB('Previously programmed a GUI', k='-CB PRIOR GUI-')],
+        [T('Share more if you want....')],
+        [In(size=(25, 1), k='-EXP NOTES-', expand_x=True)],
+    ]
 
-    checklist = (('Searched main docs for your problem', 'www.PySimpleGUI.org'),
-                 ('Looked for Demo Programs that are similar to your goal.\nIt is recommend you use the Demo Browser!', 'https://Demos.PySimpleGUI.org'),
-                 ('If not tkinter - looked for Demo Programs for specific port', ''),
-                 ('For non tkinter - Looked at readme for your specific port if not PySimpleGUI (Qt, WX, Remi)', ''),
-                 ('Run your program outside of your debugger (from a command line)', ''),
-                 ('Searched through Issues (open and closed) to see if already reported', 'https://Issues.PySimpleGUI.org'),
-                 ('Upgraded to the latest official release of PySimpleGUI on PyPI', 'https://Upgrading.PySimpleGUI.org'),
-                 ('Tried using the PySimpleGUI.py file on GitHub. Your problem may have already been fixed but not released.', ''))
+    checklist = (
+        ('Searched main docs for your problem', 'www.PySimpleGUI.org'),
+        (
+            'Looked for Demo Programs that are similar to your goal.\nIt is recommend you use the Demo Browser!',
+            'https://Demos.PySimpleGUI.org',
+        ),
+        ('If not tkinter - looked for Demo Programs for specific port', ''),
+        ('For non tkinter - Looked at readme for your specific port if not PySimpleGUI (Qt, WX, Remi)', ''),
+        ('Run your program outside of your debugger (from a command line)', ''),
+        ('Searched through Issues (open and closed) to see if already reported', 'https://Issues.PySimpleGUI.org'),
+        ('Upgraded to the latest official release of PySimpleGUI on PyPI', 'https://Upgrading.PySimpleGUI.org'),
+        (
+            'Tried using the PySimpleGUI.py file on GitHub. Your problem may have already been fixed but not released.',
+            '',
+        ),
+    )
 
-    checklist_col1 = Col([[CB(c, k=('-CB-', i)), T(t, k='-T{}-'.format(i), enable_events=True)] for i, (c, t) in enumerate(checklist[:4])], k='-C FRAME CBs1-')
-    checklist_col2 = Col([[CB(c, k=('-CB-', i + 4)), T(t, k='-T{}-'.format(i + 4), enable_events=True)] for i, (c, t) in enumerate(checklist[4:])], pad=(0, 0),
-                         k='-C FRAME CBs2-')
+    checklist_col1 = Col(
+        [
+            [CB(c, k=('-CB-', i)), T(t, k='-T{}-'.format(i), enable_events=True)]
+            for i, (c, t) in enumerate(checklist[:4])
+        ],
+        k='-C FRAME CBs1-',
+    )
+    checklist_col2 = Col(
+        [
+            [CB(c, k=('-CB-', i + 4)), T(t, k='-T{}-'.format(i + 4), enable_events=True)]
+            for i, (c, t) in enumerate(checklist[4:])
+        ],
+        pad=(0, 0),
+        k='-C FRAME CBs2-',
+    )
     checklist_tabgropup = TabGroup(
-        [[Tab('Checklist 1 *', [[checklist_col1]], expand_x=True, expand_y=True), Tab('Checklist 2  *', [[checklist_col2]]), Tab('Experience', col_experience, k='-Tab Exp-', pad=(0, 0))]], expand_x=True, expand_y=True)
+        [
+            [
+                Tab('Checklist 1 *', [[checklist_col1]], expand_x=True, expand_y=True),
+                Tab('Checklist 2  *', [[checklist_col2]]),
+                Tab('Experience', col_experience, k='-Tab Exp-', pad=(0, 0)),
+            ]
+        ],
+        expand_x=True,
+        expand_y=True,
+    )
 
     frame_details = [[Multiline(size=(65, 10), font='Courier 10', k='-ML DETAILS-', expand_x=True, expand_y=True)]]
 
-    tooltip_project_details = 'If you care to share a little about your project,\nthen by all means tell us what you are making!'
-    frame_project_details = [[Multiline(size=(65, 10), font='Courier 10', k='-ML PROJECT DETAILS-', expand_x=True, expand_y=True, tooltip=tooltip_project_details)]]
+    tooltip_project_details = (
+        'If you care to share a little about your project,\nthen by all means tell us what you are making!'
+    )
+    frame_project_details = [
+        [
+            Multiline(
+                size=(65, 10),
+                font='Courier 10',
+                k='-ML PROJECT DETAILS-',
+                expand_x=True,
+                expand_y=True,
+                tooltip=tooltip_project_details,
+            )
+        ]
+    ]
 
     tooltip_where_find_psg = 'Where did you learn about PySimpleGUI?'
-    frame_where_you_found_psg = [[Multiline(size=(65, 10), font='Courier 10', k='-ML FOUND PSG-', expand_x=True, expand_y=True, tooltip=tooltip_where_find_psg)]]
+    frame_where_you_found_psg = [
+        [
+            Multiline(
+                size=(65, 10),
+                font='Courier 10',
+                k='-ML FOUND PSG-',
+                expand_x=True,
+                expand_y=True,
+                tooltip=tooltip_where_find_psg,
+            )
+        ]
+    ]
 
     tooltip_code = 'A short program that can be immediately run will considerably speed up getting you quality help.'
-    frame_code = [[Multiline(size=(80, 10), font='Courier 8', k='-ML CODE-', expand_x=True, expand_y=True, tooltip=tooltip_code)]]
+    frame_code = [
+        [Multiline(size=(80, 10), font='Courier 8', k='-ML CODE-', expand_x=True, expand_y=True, tooltip=tooltip_code)]
+    ]
 
     frame_markdown = [[Multiline(size=(80, 10), font='Courier 8', k='-ML MARKDOWN-', expand_x=True, expand_y=True)]]
 
-    top_layout = [[Col([[Text('Open A GitHub Issue (* = Required Info)', font='_ 15')]], expand_x=True),
-                   Col([[B('Help')]])
-                   ],
-                  [Frame('Title *', [[Input(k='-TITLE-', size=(50, 1), font='_ 14', focus=True)]], font=font_frame)],
-                  # Image(data=EMOJI_BASE64_WEARY)],
-                  vtop([
-                      Frame('Platform *', frame_platforms, font=font_frame),
-                      Frame('Type of Issue *', frame_type, font=font_frame),
-                      Frame('Versions *', frame_versions, font=font_frame),
-                  ])]
+    top_layout = [
+        [Col([[Text('Open A GitHub Issue (* = Required Info)', font='_ 15')]], expand_x=True), Col([[B('Help')]])],
+        [Frame('Title *', [[Input(k='-TITLE-', size=(50, 1), font='_ 14', focus=True)]], font=font_frame)],
+        # Image(data=EMOJI_BASE64_WEARY)],
+        vtop(
+            [
+                Frame('Platform *', frame_platforms, font=font_frame),
+                Frame('Type of Issue *', frame_type, font=font_frame),
+                Frame('Versions *', frame_versions, font=font_frame),
+            ]
+        ),
+    ]
 
     middle_layout = [
-        [Frame('Checklist * (note that you can click the links)', [[checklist_tabgropup]], font=font_frame, k='-CLIST FRAME-', expand_x=True, expand_y=True)],
+        [
+            Frame(
+                'Checklist * (note that you can click the links)',
+                [[checklist_tabgropup]],
+                font=font_frame,
+                k='-CLIST FRAME-',
+                expand_x=True,
+                expand_y=True,
+            )
+        ],
         [HorizontalSeparator()],
-        [T(SYMBOL_DOWN + ' If you need more room for details grab the dot and drag to expand', background_color='red', text_color='white')]]
+        [
+            T(
+                SYMBOL_DOWN + ' If you need more room for details grab the dot and drag to expand',
+                background_color='red',
+                text_color='white',
+            )
+        ],
+    ]
 
-    bottom_layout = [[TabGroup([[Tab('Details *\n', frame_details, pad=(0, 0)),
-                                 Tab('SHORT Program\nto duplicate problem *', frame_code, pad=(0, 0)),
-                                 Tab('Your Project Details\n(optional)', frame_project_details, pad=(0, 0)),
-                                 Tab('Where you found us?\n(optional)', frame_where_you_found_psg, pad=(0, 0)),
-                                 Tab('Markdown Output\n', frame_markdown, pad=(0, 0)),
-                                 ]], k='-TABGROUP-', expand_x=True, expand_y=True),
-                      ]]
-
+    bottom_layout = [
+        [
+            TabGroup(
+                [
+                    [
+                        Tab('Details *\n', frame_details, pad=(0, 0)),
+                        Tab('SHORT Program\nto duplicate problem *', frame_code, pad=(0, 0)),
+                        Tab('Your Project Details\n(optional)', frame_project_details, pad=(0, 0)),
+                        Tab('Where you found us?\n(optional)', frame_where_you_found_psg, pad=(0, 0)),
+                        Tab('Markdown Output\n', frame_markdown, pad=(0, 0)),
+                    ]
+                ],
+                k='-TABGROUP-',
+                expand_x=True,
+                expand_y=True,
+            ),
+        ]
+    ]
 
     layout_pane = Pane([Col(middle_layout), Col(bottom_layout)], key='-PANE-', expand_x=True, expand_y=True)
 
     layout = [
-        [pin(B(SYMBOL_DOWN, pad=(0, 0), k='-HIDE CLIST-', tooltip='Hide/show upper sections of window')), pin(Col(top_layout, k='-TOP COL-'))],
+        [
+            pin(B(SYMBOL_DOWN, pad=(0, 0), k='-HIDE CLIST-', tooltip='Hide/show upper sections of window')),
+            pin(Col(top_layout, k='-TOP COL-')),
+        ],
         [layout_pane],
-        [Col([[B('Post Issue'), B('Create Markdown Only'), B('Quit')]])]]
+        [Col([[B('Post Issue'), B('Create Markdown Only'), B('Quit')]])],
+    ]
 
-    window = Window('Open A GitHub Issue', layout, finalize=True, resizable=True, enable_close_attempted_event=True, margins=(0, 0))
-
-
+    window = Window(
+        'Open A GitHub Issue', layout, finalize=True, resizable=True, enable_close_attempted_event=True, margins=(0, 0)
+    )
 
     # for i in range(len(checklist)):
     [window['-T{}-'.format(i)].set_cursor('hand1') for i in range(len(checklist))]
-
 
     if running_mac():
         window['-OS MAC VER-'].update(platform.mac_ver())
@@ -24892,21 +31921,25 @@ def main_open_github_issue():
     elif running_linux():
         window['-OS LINUX VER-'].update(platform.libc_ver())
 
-
     window.bring_to_front()
     while True:  # Event Loop
         event, values = window.read()
         # print(event, values)
         if event in (WINDOW_CLOSE_ATTEMPTED_EVENT, 'Quit'):
-            if popup_yes_no('Do you really want to exit?',
-                            'If you have not clicked Post Issue button and then clicked "Submit New Issue" button '
-                            'then your issue will not have been submitted to GitHub.\n'
-                            'If you are having trouble with PySimpleGUI opening your browser, consider generating '
-                            'the markdown, copying it to a text file, and then using it later to manually paste into a new issue '
-                            '\n'
-                            'Are you sure you want to quit?',
-                            image=EMOJI_BASE64_PONDER, keep_on_top=True
-                            ) == 'Yes':
+            if (
+                popup_yes_no(
+                    'Do you really want to exit?',
+                    'If you have not clicked Post Issue button and then clicked "Submit New Issue" button '
+                    'then your issue will not have been submitted to GitHub.\n'
+                    'If you are having trouble with PySimpleGUI opening your browser, consider generating '
+                    'the markdown, copying it to a text file, and then using it later to manually paste into a new issue '
+                    '\n'
+                    'Are you sure you want to quit?',
+                    image=EMOJI_BASE64_PONDER,
+                    keep_on_top=True,
+                )
+                == 'Yes'
+            ):
                 break
         if event == WIN_CLOSED:
             break
@@ -24916,12 +31949,14 @@ def main_open_github_issue():
             title = str(values['-TITLE-'])
             if len(title) != 0:
                 if title[0] == '[' and title.find(']'):
-                    title = title[title.find(']') + 1:]
+                    title = title[title.find(']') + 1 :]
                     title = title.strip()
             window['-TITLE-'].update('[{}] {}'.format(event, title))
         if event == '-HIDE CLIST-':
             window['-TOP COL-'].update(visible=not window['-TOP COL-'].visible)
-            window['-HIDE CLIST-'].update(text=SYMBOL_UP if window['-HIDE CLIST-'].get_text() == SYMBOL_DOWN else SYMBOL_DOWN)
+            window['-HIDE CLIST-'].update(
+                text=SYMBOL_UP if window['-HIDE CLIST-'].get_text() == SYMBOL_DOWN else SYMBOL_DOWN
+            )
         if event == 'Help':
             _github_issue_help()
         elif event in ('Post Issue', 'Create Markdown Only'):
@@ -24953,17 +31988,35 @@ def main_open_github_issue():
             if not _github_issue_post_validate(values, checklist, issue_types):
                 continue
 
-            cb_dict = {'cb_docs': checkboxes[0], 'cb_demos': checkboxes[1], 'cb_demo_port': checkboxes[2], 'cb_readme_other': checkboxes[3],
-                       'cb_command_line': checkboxes[4], 'cb_issues': checkboxes[5], 'cb_latest_pypi': checkboxes[6], 'cb_github': checkboxes[7], 'detailed_desc': values['-ML DETAILS-'],
-                       'code': values['-ML CODE-'],
-                       'project_details': values['-ML PROJECT DETAILS-'].rstrip(),
-                       'where_found': values['-ML FOUND PSG-']}
+            cb_dict = {
+                'cb_docs': checkboxes[0],
+                'cb_demos': checkboxes[1],
+                'cb_demo_port': checkboxes[2],
+                'cb_readme_other': checkboxes[3],
+                'cb_command_line': checkboxes[4],
+                'cb_issues': checkboxes[5],
+                'cb_latest_pypi': checkboxes[6],
+                'cb_github': checkboxes[7],
+                'detailed_desc': values['-ML DETAILS-'],
+                'code': values['-ML CODE-'],
+                'project_details': values['-ML PROJECT DETAILS-'].rstrip(),
+                'where_found': values['-ML FOUND PSG-'],
+            }
 
-            markdown = _github_issue_post_make_markdown(issue_type, operating_system, os_ver, 'tkinter', values['-VER PSG-'], values['-VER TK-'],
-                                                        values['-VER PYTHON-'],
-                                                        values['-EXP PYTHON-'],values['-EXP PROG-'], 'Yes' if values['-CB PRIOR GUI-'] else 'No',
-                                                        values['-EXP NOTES-'],
-                                                        **cb_dict)
+            markdown = _github_issue_post_make_markdown(
+                issue_type,
+                operating_system,
+                os_ver,
+                'tkinter',
+                values['-VER PSG-'],
+                values['-VER TK-'],
+                values['-VER PYTHON-'],
+                values['-EXP PYTHON-'],
+                values['-EXP PROG-'],
+                'Yes' if values['-CB PRIOR GUI-'] else 'No',
+                values['-EXP NOTES-'],
+                **cb_dict,
+            )
             window['-ML MARKDOWN-'].update(markdown)
             link = _github_issue_post_make_github_link(values['-TITLE-'], window['-ML MARKDOWN-'].get())
             if event == 'Post Issue':
@@ -25005,6 +32058,7 @@ MMMM  MMMM dP    dP dP       `88888P' `88888P8 `88888P8
 MMMMMMMMMM
 '''
 
+
 def _main_entry_point():
     # print('Restarting main as a new process...(needed in case you want to GitHub Upgrade)')
     # Relaunch using the same python interpreter that was used to run this function
@@ -25012,6 +32066,7 @@ def _main_entry_point():
     if 'pythonw' in interpreter:
         interpreter = interpreter.replace('pythonw', 'python')
     execute_py_file(__file__, interpreter_command=interpreter)
+
 
 ####################################################################################################
 
@@ -25062,8 +32117,13 @@ def main_get_debug_data(suppress_popup=False):
     clipboard_set(message)
 
     if not suppress_popup:
-        popup_scrolled('*** Version information copied to your clipboard. Paste into your GitHub Issue. ***\n',
-                       message, title='Select and copy this info to your GitHub Issue', keep_on_top=True, size=(100, 10))
+        popup_scrolled(
+            '*** Version information copied to your clipboard. Paste into your GitHub Issue. ***\n',
+            message,
+            title='Select and copy this info to your GitHub Issue',
+            keep_on_top=True,
+            size=(100, 10),
+        )
 
     return message
 
@@ -25107,11 +32167,19 @@ def _global_settings_get_watermark_info():
     if not pysimplegui_user_settings.get('-watermark-', False) and not Window._watermark_temp_forced:
         Window._watermark = None
         return
-    forced =  Window._watermark_temp_forced
+    forced = Window._watermark_temp_forced
     prefix_text = pysimplegui_user_settings.get('-watermark text-', '')
 
-    ver_text = ' ' + version.split(' ', 1)[0] if pysimplegui_user_settings.get('-watermark ver-', False if not forced else True) or forced else ''
-    framework_ver_text = ' Tk ' + framework_version  if pysimplegui_user_settings.get('-watermark framework ver-', False if not forced else True) or forced else ''
+    ver_text = (
+        ' ' + version.split(' ', 1)[0]
+        if pysimplegui_user_settings.get('-watermark ver-', False if not forced else True) or forced
+        else ''
+    )
+    framework_ver_text = (
+        ' Tk ' + framework_version
+        if pysimplegui_user_settings.get('-watermark framework ver-', False if not forced else True) or forced
+        else ''
+    )
     watermark_font = pysimplegui_user_settings.get('-watermark font-', '_ 9 bold')
     # background_color = pysimplegui_user_settings.get('-watermark bg color-', 'window.BackgroundColor')
     user_text = pysimplegui_user_settings.get('-watermark text-', '')
@@ -25120,12 +32188,13 @@ def _global_settings_get_watermark_info():
         text = str(user_text)
     else:
         text = prefix_text + ver_text + python_text + framework_ver_text
-    Window._watermark = lambda window: Text(text, font=watermark_font, background_color= window.BackgroundColor)
-
+    Window._watermark = lambda window: Text(text, font=watermark_font, background_color=window.BackgroundColor)
 
 
 def main_global_get_screen_snapshot_symcode():
-    pysimplegui_user_settings = UserSettings(filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH)
+    pysimplegui_user_settings = UserSettings(
+        filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH
+    )
 
     settings = pysimplegui_user_settings.read()
 
@@ -25143,6 +32212,7 @@ def main_global_get_screen_snapshot_symcode():
     elif screenshot_keysym:
         return screenshot_keysym
     return ''
+
 
 def main_global_pysimplegui_settings_erase():
     """
@@ -25180,103 +32250,264 @@ def main_global_pysimplegui_settings():
         'spyder': '<editor> <file>',
         'thonny': '<editor> <file>',
         'pydev': '<editor> <file>:<line>',
-        'idle': '<editor> <file>'}
+        'idle': '<editor> <file>',
+    }
 
-    tooltip = 'Format strings for some popular editors/IDEs:\n' + \
-              'PyCharm - <editor> --line <line> <file>\n' + \
-              'Notepad++ - <editor> -n<line> <file>\n' + \
-              'Sublime - <editor> <file>:<line>\n' + \
-              'vim -  <editor> +<line> <file>\n' + \
-              'wing - <editor> <file>:<line>\n' + \
-              'Visual Studio - <editor> <file> /command "edit.goto <line>"\n' + \
-              'Atom - <editor> <file>:<line>\n' + \
-              'Spyder - <editor> <file>\n' + \
-              'Thonny - <editor> <file>\n' + \
-              'PyDev - <editor> <file>:<line>\n' + \
-              'IDLE - <editor> <file>\n'
+    tooltip = (
+        'Format strings for some popular editors/IDEs:\n'
+        + 'PyCharm - <editor> --line <line> <file>\n'
+        + 'Notepad++ - <editor> -n<line> <file>\n'
+        + 'Sublime - <editor> <file>:<line>\n'
+        + 'vim -  <editor> +<line> <file>\n'
+        + 'wing - <editor> <file>:<line>\n'
+        + 'Visual Studio - <editor> <file> /command "edit.goto <line>"\n'
+        + 'Atom - <editor> <file>:<line>\n'
+        + 'Spyder - <editor> <file>\n'
+        + 'Thonny - <editor> <file>\n'
+        + 'PyDev - <editor> <file>:<line>\n'
+        + 'IDLE - <editor> <file>\n'
+    )
 
-    tooltip_file_explorer = 'This is the program you normally use to "Browse" for files\n' + \
-                            'For Windows this is normally "explorer". On Linux "nemo" is sometimes used.'
+    tooltip_file_explorer = (
+        'This is the program you normally use to "Browse" for files\n'
+        + 'For Windows this is normally "explorer". On Linux "nemo" is sometimes used.'
+    )
 
-    tooltip_theme = 'The normal default theme for PySimpleGUI is "Dark Blue 13\n' + \
-                    'If you do not call theme("theme name") by your program to change the theme, then the default is used.\n' + \
-                    'This setting allows you to set the theme that PySimpleGUI will use for ALL of your programs that\n' + \
-                    'do not set a theme specifically.'
+    tooltip_theme = (
+        'The normal default theme for PySimpleGUI is "Dark Blue 13\n'
+        + 'If you do not call theme("theme name") by your program to change the theme, then the default is used.\n'
+        + 'This setting allows you to set the theme that PySimpleGUI will use for ALL of your programs that\n'
+        + 'do not set a theme specifically.'
+    )
 
     # ------------------------- TTK Tab -------------------------
-    ttk_scrollbar_tab_layout = [[T('Default TTK Theme', font='_ 16'), Combo([], DEFAULT_TTK_THEME, readonly=True, size=(20, 10), key='-TTK THEME-', font='_ 16')],
-                                [HorizontalSeparator()],
-                                [T('TTK Scrollbar Settings', font='_ 16')]]
+    ttk_scrollbar_tab_layout = [
+        [
+            T('Default TTK Theme', font='_ 16'),
+            Combo([], DEFAULT_TTK_THEME, readonly=True, size=(20, 10), key='-TTK THEME-', font='_ 16'),
+        ],
+        [HorizontalSeparator()],
+        [T('TTK Scrollbar Settings', font='_ 16')],
+    ]
 
-    t_len = max([len(l) for l in TTK_SCROLLBAR_PART_LIST])
+    t_len = max(len(item) for item in TTK_SCROLLBAR_PART_LIST)
     ttk_layout = [[]]
     for key, item in ttk_part_mapping_dict.items():
         if key in TTK_SCROLLBAR_PART_THEME_BASED_LIST:
-            ttk_layout += [[T(key, s=t_len, justification='r'), Combo(PSG_THEME_PART_LIST, default_value=settings.get(('-ttk scroll-', key), item), key=('-TTK SCROLL-', key))]]
+            ttk_layout += [
+                [
+                    T(key, s=t_len, justification='r'),
+                    Combo(
+                        PSG_THEME_PART_LIST,
+                        default_value=settings.get(('-ttk scroll-', key), item),
+                        key=('-TTK SCROLL-', key),
+                    ),
+                ]
+            ]
         elif key in (TTK_SCROLLBAR_PART_ARROW_WIDTH, TTK_SCROLLBAR_PART_SCROLL_WIDTH):
-            ttk_layout += [[T(key, s=t_len, justification='r'), Combo(list(range(100)), default_value=settings.get(('-ttk scroll-', key), item), key=('-TTK SCROLL-', key))]]
+            ttk_layout += [
+                [
+                    T(key, s=t_len, justification='r'),
+                    Combo(
+                        list(range(100)),
+                        default_value=settings.get(('-ttk scroll-', key), item),
+                        key=('-TTK SCROLL-', key),
+                    ),
+                ]
+            ]
         elif key == TTK_SCROLLBAR_PART_RELIEF:
-            ttk_layout += [[T(key, s=t_len, justification='r'), Combo(RELIEF_LIST, default_value=settings.get(('-ttk scroll-', key), item), readonly=True, key=('-TTK SCROLL-', key))]]
+            ttk_layout += [
+                [
+                    T(key, s=t_len, justification='r'),
+                    Combo(
+                        RELIEF_LIST,
+                        default_value=settings.get(('-ttk scroll-', key), item),
+                        readonly=True,
+                        key=('-TTK SCROLL-', key),
+                    ),
+                ]
+            ]
 
     ttk_scrollbar_tab_layout += ttk_layout
     ttk_scrollbar_tab_layout += [[Button('Reset Scrollbar Settings'), Button('Test Scrollbar Settings')]]
     ttk_tab = Tab('TTK', ttk_scrollbar_tab_layout)
 
-    layout = [[T('Global PySimpleGUI Settings', text_color=theme_button_color()[0], background_color=theme_button_color()[1],font='_ 18', expand_x=True, justification='c')]]
+    layout = [
+        [
+            T(
+                'Global PySimpleGUI Settings',
+                text_color=theme_button_color()[0],
+                background_color=theme_button_color()[1],
+                font='_ 18',
+                expand_x=True,
+                justification='c',
+            )
+        ]
+    ]
 
     # ------------------------- Interpreter Tab -------------------------
 
-
-    interpreter_tab = Tab('Python Interpreter',
-              [[T('Normally leave this blank')],
-                [T('Command to run a python program:'), In(settings.get('-python command-', ''), k='-PYTHON COMMAND-', enable_events=True), FileBrowse()]], font='_ 16', expand_x=True)
+    interpreter_tab = Tab(
+        'Python Interpreter',
+        [
+            [T('Normally leave this blank')],
+            [
+                T('Command to run a python program:'),
+                In(settings.get('-python command-', ''), k='-PYTHON COMMAND-', enable_events=True),
+                FileBrowse(),
+            ],
+        ],
+        font='_ 16',
+        expand_x=True,
+    )
 
     # ------------------------- Editor Tab -------------------------
 
-    editor_tab = Tab('Editor Settings',
-              [[T('Command to invoke your editor:'), In(settings.get('-editor program-', ''), k='-EDITOR PROGRAM-', enable_events=True), FileBrowse()],
-              [T('String to launch your editor to edit at a particular line #.')],
-              [T('Use tags <editor> <file> <line> to specify the string')],
-              [T('that will be executed to edit python files using your editor')],
-              [T('Edit Format String (hover for tooltip)', tooltip=tooltip),
-               In(settings.get('-editor format string-', '<editor> <file>'), k='-EDITOR FORMAT-', tooltip=tooltip)]], font='_ 16', expand_x=True)
+    editor_tab = Tab(
+        'Editor Settings',
+        [
+            [
+                T('Command to invoke your editor:'),
+                In(settings.get('-editor program-', ''), k='-EDITOR PROGRAM-', enable_events=True),
+                FileBrowse(),
+            ],
+            [T('String to launch your editor to edit at a particular line #.')],
+            [T('Use tags <editor> <file> <line> to specify the string')],
+            [T('that will be executed to edit python files using your editor')],
+            [
+                T('Edit Format String (hover for tooltip)', tooltip=tooltip),
+                In(settings.get('-editor format string-', '<editor> <file>'), k='-EDITOR FORMAT-', tooltip=tooltip),
+            ],
+        ],
+        font='_ 16',
+        expand_x=True,
+    )
 
     # ------------------------- Explorer Tab -------------------------
 
-    explorer_tab = Tab('Explorer Program',
-              [[In(settings.get('-explorer program-', ''), k='-EXPLORER PROGRAM-', tooltip=tooltip_file_explorer)]], font='_ 16', expand_x=True,  tooltip=tooltip_file_explorer)
+    explorer_tab = Tab(
+        'Explorer Program',
+        [[In(settings.get('-explorer program-', ''), k='-EXPLORER PROGRAM-', tooltip=tooltip_file_explorer)]],
+        font='_ 16',
+        expand_x=True,
+        tooltip=tooltip_file_explorer,
+    )
 
     # ------------------------- Snapshots Tab -------------------------
 
-    snapshots_tab = Tab('Window Snapshots',
-              [[Combo(('',)+key_choices, default_value=settings.get(json.dumps(('-snapshot keysym-', i)), ''), readonly=True, k=('-SNAPSHOT KEYSYM-', i), s=(None, 30)) for i in range(4)],
-              [T('Manually Entered Bind String:'), Input(settings.get('-snapshot keysym manual-', ''),k='-SNAPSHOT KEYSYM MANUAL-')],
-              [T('Folder to store screenshots:'), Push(), In(settings.get('-screenshots folder-', ''), k='-SCREENSHOTS FOLDER-'), FolderBrowse()],
-              [T('Screenshots Filename or Prefix:'), Push(), In(settings.get('-screenshots filename-', ''), k='-SCREENSHOTS FILENAME-'), FileBrowse()],
-              [Checkbox('Auto-number Images', k='-SCREENSHOTS AUTONUMBER-')]], font='_ 16', expand_x=True,)
+    snapshots_tab = Tab(
+        'Window Snapshots',
+        [
+            [
+                Combo(
+                    ('',) + key_choices,
+                    default_value=settings.get(json.dumps(('-snapshot keysym-', i)), ''),
+                    readonly=True,
+                    k=('-SNAPSHOT KEYSYM-', i),
+                    s=(None, 30),
+                )
+                for i in range(4)
+            ],
+            [
+                T('Manually Entered Bind String:'),
+                Input(settings.get('-snapshot keysym manual-', ''), k='-SNAPSHOT KEYSYM MANUAL-'),
+            ],
+            [
+                T('Folder to store screenshots:'),
+                Push(),
+                In(settings.get('-screenshots folder-', ''), k='-SCREENSHOTS FOLDER-'),
+                FolderBrowse(),
+            ],
+            [
+                T('Screenshots Filename or Prefix:'),
+                Push(),
+                In(settings.get('-screenshots filename-', ''), k='-SCREENSHOTS FILENAME-'),
+                FileBrowse(),
+            ],
+            [Checkbox('Auto-number Images', k='-SCREENSHOTS AUTONUMBER-')],
+        ],
+        font='_ 16',
+        expand_x=True,
+    )
 
     # ------------------------- Theme Tab -------------------------
 
-    theme_tab = Tab('Theme',
-              [[T('Leave blank for "official" PySimpleGUI default theme: {}'.format(OFFICIAL_PYSIMPLEGUI_THEME))],
-              [T('Default Theme For All Programs:'),
-               Combo([''] + theme_list(), settings.get('-theme-', None), readonly=True, k='-THEME-', tooltip=tooltip_theme), Checkbox('Always use custom Titlebar', default=pysimplegui_user_settings.get('-custom titlebar-',False), k='-CUSTOM TITLEBAR-')],
-               [Frame('Window Watermarking',
-                       [[Checkbox('Enable Window Watermarking', pysimplegui_user_settings.get('-watermark-', False), k='-WATERMARK-')],
-                       [T('Prefix Text String:'), Input(pysimplegui_user_settings.get('-watermark text-', ''), k='-WATERMARK TEXT-')],
-                       [Checkbox('PySimpleGUI Version', pysimplegui_user_settings.get('-watermark ver-', False), k='-WATERMARK VER-')],
-                       [Checkbox('Framework Version',pysimplegui_user_settings.get('-watermark framework ver-', False), k='-WATERMARK FRAMEWORK VER-')],
-                       [T('Font:'), Input(pysimplegui_user_settings.get('-watermark font-', '_ 9 bold'), k='-WATERMARK FONT-')],
-                       # [T('Background Color:'), Input(pysimplegui_user_settings.get('-watermark bg color-', 'window.BackgroundColor'), k='-WATERMARK BG COLOR-')],
+    theme_tab = Tab(
+        'Theme',
+        [
+            [T('Leave blank for "official" PySimpleGUI default theme: {}'.format(OFFICIAL_PYSIMPLEGUI_THEME))],
+            [
+                T('Default Theme For All Programs:'),
+                Combo(
+                    [''] + theme_list(),
+                    settings.get('-theme-', None),
+                    readonly=True,
+                    k='-THEME-',
+                    tooltip=tooltip_theme,
+                ),
+                Checkbox(
+                    'Always use custom Titlebar',
+                    default=pysimplegui_user_settings.get('-custom titlebar-', False),
+                    k='-CUSTOM TITLEBAR-',
+                ),
+            ],
+            [
+                Frame(
+                    'Window Watermarking',
+                    [
+                        [
+                            Checkbox(
+                                'Enable Window Watermarking',
+                                pysimplegui_user_settings.get('-watermark-', False),
+                                k='-WATERMARK-',
+                            )
                         ],
-                font='_ 16', expand_x=True)]])
+                        [
+                            T('Prefix Text String:'),
+                            Input(pysimplegui_user_settings.get('-watermark text-', ''), k='-WATERMARK TEXT-'),
+                        ],
+                        [
+                            Checkbox(
+                                'PySimpleGUI Version',
+                                pysimplegui_user_settings.get('-watermark ver-', False),
+                                k='-WATERMARK VER-',
+                            )
+                        ],
+                        [
+                            Checkbox(
+                                'Framework Version',
+                                pysimplegui_user_settings.get('-watermark framework ver-', False),
+                                k='-WATERMARK FRAMEWORK VER-',
+                            )
+                        ],
+                        [
+                            T('Font:'),
+                            Input(pysimplegui_user_settings.get('-watermark font-', '_ 9 bold'), k='-WATERMARK FONT-'),
+                        ],
+                        # [T('Background Color:'), Input(pysimplegui_user_settings.get('-watermark bg color-', 'window.BackgroundColor'), k='-WATERMARK BG COLOR-')],
+                    ],
+                    font='_ 16',
+                    expand_x=True,
+                )
+            ],
+        ],
+    )
 
-
-
-    settings_tab_group = TabGroup([[theme_tab, ttk_tab, interpreter_tab, explorer_tab, editor_tab, snapshots_tab,  ]])
+    settings_tab_group = TabGroup(
+        [
+            [
+                theme_tab,
+                ttk_tab,
+                interpreter_tab,
+                explorer_tab,
+                editor_tab,
+                snapshots_tab,
+            ]
+        ]
+    )
     layout += [[settings_tab_group]]
-              # [T('Buttons (Leave Unchecked To Use Default) NOT YET IMPLEMENTED!',  font='_ 16')],
-              #      [Checkbox('Always use TTK buttons'), CBox('Always use TK Buttons')],
+    # [T('Buttons (Leave Unchecked To Use Default) NOT YET IMPLEMENTED!',  font='_ 16')],
+    #      [Checkbox('Always use TTK buttons'), CBox('Always use TK Buttons')],
     layout += [[B('Ok', bind_return_key=True), B('Cancel'), B('Mac Patch Control')]]
 
     window = Window('Settings', layout, keep_on_top=True, modal=False, finalize=True)
@@ -25314,7 +32545,7 @@ def main_global_pysimplegui_settings():
             pysimplegui_user_settings.set('-snapshot keysym manual-', values['-SNAPSHOT KEYSYM MANUAL-'])
             screenshot_keysym = ''
             for i in range(4):
-                pysimplegui_user_settings.set(json.dumps(('-snapshot keysym-',i)), values[('-SNAPSHOT KEYSYM-', i)])
+                pysimplegui_user_settings.set(json.dumps(('-snapshot keysym-', i)), values[('-SNAPSHOT KEYSYM-', i)])
                 if values[('-SNAPSHOT KEYSYM-', i)]:
                     screenshot_keysym += '<{}>'.format(values[('-SNAPSHOT KEYSYM-', i)])
             if screenshot_keysym_manual:
@@ -25333,8 +32564,6 @@ def main_global_pysimplegui_settings():
 
             # Upgrade Service Settings
             pysimplegui_user_settings.set('-upgrade show only critical-', values['-UPGRADE SHOW ONLY CRITICAL-'])
-
-
 
             theme(new_theme)
 
@@ -25463,7 +32692,7 @@ def main_sdk_help():
             for i, a in enumerate(args):
                 args_defaults.append((a, defaults[i]))
             element_arg_default_dict_update[element.__name__] = args_defaults if len(args_defaults) else (('', ''),)
-        except Exception as e:
+        except Exception:
             pass
 
     # Add on the pseudo-elements
@@ -25473,14 +32702,46 @@ def main_sdk_help():
     buttons = [[B(e, pad=(0, 0), size=(22, 1), font='Courier 10')] for e in sorted(element_names.keys())]
     buttons += [[B('Func Search', pad=(0, 0), size=(22, 1), font='Courier 10')]]
     button_col = Col(buttons, vertical_alignment='t')
-    mline_col = Column([[Multiline(size=(100, 46), key='-ML-', write_only=True, reroute_stdout=True, font='Courier 10', expand_x=True, expand_y=True)],
-                        [T(size=(80, 1), font='Courier 10 underline', k='-DOC LINK-', enable_events=True)]], pad=(0, 0), expand_x=True, expand_y=True, vertical_alignment='t')
+    mline_col = Column(
+        [
+            [
+                Multiline(
+                    size=(100, 46),
+                    key='-ML-',
+                    write_only=True,
+                    reroute_stdout=True,
+                    font='Courier 10',
+                    expand_x=True,
+                    expand_y=True,
+                )
+            ],
+            [T(size=(80, 1), font='Courier 10 underline', k='-DOC LINK-', enable_events=True)],
+        ],
+        pad=(0, 0),
+        expand_x=True,
+        expand_y=True,
+        vertical_alignment='t',
+    )
     layout = [[button_col, mline_col]]
-    layout += [[CBox('Summary Only', enable_events=True, k='-SUMMARY-'), CBox('Display Only PEP8 Functions', default=True, k='-PEP8-')]]
+    layout += [
+        [
+            CBox('Summary Only', enable_events=True, k='-SUMMARY-'),
+            CBox('Display Only PEP8 Functions', default=True, k='-PEP8-'),
+        ]
+    ]
     # layout = [[Column(layout, scrollable=True, p=0, expand_x=True, expand_y=True, vertical_alignment='t'), Sizegrip()]]
     layout += [[Button('Exit', size=(15, 1)), Sizegrip()]]
 
-    window = Window('SDK API Call Reference', layout, resizable=True, use_default_focus=False, keep_on_top=True, icon=EMOJI_BASE64_THINK, finalize=True, right_click_menu=MENU_RIGHT_CLICK_EDITME_EXIT)
+    window = Window(
+        'SDK API Call Reference',
+        layout,
+        resizable=True,
+        use_default_focus=False,
+        keep_on_top=True,
+        icon=EMOJI_BASE64_THINK,
+        finalize=True,
+        right_click_menu=MENU_RIGHT_CLICK_EDITME_EXIT,
+    )
     window['-DOC LINK-'].set_cursor('hand1')
     online_help_link = ''
     ml = window['-ML-']
@@ -25515,7 +32776,11 @@ def main_sdk_help():
                     if inspect.isfunction(elem):
                         ml.print('Not a class...It is a function', background_color='red', text_color='white')
                     else:
-                        element_methods = [m[0] for m in inspect.getmembers(Element, inspect.isfunction) if not m[0].startswith('_') and not m[0][0].isupper()]
+                        element_methods = [
+                            m[0]
+                            for m in inspect.getmembers(Element, inspect.isfunction)
+                            if not m[0].startswith('_') and not m[0][0].isupper()
+                        ]
                         methods = inspect.getmembers(elem, inspect.isfunction)
                         methods = [m[0] for m in methods if not m[0].startswith('_') and not m[0][0].isupper()]
 
@@ -25537,7 +32802,9 @@ def main_sdk_help():
                             ml.print('{:18}'.format(parm), end=' = ')
                             ml.print(default, end=',\n')
                         if elem_text_name in element_arg_default_dict_update:
-                            ml.print('========== Update Parms ==========', background_color='#FFFF00', text_color='black')
+                            ml.print(
+                                '========== Update Parms ==========', background_color='#FFFF00', text_color='black'
+                            )
                             for parm, default in element_arg_default_dict_update[elem_text_name]:
                                 ml.print('{:18}'.format(parm), end=' = ')
                                 ml.print(default, end=',\n')
@@ -25555,12 +32822,17 @@ def main_sdk_help():
                                 if values['-SUMMARY-']:
                                     ml.print(f)
                                 else:
-                                    ml.print('=========== ' + f + '===========', background_color='#FFFF00', text_color='black')
+                                    ml.print(
+                                        '=========== ' + f + '===========',
+                                        background_color='#FFFF00',
+                                        text_color='black',
+                                    )
                                     ml.print(pydoc.help(f_entry[1]))
                 ml.set_vscroll_position(0)  # scroll to top of multoline
     except Exception as e:
         _error_popup_with_traceback('Exception in SDK reference', e)
     window.close()
+
 
 #                     oo
 #
@@ -25590,9 +32862,9 @@ def main_sdk_help():
 def _main_switch_theme():
     layout = [
         [Text('Click a look and feel color to see demo window')],
-        [Listbox(values=theme_list(),
-                 size=(20, 20), key='-LIST-')],
-        [Button('Choose'), Button('Cancel')]]
+        [Listbox(values=theme_list(), size=(20, 20), key='-LIST-')],
+        [Button('Choose'), Button('Cancel')],
+    ]
 
     window = Window('Change Themes', layout)
 
@@ -25611,39 +32883,70 @@ def _create_main_window():
     :rtype:  Window
     """
 
-    # theme('dark blue 3')
-    # theme('dark brown 2')
-    # theme('dark')
-    # theme('dark red')
-    # theme('Light Green 6')
-    # theme('Dark Grey 8')
-
     tkversion = tkinter.TkVersion
     tclversion = tkinter.TclVersion
     tclversion_detailed = tkinter.Tcl().eval('info patchlevel')
 
     print('Starting up PySimpleGUI Diagnostic & Help System')
     print('PySimpleGUI long version = ', version)
-    print('PySimpleGUI Version ', ver, '\ntcl ver = {}'.format(tclversion),
-          'tkinter version = {}'.format(tkversion), '\nPython Version {}'.format(sys.version))
+    print(
+        'PySimpleGUI Version ',
+        ver,
+        '\ntcl ver = {}'.format(tclversion),
+        'tkinter version = {}'.format(tkversion),
+        '\nPython Version {}'.format(sys.version),
+    )
     print('tcl detailed version = {}'.format(tclversion_detailed))
     print('PySimpleGUI.py location', __file__)
     # ------ Menu Definition ------ #
-    menu_def = [['&File', ['!&Open', '&Save::savekey', '---', '&Properties', 'E&xit']],
-                ['&Edit', ['&Paste', ['Special', 'Normal', '!Disabled'], 'Undo'], ],
-                ['&Debugger', ['Popout', 'Launch Debugger']],
-                ['!&Disabled', ['Popout', 'Launch Debugger']],
-                ['&Toolbar', ['Command &1', 'Command &2', 'Command &3', 'Command &4']],
-                ['&Help', '&About...'], ]
+    menu_def = [
+        ['&File', ['!&Open', '&Save::savekey', '---', '&Properties', 'E&xit']],
+        [
+            '&Edit',
+            ['&Paste', ['Special', 'Normal', '!Disabled'], 'Undo'],
+        ],
+        ['&Debugger', ['Popout', 'Launch Debugger']],
+        ['!&Disabled', ['Popout', 'Launch Debugger']],
+        ['&Toolbar', ['Command &1', 'Command &2', 'Command &3', 'Command &4']],
+        ['&Help', '&About...'],
+    ]
 
-    button_menu_def = ['unused', ['&Paste', ['Special', 'Normal', '!Disabled'], 'Undo', 'Exit'], ]
+    button_menu_def = [
+        'unused',
+        ['&Paste', ['Special', 'Normal', '!Disabled'], 'Undo', 'Exit'],
+    ]
     treedata = TreeData()
 
-    treedata.Insert('', '_A_', 'Tree Item 1', [1, 2, 3], )
-    treedata.Insert('', '_B_', 'B', [4, 5, 6], )
-    treedata.Insert('_A_', '_A1_', 'Sub Item 1', ['can', 'be', 'anything'], )
-    treedata.Insert('', '_C_', 'C', [], )
-    treedata.Insert('_C_', '_C1_', 'C1', ['or'], )
+    treedata.Insert(
+        '',
+        '_A_',
+        'Tree Item 1',
+        [1, 2, 3],
+    )
+    treedata.Insert(
+        '',
+        '_B_',
+        'B',
+        [4, 5, 6],
+    )
+    treedata.Insert(
+        '_A_',
+        '_A1_',
+        'Sub Item 1',
+        ['can', 'be', 'anything'],
+    )
+    treedata.Insert(
+        '',
+        '_C_',
+        'C',
+        [],
+    )
+    treedata.Insert(
+        '_C_',
+        '_C1_',
+        'C1',
+        ['or'],
+    )
     treedata.Insert('_A_', '_A2_', 'Sub Item 2', [None, None])
     treedata.Insert('_A1_', '_A3_', 'A30', ['getting deep'])
     treedata.Insert('_C_', '_C2_', 'C2', ['nothing', 'at', 'all'])
@@ -25652,19 +32955,41 @@ def _create_main_window():
         treedata.Insert('_C_', i, i, [])
 
     frame1 = [
-        [Input('Input Text', size=(25, 1)), ],
+        [
+            Input('Input Text', size=(25, 1)),
+        ],
         [Multiline(size=(30, 5), default_text='Multiline Input')],
     ]
 
     frame2 = [
         # [ProgressBar(100, bar_color=('red', 'green'), orientation='h')],
-
-        [Listbox(['Listbox 1', 'Listbox 2', 'Listbox 3'], select_mode=SELECT_MODE_EXTENDED, size=(20, 5), no_scrollbar=True),
-         Spin([1, 2, 3, 'a', 'b', 'c'], initial_value='a', size=(4, 3), wrap=True)],
-        [Combo(['Combo item %s' % i for i in range(5)], size=(20, 3), default_value='Combo item 2', key='-COMBO1-', )],
-        [Combo(['Combo item %s' % i for i in range(5)], size=(20, 3), font='Courier 14', default_value='Combo item 2', key='-COMBO2-', )],
+        [
+            Listbox(
+                ['Listbox 1', 'Listbox 2', 'Listbox 3'],
+                select_mode=SELECT_MODE_EXTENDED,
+                size=(20, 5),
+                no_scrollbar=True,
+            ),
+            Spin([1, 2, 3, 'a', 'b', 'c'], initial_value='a', size=(4, 3), wrap=True),
+        ],
+        [
+            Combo(
+                ['Combo item %s' % i for i in range(5)],
+                size=(20, 3),
+                default_value='Combo item 2',
+                key='-COMBO1-',
+            )
+        ],
+        [
+            Combo(
+                ['Combo item %s' % i for i in range(5)],
+                size=(20, 3),
+                font='Courier 14',
+                default_value='Combo item 2',
+                key='-COMBO2-',
+            )
+        ],
         # [Combo(['Combo item 1', 2,3,4], size=(20, 3), readonly=False, text_color='blue', background_color='red', key='-COMBO2-')],
-
     ]
 
     frame3 = [
@@ -25674,126 +32999,262 @@ def _create_main_window():
     ]
 
     frame4 = [
-        [Slider(range=(0, 100), orientation='v', size=(7, 15), default_value=40, key='-SLIDER1-'),
-         Slider(range=(0, 100), orientation='h', size=(11, 15), default_value=40, key='-SLIDER2-'), ],
+        [
+            Slider(range=(0, 100), orientation='v', size=(7, 15), default_value=40, key='-SLIDER1-'),
+            Slider(range=(0, 100), orientation='h', size=(11, 15), default_value=40, key='-SLIDER2-'),
+        ],
     ]
     matrix = [[str(x * y) for x in range(1, 5)] for y in range(1, 8)]
 
-    frame5 = [vtop([
-        Table(values=matrix, headings=matrix[0],
-              auto_size_columns=False, display_row_numbers=True, change_submits=False, justification='right',  header_border_width=4,
-              # header_relief=RELIEF_GROOVE,
-              num_rows=10, alternating_row_color='lightblue', key='-TABLE-',
-              col_widths=[5, 5, 5, 5]),
-        Tree(data=treedata, headings=['col1', 'col2', 'col3'], col_widths=[5, 5, 5, 5], change_submits=True, auto_size_columns=False, header_border_width=4,
-             # header_relief=RELIEF_GROOVE,
-             num_rows=8, col0_width=8, key='-TREE-', show_expanded=True )])]
-    frame7 = [[Image(EMOJI_BASE64_HAPPY_HEARTS, enable_events=True, k='-EMOJI-HEARTS-'), T('Do you'), Image(HEART_3D_BASE64, subsample=3, enable_events=True, k='-HEART-'), T('so far?')],
-              [T('Want to be taught PySimpleGUI?\nThen maybe the "Official PySimpleGUI Course" on Udemy is for you.')],
-              [B(image_data=UDEMY_ICON, enable_events=True,  k='-UDEMY-'),T('Check docs, announcements, easter eggs on this page for coupons.')],
-              [B(image_data=ICON_BUY_ME_A_COFFEE, enable_events=True,  k='-COFFEE-'), T('It is financially draining to operate a project this huge. $1 helps')]]
-
+    frame5 = [
+        vtop(
+            [
+                Table(
+                    values=matrix,
+                    headings=matrix[0],
+                    auto_size_columns=False,
+                    display_row_numbers=True,
+                    change_submits=False,
+                    justification='right',
+                    header_border_width=4,
+                    # header_relief=RELIEF_GROOVE,
+                    num_rows=10,
+                    alternating_row_color='lightblue',
+                    key='-TABLE-',
+                    col_widths=[5, 5, 5, 5],
+                ),
+                Tree(
+                    data=treedata,
+                    headings=['col1', 'col2', 'col3'],
+                    col_widths=[5, 5, 5, 5],
+                    change_submits=True,
+                    auto_size_columns=False,
+                    header_border_width=4,
+                    # header_relief=RELIEF_GROOVE,
+                    num_rows=8,
+                    col0_width=8,
+                    key='-TREE-',
+                    show_expanded=True,
+                ),
+            ]
+        )
+    ]
+    frame7 = [
+        [
+            Image(EMOJI_BASE64_HAPPY_HEARTS, enable_events=True, k='-EMOJI-HEARTS-'),
+            T('Do you'),
+            Image(HEART_3D_BASE64, subsample=3, enable_events=True, k='-HEART-'),
+            T('so far?'),
+        ],
+        [T('Want to be taught PySimpleGUI?\nThen maybe the "Official PySimpleGUI Course" on Udemy is for you.')],
+        [
+            B(image_data=UDEMY_ICON, enable_events=True, k='-UDEMY-'),
+            T('Check docs, announcements, easter eggs on this page for coupons.'),
+        ],
+        [
+            B(image_data=ICON_BUY_ME_A_COFFEE, enable_events=True, k='-COFFEE-'),
+            T('It is financially draining to operate a project this huge. $1 helps'),
+        ],
+    ]
 
     pop_test_tab_layout = [
         [Image(EMOJI_BASE64_HAPPY_IDEA), T('Popup tests? Good idea!')],
-        [B('Popup', k='P '), B('No Titlebar', k='P NoTitle'), B('Not Modal', k='P NoModal'), B('Non Blocking', k='P NoBlock'), B('Auto Close', k='P AutoClose')],
+        [
+            B('Popup', k='P '),
+            B('No Titlebar', k='P NoTitle'),
+            B('Not Modal', k='P NoModal'),
+            B('Non Blocking', k='P NoBlock'),
+            B('Auto Close', k='P AutoClose'),
+        ],
         [T('"Get" popups too!')],
-        [B('Get File'), B('Get Folder'), B('Get Date'), B('Get Text')]]
+        [B('Get File'), B('Get Folder'), B('Get Date'), B('Get Text')],
+    ]
 
-    GRAPH_SIZE=(500, 200)
+    GRAPH_SIZE = (500, 200)
     graph_elem = Graph(GRAPH_SIZE, (0, 0), GRAPH_SIZE, key='+GRAPH+')
 
-    frame6 = [[VPush()],[graph_elem]]
+    frame6 = [[VPush()], [graph_elem]]
 
-    themes_tab_layout = [[T('You can see a preview of the themes, the color swatches, or switch themes for this window')],
-                         [T('If you want to change the default theme for PySimpleGUI, use the Global Settings')],
-                         [B('Themes'), B('Theme Swatches'), B('Switch Themes')]]
+    themes_tab_layout = [
+        [T('You can see a preview of the themes, the color swatches, or switch themes for this window')],
+        [T('If you want to change the default theme for PySimpleGUI, use the Global Settings')],
+        [B('Themes'), B('Theme Swatches'), B('Switch Themes')],
+    ]
 
-
-    upgrade_recommendation_tab_layout = [[T('Latest Recommendation and Announcements For You', font='_ 14')],
-                                         [T('Severity Level of Update:'), T(pysimplegui_user_settings.get('-severity level-',''))],
-                                         [T('Recommended Version To Upgrade To:'), T(pysimplegui_user_settings.get('-upgrade recommendation-',''))],
-                                         [T(pysimplegui_user_settings.get('-upgrade message 1-',''))],
-                                         [T(pysimplegui_user_settings.get('-upgrade message 2-',''))],
-                                         [Checkbox('Show Only Critical Messages', default=pysimplegui_user_settings.get('-upgrade show only critical-', False), key='-UPGRADE SHOW ONLY CRITICAL-', enable_events=True)],
-                                         [Button('Show Notification Again'),
-],
-                                         ]
-    tab_upgrade = Tab('Upgrade\n',upgrade_recommendation_tab_layout,  expand_x=True)
-
+    upgrade_recommendation_tab_layout = [
+        [T('Latest Recommendation and Announcements For You', font='_ 14')],
+        [T('Severity Level of Update:'), T(pysimplegui_user_settings.get('-severity level-', ''))],
+        [T('Recommended Version To Upgrade To:'), T(pysimplegui_user_settings.get('-upgrade recommendation-', ''))],
+        [T(pysimplegui_user_settings.get('-upgrade message 1-', ''))],
+        [T(pysimplegui_user_settings.get('-upgrade message 2-', ''))],
+        [
+            Checkbox(
+                'Show Only Critical Messages',
+                default=pysimplegui_user_settings.get('-upgrade show only critical-', False),
+                key='-UPGRADE SHOW ONLY CRITICAL-',
+                enable_events=True,
+            )
+        ],
+        [
+            Button('Show Notification Again'),
+        ],
+    ]
+    tab_upgrade = Tab('Upgrade\n', upgrade_recommendation_tab_layout, expand_x=True)
 
     tab1 = Tab('Graph\n', frame6, tooltip='Graph is in here', title_color='red')
-    tab2 = Tab('CB, Radio\nList, Combo',
-               [[Frame('Multiple Choice Group', frame2, title_color='#FFFFFF', tooltip='Checkboxes, radio buttons, etc', vertical_alignment='t',),
-                 Frame('Binary Choice Group', frame3, title_color='#FFFFFF', tooltip='Binary Choice', vertical_alignment='t', ), ]])
+    tab2 = Tab(
+        'CB, Radio\nList, Combo',
+        [
+            [
+                Frame(
+                    'Multiple Choice Group',
+                    frame2,
+                    title_color='#FFFFFF',
+                    tooltip='Checkboxes, radio buttons, etc',
+                    vertical_alignment='t',
+                ),
+                Frame(
+                    'Binary Choice Group',
+                    frame3,
+                    title_color='#FFFFFF',
+                    tooltip='Binary Choice',
+                    vertical_alignment='t',
+                ),
+            ]
+        ],
+    )
     # tab3 = Tab('Table and Tree', [[Frame('Structured Data Group', frame5, title_color='red', element_justification='l')]], tooltip='tab 3', title_color='red', )
-    tab3 = Tab('Table &\nTree', [[Column(frame5, element_justification='l', vertical_alignment='t')]], tooltip='tab 3', title_color='red', k='-TAB TABLE-')
-    tab4 = Tab('Sliders\n', [[Frame('Variable Choice Group', frame4, title_color='blue')]], tooltip='tab 4', title_color='red', k='-TAB VAR-')
-    tab5 = Tab('Input\nMultiline', [[Frame('TextInput', frame1, title_color='blue')]], tooltip='tab 5', title_color='red', k='-TAB TEXT-')
+    tab3 = Tab(
+        'Table &\nTree',
+        [[Column(frame5, element_justification='l', vertical_alignment='t')]],
+        tooltip='tab 3',
+        title_color='red',
+        k='-TAB TABLE-',
+    )
+    tab4 = Tab(
+        'Sliders\n',
+        [[Frame('Variable Choice Group', frame4, title_color='blue')]],
+        tooltip='tab 4',
+        title_color='red',
+        k='-TAB VAR-',
+    )
+    tab5 = Tab(
+        'Input\nMultiline',
+        [[Frame('TextInput', frame1, title_color='blue')]],
+        tooltip='tab 5',
+        title_color='red',
+        k='-TAB TEXT-',
+    )
     tab6 = Tab('Course or\nSponsor', frame7, k='-TAB SPONSOR-')
     tab7 = Tab('Popups\n', pop_test_tab_layout, k='-TAB POPUP-')
     tab8 = Tab('Themes\n', themes_tab_layout, k='-TAB THEMES-')
 
     def VerLine(version, description, justification='r', size=(40, 1)):
-        return [T(version, justification=justification, font='Any 12', text_color='yellow', size=size, pad=(0,0)), T(description, font='Any 12', pad=(0,0))]
+        return [
+            T(version, justification=justification, font='Any 12', text_color='yellow', size=size, pad=(0, 0)),
+            T(description, font='Any 12', pad=(0, 0)),
+        ]
 
-    layout_top = Column([
-        [Image(EMOJI_BASE64_HAPPY_BIG_SMILE, enable_events=True, key='-LOGO-', tooltip='This is PySimpleGUI logo'),
-         Image(data=DEFAULT_BASE64_LOADING_GIF, enable_events=True, key='-IMAGE-'),
-         Text('PySimpleGUI Test Harness', font='ANY 14',
-              tooltip='My tooltip', key='-TEXT1-')],
-        VerLine(ver, 'PySimpleGUI Version') + [Image(HEART_3D_BASE64, subsample=4)],
-        # VerLine('{}/{}'.format(tkversion, tclversion), 'TK/TCL Versions'),
-        VerLine(tclversion_detailed, 'detailed tkinter version'),
-        VerLine(os.path.dirname(os.path.abspath(__file__)), 'PySimpleGUI Location', size=(40, None)),
-        VerLine(sys.executable, 'Python Executable'),
-        VerLine(sys.version, 'Python Version', size=(40,2)) +[Image(PYTHON_COLORED_HEARTS_BASE64, subsample=3, k='-PYTHON HEARTS-', enable_events=True)]], pad=0)
+    layout_top = Column(
+        [
+            [
+                Image(
+                    EMOJI_BASE64_HAPPY_BIG_SMILE, enable_events=True, key='-LOGO-', tooltip='This is PySimpleGUI logo'
+                ),
+                Image(data=DEFAULT_BASE64_LOADING_GIF, enable_events=True, key='-IMAGE-'),
+                Text('PySimpleGUI Test Harness', font='ANY 14', tooltip='My tooltip', key='-TEXT1-'),
+            ],
+            VerLine(ver, 'PySimpleGUI Version') + [Image(HEART_3D_BASE64, subsample=4)],
+            # VerLine('{}/{}'.format(tkversion, tclversion), 'TK/TCL Versions'),
+            VerLine(tclversion_detailed, 'detailed tkinter version'),
+            VerLine(os.path.dirname(os.path.abspath(__file__)), 'PySimpleGUI Location', size=(40, None)),
+            VerLine(sys.executable, 'Python Executable'),
+            VerLine(sys.version, 'Python Version', size=(40, 2))
+            + [Image(PYTHON_COLORED_HEARTS_BASE64, subsample=3, k='-PYTHON HEARTS-', enable_events=True)],
+        ],
+        pad=0,
+    )
 
     layout_bottom = [
-        [B(SYMBOL_DOWN, pad=(0, 0), k='-HIDE TABS-'),
-         pin(Col([[TabGroup([[tab1, tab2, tab3, tab6, tab4, tab5, tab7, tab8, tab_upgrade]], key='-TAB_GROUP-')]], k='-TAB GROUP COL-'))],
-        [B('Button', highlight_colors=('yellow', 'red'),pad=(1, 0)),
-         B('ttk Button', use_ttk_buttons=True, tooltip='This is a TTK Button',pad=(1, 0)),
-         B('See-through Mode', tooltip='Make the background transparent',pad=(1, 0)),
-         B('Upgrade PySimpleGUI from GitHub', button_color='white on red', key='-INSTALL-',pad=(1, 0)),
-         B('Global Settings', tooltip='Settings across all PySimpleGUI programs',pad=(1, 0)),
-         B('Exit', tooltip='Exit button',pad=(1, 0))],
+        [
+            B(SYMBOL_DOWN, pad=(0, 0), k='-HIDE TABS-'),
+            pin(
+                Col(
+                    [[TabGroup([[tab1, tab2, tab3, tab6, tab4, tab5, tab7, tab8, tab_upgrade]], key='-TAB_GROUP-')]],
+                    k='-TAB GROUP COL-',
+                )
+            ),
+        ],
+        [
+            B('Button', highlight_colors=('yellow', 'red'), pad=(1, 0)),
+            B('ttk Button', use_ttk_buttons=True, tooltip='This is a TTK Button', pad=(1, 0)),
+            B('See-through Mode', tooltip='Make the background transparent', pad=(1, 0)),
+            B('Upgrade PySimpleGUI from GitHub', button_color='white on red', key='-INSTALL-', pad=(1, 0)),
+            B('Global Settings', tooltip='Settings across all PySimpleGUI programs', pad=(1, 0)),
+            B('Exit', tooltip='Exit button', pad=(1, 0)),
+        ],
         # [B(image_data=ICON_BUY_ME_A_COFFEE,pad=(1, 0), key='-COFFEE-'),
-        [B(image_data=UDEMY_ICON,pad=(1, 0), key='-UDEMY-'),
-         B('SDK Reference', pad=(1, 0)), B('Open GitHub Issue',pad=(1, 0)), B('Versions for GitHub',pad=(1, 0)),
-         ButtonMenu('ButtonMenu', button_menu_def, pad=(1, 0),key='-BMENU-', tearoff=True,  disabled_text_color='yellow')
-         ]]
+        [
+            B(image_data=UDEMY_ICON, pad=(1, 0), key='-UDEMY-'),
+            B('SDK Reference', pad=(1, 0)),
+            B('Open GitHub Issue', pad=(1, 0)),
+            B('Versions for GitHub', pad=(1, 0)),
+            ButtonMenu(
+                'ButtonMenu', button_menu_def, pad=(1, 0), key='-BMENU-', tearoff=True, disabled_text_color='yellow'
+            ),
+        ],
+    ]
 
     layout = [[]]
 
     if not theme_use_custom_titlebar():
-        layout += [[Menu(menu_def, key='-MENU-', font='Courier 15', background_color='red', text_color='white', disabled_text_color='yellow', tearoff=True)]]
+        layout += [
+            [
+                Menu(
+                    menu_def,
+                    key='-MENU-',
+                    font='Courier 15',
+                    background_color='red',
+                    text_color='white',
+                    disabled_text_color='yellow',
+                    tearoff=True,
+                )
+            ]
+        ]
     else:
-        layout += [[MenubarCustom(menu_def, key='-MENU-', font='Courier 15', bar_background_color=theme_background_color(), bar_text_color=theme_text_color(),
-                                  background_color='red', text_color='white', disabled_text_color='yellow')]]
+        layout += [
+            [
+                MenubarCustom(
+                    menu_def,
+                    key='-MENU-',
+                    font='Courier 15',
+                    bar_background_color=theme_background_color(),
+                    bar_text_color=theme_text_color(),
+                    background_color='red',
+                    text_color='white',
+                    disabled_text_color='yellow',
+                )
+            ]
+        ]
 
     layout += [[layout_top] + [ProgressBar(max_value=800, size=(20, 25), orientation='v', key='+PROGRESS+')]]
     layout += layout_bottom
 
-    window = Window('PySimpleGUI Main Test Harness', layout,
-                    # font=('Helvetica', 18),
-                    # background_color='black',
-                    right_click_menu=['&Right', ['Right', 'Edit Me', '!&Click', '&Menu', 'E&xit', 'Properties']],
-                    # transparent_color= '#9FB8AD',
-                    resizable=True,
-                    keep_on_top=False,
-                    element_justification='left',  # justify contents to the left
-                    metadata='My window metadata',
-                    finalize=True,
-                    # grab_anywhere=True,
-                    enable_close_attempted_event=True,
-                    modal=False,
-                    # ttk_theme=THEME_CLASSIC,
-                    # scaling=2,
-                    # icon=PSG_DEBUGGER_LOGO,
-                    # icon=PSGDebugLogo,
-                    )
-    # window['-SPONSOR-'].set_cursor(cursor='hand2')
+    window = Window(
+        'PySimpleGUI Main Test Harness',
+        layout,
+        # font=('Helvetica', 18),
+        # background_color='black',
+        right_click_menu=['&Right', ['Right', 'Edit Me', '!&Click', '&Menu', 'E&xit', 'Properties']],
+        # transparent_color= '#9FB8AD',
+        resizable=True,
+        keep_on_top=False,
+        element_justification='left',  # justify contents to the left
+        metadata='My window metadata',
+        finalize=True,
+        enable_close_attempted_event=True,
+        modal=False,
+    )
     window._see_through = False
     return window
 
@@ -25827,16 +33288,31 @@ def main():
             print(event, values)
             # Print(event, text_color='white', background_color='red', end='')
             # Print(values)
-        if event == WIN_CLOSED or event == WIN_CLOSE_ATTEMPTED_EVENT or event == 'Exit' or (event == '-BMENU-' and values['-BMENU-'] == 'Exit'):
+        if (
+            event == WIN_CLOSED
+            or event == WIN_CLOSE_ATTEMPTED_EVENT
+            or event == 'Exit'
+            or (event == '-BMENU-' and values['-BMENU-'] == 'Exit')
+        ):
             break
         if i < graph_elem.CanvasSize[0]:
             x = i % graph_elem.CanvasSize[0]
-            fig = graph_elem.draw_line((x, 0), (x, random.randint(0, graph_elem.CanvasSize[1])), width=1, color='#{:06x}'.format(random.randint(0, 0xffffff)))
+            fig = graph_elem.draw_line(
+                (x, 0),
+                (x, random.randint(0, graph_elem.CanvasSize[1])),
+                width=1,
+                color='#{:06x}'.format(random.randint(0, 0xFFFFFF)),
+            )
             graph_figures.append(fig)
         else:
             x = graph_elem.CanvasSize[0]
             graph_elem.move(-1, 0)
-            fig = graph_elem.draw_line((x, 0), (x, random.randint(0, graph_elem.CanvasSize[1])), width=1, color='#{:06x}'.format(random.randint(0, 0xffffff)))
+            fig = graph_elem.draw_line(
+                (x, 0),
+                (x, random.randint(0, graph_elem.CanvasSize[1])),
+                width=1,
+                color='#{:06x}'.format(random.randint(0, 0xFFFFFF)),
+            )
             graph_figures.append(fig)
             graph_elem.delete_figure(graph_figures[0])
             del graph_figures[0]
@@ -25850,7 +33326,13 @@ def main():
         elif event == 'Launch Debugger':
             show_debugger_window()
         elif event == 'About...':
-            popup('About this program...', 'You are looking at the test harness for the PySimpleGUI program', version, keep_on_top=True, image=DEFAULT_BASE64_ICON)
+            popup(
+                'About this program...',
+                'You are looking at the test harness for the PySimpleGUI program',
+                version,
+                keep_on_top=True,
+                image=DEFAULT_BASE64_ICON,
+            )
         elif event.startswith('See'):
             window._see_through = not window._see_through
             window.set_transparent_color(theme_background_color() if window._see_through else '')
@@ -25872,10 +33354,12 @@ def main():
             pass
         elif event == '-COFFEE-':
             pass
-        elif event in  ('-EMOJI-HEARTS-', '-HEART-', '-PYTHON HEARTS-'):
+        elif event in ('-EMOJI-HEARTS-', '-HEART-', '-PYTHON HEARTS-'):
             pass
         elif event == 'Themes':
-            search_string = popup_get_text('Enter a search term or leave blank for all themes', 'Show Available Themes', keep_on_top=True)
+            search_string = popup_get_text(
+                'Enter a search term or leave blank for all themes', 'Show Available Themes', keep_on_top=True
+            )
             if search_string is not None:
                 theme_previewer(search_string=search_string)
         elif event == 'Theme Swatches':
@@ -25886,7 +33370,7 @@ def main():
             window = _create_main_window()
             graph_elem = window['+GRAPH+']
         elif event == '-HIDE TABS-':
-            window['-TAB GROUP COL-'].update(visible=window['-TAB GROUP COL-'].metadata == True)
+            window['-TAB GROUP COL-'].update(visible=window['-TAB GROUP COL-'].metadata is True)
             window['-TAB GROUP COL-'].metadata = not window['-TAB GROUP COL-'].metadata
             window['-HIDE TABS-'].update(text=SYMBOL_UP if window['-TAB GROUP COL-'].metadata else SYMBOL_DOWN)
         elif event == 'SDK Reference':
@@ -25906,8 +33390,14 @@ def main():
                 popup_no_titlebar('No titlebar', keep_on_top=True)
             elif event == 'P NoModal':
                 set_options(force_modal_windows=False)
-                popup('Normal Popup - Not Modal', 'You can interact with main window menubar ',
-                      'but will have no effect immediately', 'button clicks will happen after you close this popup', modal=False, keep_on_top=True)
+                popup(
+                    'Normal Popup - Not Modal',
+                    'You can interact with main window menubar ',
+                    'but will have no effect immediately',
+                    'button clicks will happen after you close this popup',
+                    modal=False,
+                    keep_on_top=True,
+                )
                 set_options(force_modal_windows=forced_modal)
             elif event == 'P NoBlock':
                 popup_non_blocking('Non-blocking', 'The background window should still be running', keep_on_top=True)
@@ -25932,6 +33422,7 @@ def main():
     print('event = ', event)
     window.close()
     set_options(force_modal_windows=forced_modal)
+
 
 # ------------------------ PEP8-ify The SDK ------------------------#
 
@@ -25989,6 +33480,7 @@ TimerStop = timer_stop
 test = main
 sdk_help = main_sdk_help
 
+
 def _optional_window_data(window):
     """
     A function to help with testing PySimpleGUI releases. Makes it easier to add a watermarked line to the bottom
@@ -26001,7 +33493,10 @@ def _optional_window_data(window):
     """
     return None
 
-pysimplegui_user_settings = UserSettings(filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH)
+
+pysimplegui_user_settings = UserSettings(
+    filename=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_FILENAME, path=DEFAULT_USER_SETTINGS_PYSIMPLEGUI_PATH
+)
 # ------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
 
 
@@ -26017,7 +33512,12 @@ if running_trinket():
     USE_CUSTOM_TITLEBAR = True
 
 if tclversion_detailed.startswith('8.5'):
-    warnings.warn('You are running a VERY old version of tkinter {}. You cannot use PNG formatted images for example.  Please upgrade to 8.6.x'.format(tclversion_detailed), UserWarning)
+    warnings.warn(
+        'You are running a VERY old version of tkinter {}. You cannot use PNG formatted images for example.  Please upgrade to 8.6.x'.format(
+            tclversion_detailed
+        ),
+        UserWarning,
+    )
 
 # Enables the correct application icon to be shown on the Windows taskbar
 if running_windows():
@@ -26035,14 +33535,15 @@ if _mac_should_set_alpha_to_99():
     set_options(alpha_channel=0.99)
 
 
-
-
 # -------------------------------- ENTRY POINT IF RUN STANDALONE -------------------------------- #
 if __name__ == '__main__':
     # To execute the upgrade from command line, type:
     # python -m PySimpleGUI.PySimpleGUI upgrade
     if len(sys.argv) > 1 and sys.argv[1] == 'upgrade':
-        print('Upgrading FreeSimpleGUI in place is not supported. Please use pip or your preferred package manager to update FreeSimpleGUI.', file=sys.stderr)
+        print(
+            'Upgrading FreeSimpleGUI in place is not supported. Please use pip or your preferred package manager to update FreeSimpleGUI.',
+            file=sys.stderr,
+        )
         exit(1)
     elif len(sys.argv) > 1 and sys.argv[1] == 'help':
         main_sdk_help()

--- a/FreeSimpleGUIQt/FreeSimpleGUIQt/FreeSimpleGUIQt.py
+++ b/FreeSimpleGUIQt/FreeSimpleGUIQt/FreeSimpleGUIQt.py
@@ -742,9 +742,7 @@ class InputText(Element):
         self._ReturnKeyHandler(None)
         return
 
-    def Update(
-        self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None):
         if disabled is True:
             self.QT_QLineEdit.setDisabled(True)
         elif disabled is False:
@@ -757,9 +755,7 @@ class InputText(Element):
             # self.ValueWasChanged = True
         if select:
             self.QT_QLineEdit.setSelection(0, QtGui.QTextCursor.End)
-        super().Update(
-            self.QT_QLineEdit, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_QLineEdit, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         return self.QT_QLineEdit.text()
@@ -913,9 +909,7 @@ class Combo(Element):
         if readonly is not None:
             self.Readonly = readonly
 
-        super().Update(
-            self.QT_ComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_ComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     update = Update
 
@@ -1143,9 +1137,7 @@ class Listbox(Element):
             self.QT_ListWidget.setDisabled(False)
         if set_to_index is not None:
             self.QT_ListWidget.setCurrentRow(set_to_index)
-        super().Update(
-            self.QT_ListWidget, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_ListWidget, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
         return
 
@@ -1285,9 +1277,7 @@ class Radio(Element):
             self.QT_RadioButtonGroup.setExclusive(False)
             self.QT_Radio_Button.setChecked(False)
             self.QT_RadioButtonGroup.setExclusive(True)
-        super().Update(
-            self.QT_Radio_Button, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_Radio_Button, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def reset_group(self):
         self.QT_Radio_Button.setChecked(True)
@@ -1405,9 +1395,7 @@ class Checkbox(Element):
             self.QT_Checkbox.setDisabled(True)
         elif disabled == False:
             self.QT_Checkbox.setDisabled(False)
-        super().Update(
-            self.QT_Checkbox, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_Checkbox, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     get = Get
     update = Update
@@ -1533,9 +1521,7 @@ class Spin(Element):
             return
         _element_callback_quit_mainloop(self)
 
-    def Update(
-        self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
         if values != None:
             self.Values = values
             self.QT_Spinner.setStrings(values)
@@ -1551,9 +1537,7 @@ class Spin(Element):
             self.QT_Spinner.setDisabled(True)
         elif disabled == False:
             self.QT_Spinner.setDisabled(False)
-        super().Update(
-            self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         return self.QT_Spinner.value()
@@ -1757,9 +1741,7 @@ class Multiline(Element):
             self.QT_TextEdit.setReadOnly(True)
         elif readonly is False:
             self.QT_TextEdit.setReadOnly(False)
-        super().Update(
-            self.QT_TextEdit, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_TextEdit, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         return self.QT_TextEdit.toPlainText()
@@ -1932,9 +1914,7 @@ class MultilineOutput(Element):
             self.QT_TextBrowser.setDisabled(False)
         if self.Autoscroll or autoscroll and autoscroll is not False:
             self.QT_TextBrowser.moveCursor(QtGui.QTextCursor.End)
-        super().Update(
-            self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         return self.QT_TextBrowser.toPlainText()
@@ -2083,9 +2063,7 @@ class Text(Element):
         if value is not None:
             self.DisplayText = str(value)
             self.QT_Label.setText(str(value))
-        super().Update(
-            self.QT_Label, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_Label, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     update = Update
 
@@ -2192,9 +2170,7 @@ class Output(Element):
     def Update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.QT_TextBrowser.setText(value)
-        super().Update(
-            self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def __del__(self):
         sys.stdout = self.my_stdout
@@ -2466,9 +2442,7 @@ class Button(Element):
             if self.ParentForm.CurrentlyRunningMainloop:  # if this window is running the mainloop, kick out
                 self.ParentForm.QTApplication.exit()
             Window.DecrementOpenCount()
-        elif (
-            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
-        ):  # this is a return type button so GET RESULTS and destroy window
+        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
             should_submit_window = False
 
         if should_submit_window:
@@ -4042,9 +4016,7 @@ class Column(Element):
         self.vbox_layout = None  # type: QVBoxLayout
         self.Layout(layout)
 
-        super().__init__(
-            ELEM_TYPE_COLUMN, background_color=bg, size=size, pad=pad, key=key, visible=visible, metadata=metadata
-        )
+        super().__init__(ELEM_TYPE_COLUMN, background_color=bg, size=size, pad=pad, key=key, visible=visible, metadata=metadata)
         return
 
     def AddRow(self, *args):
@@ -4280,9 +4252,7 @@ class Table(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
         self.HeaderTextColor = header_text_color if header_text_color is not None else theme_input_text_color()
-        self.HeaderBackgroundColor = (
-            header_background_color if header_background_color is not None else theme_input_background_color()
-        )
+        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else theme_input_background_color()
         self.HeaderFont = header_font
         self.Justification = justification
         self.InitialState = None
@@ -4511,9 +4481,7 @@ class Tree(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
         self.HeaderTextColor = header_text_color if header_text_color is not None else theme_input_text_color()
-        self.HeaderBackgroundColor = (
-            header_background_color if header_background_color is not None else theme_input_background_color()
-        )
+        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else theme_input_background_color()
         self.HeaderFont = header_font
         self.Justification = justification
         self.InitialState = None
@@ -4653,10 +4621,7 @@ class TreeData(object):
         return self._NodeStr(self.root_node, 1)
 
     def _NodeStr(self, node, level):
-        return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text)]
-            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
-        )
+        return '\n'.join([str(node.key) + ' : ' + str(node.text)] + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
 
     insert = Insert
 
@@ -5039,11 +5004,7 @@ class Window:
         self.Title = title
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = _convert_tkinter_size_to_Qt(default_element_size)
-        self.DefaultButtonElementSize = (
-            _convert_tkinter_size_to_Qt(default_button_element_size)
-            if default_button_element_size != (None, None)
-            else DEFAULT_BUTTON_ELEMENT_SIZE
-        )
+        self.DefaultButtonElementSize = _convert_tkinter_size_to_Qt(default_button_element_size) if default_button_element_size != (None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
         self.Location = location
         self.ButtonColor = button_color if button_color else DEFAULT_BUTTON_COLOR
         self.BackgroundColor = background_color if background_color else DEFAULT_BACKGROUND_COLOR
@@ -5187,9 +5148,7 @@ class Window:
         return self
 
     def LayoutAndRead(self, rows, non_blocking=False):
-        raise DeprecationWarning(
-            'LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()'
-        )
+        raise DeprecationWarning('LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()')
         # self.AddRows(rows)
         # self.Show(non_blocking=non_blocking)
         # return self.ReturnValues
@@ -5367,13 +5326,9 @@ class Window:
                 self.LastButtonClicked = None
             return results
         else:
-            if (
-                not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None
-            ):  # Special Qt case because returning for no reason so fake timeout
+            if not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None:  # Special Qt case because returning for no reason so fake timeout
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
-            elif (
-                not self.XFound and self.ReturnValues[0] is None
-            ):  # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
+            elif not self.XFound and self.ReturnValues[0] is None:  # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
                 # print("*** Faking timeout ***")
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
             return self.ReturnValues
@@ -5485,18 +5440,10 @@ class Window:
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        (
-                            print('*** Duplicate key found in your layout {} ***'.format(element.Key))
-                            if element.Type != ELEM_TYPE_BUTTON
-                            else None
-                        )
+                        (print('*** Duplicate key found in your layout {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None)
                         element.Key = str(element.Key) + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
-                        (
-                            print('*** Replaced new key with {} ***'.format(element.Key))
-                            if element.Type != ELEM_TYPE_BUTTON
-                            else None
-                        )
+                        (print('*** Replaced new key with {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None)
                     key_dict[element.Key] = element
         return key_dict
 
@@ -6015,9 +5962,7 @@ def _element_callback_quit_mainloop(element):
 # =========================================================================== #
 # Convert from characters to pixels                                           #
 # =========================================================================== #
-def _convert_tkinter_size_to_Qt(
-    size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF
-):
+def _convert_tkinter_size_to_Qt(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF):
     """
     Converts size in characters to size in pixels
     :param size:  size in characters, rows
@@ -7261,11 +7206,7 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
             if not initialize_only:
                 if element.Type == ELEM_TYPE_INPUT_TEXT:
                     value = element.QT_QLineEdit.text()
-                    if (
-                        not top_level_form.NonBlocking
-                        and not element.do_not_clear
-                        and not top_level_form.ReturnKeyboardEvents
-                    ):
+                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
                         element.QT_QLineEdit.setText('')
 
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
@@ -7290,9 +7231,7 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                             value = None
                 elif element.Type == ELEM_TYPE_INPUT_COMBO:
                     element = element  # type: Combo
-                    index = (
-                        element.QT_ComboBox.currentIndex()
-                    )  # index into the list of values, but can be larger if manual entry
+                    index = element.QT_ComboBox.currentIndex()  # index into the list of values, but can be larger if manual entry
                     if index < len(element.Values):
                         value = element.Values[index]
                     else:  # if not a valid index, then get what was typed in
@@ -7326,11 +7265,7 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                     if element.WriteOnly:
                         continue
                     value = element.QT_TextEdit.toPlainText()
-                    if (
-                        not top_level_form.NonBlocking
-                        and not element.do_not_clear
-                        and not top_level_form.ReturnKeyboardEvents
-                    ):
+                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
                         element.QT_TextEdit.setText('')
                 elif element.Type == ELEM_TYPE_TAB_GROUP:
                     element = element  # type: TabGroup
@@ -7360,29 +7295,12 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 value = None
 
             # if an input type element, update the results
-            if (
-                element.Type != ELEM_TYPE_BUTTON
-                and element.Type != ELEM_TYPE_TEXT
-                and element.Type != ELEM_TYPE_IMAGE
-                and element.Type != ELEM_TYPE_OUTPUT
-                and element.Type != ELEM_TYPE_PROGRESS_BAR
-                and element.Type != ELEM_TYPE_COLUMN
-                and element.Type != ELEM_TYPE_FRAME
-                and element.Type != ELEM_TYPE_TAB
-            ):
+            if element.Type != ELEM_TYPE_BUTTON and element.Type != ELEM_TYPE_TEXT and element.Type != ELEM_TYPE_IMAGE and element.Type != ELEM_TYPE_OUTPUT and element.Type != ELEM_TYPE_PROGRESS_BAR and element.Type != ELEM_TYPE_COLUMN and element.Type != ELEM_TYPE_FRAME and element.Type != ELEM_TYPE_TAB:
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
             elif (
-                (
-                    element.Type == ELEM_TYPE_BUTTON
-                    and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER
-                    and element.Target == (None, None)
-                )
-                or (
-                    element.Type == ELEM_TYPE_BUTTON
-                    and element.BType == BUTTON_TYPE_COLOR_CHOOSER
-                    and element.Target == (None, None)
-                )
+                (element.Type == ELEM_TYPE_BUTTON and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER and element.Target == (None, None))
+                or (element.Type == ELEM_TYPE_BUTTON and element.BType == BUTTON_TYPE_COLOR_CHOOSER and element.Target == (None, None))
                 or (
                     element.Type == ELEM_TYPE_BUTTON
                     and element.Key is not None
@@ -8065,11 +7983,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style === end
 
                 # element.QT_QPushButton.setFlat(False)
-                if (
-                    element.AutoSizeButton is False
-                    or toplevel_win.AutoSizeButtons is False
-                    or element.Size[0] is not None
-                ) and element.ImageData is None:
+                if (element.AutoSizeButton is False or toplevel_win.AutoSizeButtons is False or element.Size[0] is not None) and element.ImageData is None:
                     if element_size[0] is not None:
                         element.QT_QPushButton.setFixedWidth(element_size[0])
                     if element_size[1] is not None:
@@ -8410,9 +8324,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
 
                     style['border'] = '%spx solid grey' % border_depth
                     style['border-radius'] = '0px'
-                    style['background-color'] = str(
-                        element.BarColor[1] if element.BarColor[1] is not None else DEFAULT_PROGRESS_BAR_COLOR[1]
-                    )
+                    style['background-color'] = str(element.BarColor[1] if element.BarColor[1] is not None else DEFAULT_PROGRESS_BAR_COLOR[1])
 
                 element.QT_QProgressBar.setStyleSheet(style.build_css_string() + style_chunk.build_css_string())
                 element.qt_styles = (style, style_chunk)
@@ -8636,10 +8548,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                     menu_style['font'] = create_style_from_font(font)
                     if element.MenuItemTextColor is not None and element.MenuItemTextColor != COLOR_SYSTEM_DEFAULT:
                         menu_style['color'] = element.MenuItemTextColor
-                    if (
-                        element.MenuItemBackgroundColor is not None
-                        and element.MenuItemBackgroundColor != COLOR_SYSTEM_DEFAULT
-                    ):
+                    if element.MenuItemBackgroundColor is not None and element.MenuItemBackgroundColor != COLOR_SYSTEM_DEFAULT:
                         menu_style['background-color'] = element.MenuItemBackgroundColor
                     # style['margin'] = full_element_pad
                     baritem.setStyleSheet(menu_style.build_css_string())
@@ -8675,11 +8584,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 element.qt_styles = (style,)
                 # === style === end
 
-                if (
-                    element.AutoSizeButton is False
-                    or toplevel_win.AutoSizeButtons is False
-                    or element.Size[0] is not None
-                ) and element.ImageData is None:
+                if (element.AutoSizeButton is False or toplevel_win.AutoSizeButtons is False or element.Size[0] is not None) and element.ImageData is None:
                     if element_size[0] is not None:
                         element.QT_QPushButton.setFixedWidth(element_size[0])
                     if element_size[1] is not None:
@@ -8998,9 +8903,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
             # -------------------------  TABLE placement element  ------------------------- #
             elif element_type == ELEM_TYPE_TABLE:
                 element = element  # type: Table
-                element.Widget = element.QT_TableWidget = Table.QTTableWidget(
-                    toplevel_win.ReturnKeyboardEvents, toplevel_win
-                )
+                element.Widget = element.QT_TableWidget = Table.QTTableWidget(toplevel_win.ReturnKeyboardEvents, toplevel_win)
                 if element.NumRows is not None:
                     element.QT_TableWidget.setFixedHeight(element.NumRows * 35 + 25)
                 # element.QT_TableWidget = QTableWidget()
@@ -9016,14 +8919,10 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 style['border'] = '{}px solid gray'.format(border_depth)
 
                 # more css: ScrollBar
-                style.append_css_to_end.append(
-                    ' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } '
-                )
+                style.append_css_to_end.append(' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } ')
                 # more css: QHeaderView
                 header_style = QtStyle('QHeaderView::section')
-                header_style['font'] = create_style_from_font(
-                    element.HeaderFont if element.HeaderFont is not None else font
-                )
+                header_style['font'] = create_style_from_font(element.HeaderFont if element.HeaderFont is not None else font)
                 header_style['background-color'] = element.HeaderBackgroundColor
                 header_style['color'] = element.HeaderTextColor
 
@@ -9116,14 +9015,10 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                     style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
-                style.append_css_to_end.append(
-                    ' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } '
-                )
+                style.append_css_to_end.append(' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } ')
 
                 header_style = QtStyle('QHeaderView::section')
-                header_style['font'] = create_style_from_font(
-                    element.HeaderFont if element.HeaderFont is not None else font
-                )
+                header_style['font'] = create_style_from_font(element.HeaderFont if element.HeaderFont is not None else font)
                 header_style['background-color'] = element.HeaderBackgroundColor
                 header_style['color'] = element.HeaderTextColor
 
@@ -9484,9 +9379,7 @@ class QuickMeter(object):
     def BuildWindow(self, *args):
         layout = []
         if self.orientation.lower().startswith('h'):
-            col = [
-                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
-            ]  ### convert all *args into one string that can be updated
+            col = [[T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]]  ### convert all *args into one string that can be updated
             col += [
                 [T('', size=(25, 5), key='_STATS_')],
                 [
@@ -9513,9 +9406,7 @@ class QuickMeter(object):
                     )
                 ]
             ]
-            col2 = [
-                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
-            ]  ### convert all *args into one string that can be updated
+            col2 = [[T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]]  ### convert all *args into one string that can be updated
             col2 += [[T('', size=(25, 5), key='_STATS_')], [Cancel(button_color=self.button_color), Stretch()]]
             layout += [Column(col), Column(col2)]
         self.window = Window(self.title, grab_anywhere=self.grab_anywhere, border_depth=self.border_width)
@@ -9528,18 +9419,12 @@ class QuickMeter(object):
         self.max_value = max_value
         self.window.Element('_PROG_').UpdateBar(self.current_value, self.max_value)
         self.window.Element('_STATS_').Update('\n'.join(self.ComputeProgressStats()))
-        self.window.Element('_OPTMSG_').Update(
-            value=''.join(map(lambda x: str(x) + '\n', args))
-        )  ###  update the string with the args
+        self.window.Element('_OPTMSG_').Update(value=''.join(map(lambda x: str(x) + '\n', args)))  ###  update the string with the args
         event, values = self.window.Read(timeout=0)
         if event in ('Cancel', None) or current_value >= max_value:
             self.window.Close()
             del QuickMeter.active_meters[self.key]
-            QuickMeter.exit_reasons[self.key] = (
-                METER_REASON_CANCELLED
-                if event == 'Cancel'
-                else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
-            )
+            QuickMeter.exit_reasons[self.key] = METER_REASON_CANCELLED if event == 'Cancel' else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
             return QuickMeter.exit_reasons[self.key]
         return METER_OK
 
@@ -9695,9 +9580,7 @@ class DebugWin:
             grab_anywhere=grab_anywhere,
             keep_on_top=keep_on_top,
         )
-        self.output_element = (
-            MultilineOutput(size=win_size, key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
-        )
+        self.output_element = MultilineOutput(size=win_size, key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
 
         if no_button:
             self.layout = [[self.output_element]]
@@ -9973,9 +9856,7 @@ def cprint(
 # ------------------------------------------------------------------------------------------------ #
 
 
-def _print_to_element(
-    multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True
-):
+def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True):
     """
     Print like Python normally prints except route the output to a multline element and also add colors if desired
 
@@ -10085,9 +9966,7 @@ def PopupScrolled(
         height_computed += lines_needed
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = (
-        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
-    )
+    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
     if height:
         height_computed = height
     computed_size = (max_line_width * 10, height_computed * 16)
@@ -10098,9 +9977,7 @@ def PopupScrolled(
     if yes_no:
         window.AddRow(Text('', size=(pad, 1), auto_size_text=False), button('Yes'), button('No'))
     else:
-        window.AddRow(
-            Text('', size=(pad, 1), auto_size_text=False), button('OK', size=(5, 1), button_color=button_color)
-        )
+        window.AddRow(Text('', size=(pad, 1), auto_size_text=False), button('OK', size=(5, 1), button_color=button_color))
 
     if non_blocking:
         button, values = window.Read(timeout=0)
@@ -12692,11 +12569,7 @@ def ObjToStringSingleObj(obj):
     """
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
-    )
+    return str(obj.__class__) + '\n' + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
 
 
 def ObjToString(obj, extra='    '):
@@ -12711,25 +12584,7 @@ def ObjToString(obj, extra='    '):
     """
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join(
-            (
-                extra
-                + (
-                    str(item)
-                    + ' = '
-                    + (
-                        ObjToString(obj.__dict__[item], extra + '    ')
-                        if hasattr(obj.__dict__[item], '__dict__')
-                        else str(obj.__dict__[item])
-                    )
-                )
-                for item in sorted(obj.__dict__)
-            )
-        )
-    )
+    return str(obj.__class__) + '\n' + '\n'.join((extra + (str(item) + ' = ' + (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(obj.__dict__[item]))) for item in sorted(obj.__dict__)))
 
 
 # ------------------------------------------------------------------------------------------------------------------ #
@@ -12856,9 +12711,7 @@ def Popup(
         max_line_total = max(max_line_total, width_used)
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
-        window.AddRow(
-            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)
-        )
+        window.AddRow(Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color))
         total_lines += height
 
     # if total_lines < 3:
@@ -12890,9 +12743,7 @@ def Popup(
             ]
         )
     elif button_type is POPUP_BUTTONS_CANCELLED:
-        layout.append(
-            [PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True), Stretch()]
-        )
+        layout.append([PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True), Stretch()])
     elif button_type is POPUP_BUTTONS_ERROR:
         layout.append(
             [
@@ -12911,9 +12762,7 @@ def Popup(
     elif button_type is POPUP_BUTTONS_NO_BUTTONS:
         pass
     else:
-        layout.append(
-            [PopupButton('OK', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True), Stretch()]
-        )
+        layout.append([PopupButton('OK', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True), Stretch()])
 
     window.Layout(layout)
     if non_blocking:
@@ -13969,11 +13818,7 @@ def PopupGetFile(
             filename = QFileDialog.getOpenFileName(dir=initial_folder, filter=qt_types)
         return filename[0]
 
-    browse_button = (
-        SaveAs(file_types=file_types, initial_folder=initial_folder)
-        if save_as
-        else FileBrowse(file_types=file_types, initial_folder=initial_folder)
-    )
+    browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder) if save_as else FileBrowse(file_types=file_types, initial_folder=initial_folder)
 
     if image is not None:
         if isinstance(image, str):
@@ -14258,9 +14103,7 @@ def main():
 
     frame4 = [
         [
-            Slider(
-                range=(0, 100), tick_interval=None, orientation='v', size=(3, 30), default_value=40, tooltip='Slider'
-            ),
+            Slider(range=(0, 100), tick_interval=None, orientation='v', size=(3, 30), default_value=40, tooltip='Slider'),
             Dial(range=(0, 100), tick_interval=1, resolution=1, size=(150, 150), default_value=40, tooltip='Dial'),
             Stretch(),
         ],
@@ -14315,9 +14158,7 @@ def main():
         [Text('VERSION {}'.format(ver), size=(85, 1), text_color='yellow', font='ANY 18')],
         # [Image(data_base64=logo, tooltip='Image', click_submits=True, key='_IMAGE_'),
         [
-            Frame(
-                'Input Text Group', frame1, title_color='yellow', tooltip='Text Group', frame_color='yellow', pad=(0, 0)
-            ),
+            Frame('Input Text Group', frame1, title_color='yellow', tooltip='Text Group', frame_color='yellow', pad=(0, 0)),
             Stretch(),
         ],
         [
@@ -14336,9 +14177,7 @@ def main():
             ProgressBar(max_value=600, start_value=400, size=(600, 25), key='+PROGRESS+'),
             Text('', key='_PROGTEXT_'),
             Stretch(),
-            ButtonMenu(
-                '&Menu', ['Menu', ['&Pause Graph', 'Menu item::optional_key']], key='_MENU_', tooltip='Button Menu'
-            ),
+            ButtonMenu('&Menu', ['Menu', ['&Pause Graph', 'Menu item::optional_key']], key='_MENU_', tooltip='Button Menu'),
             Button('Button'),
             Button('Exit', tooltip='Exit button'),
         ],
@@ -14373,14 +14212,10 @@ def main():
         if not graph_paused:
 
             if i < 600:
-                graph_elem.DrawLine(
-                    (i, 0), (i, random.randint(0, 300)), width=1, color='#{:06x}'.format(random.randint(0, 0xFFFFFF))
-                )
+                graph_elem.DrawLine((i, 0), (i, random.randint(0, 300)), width=1, color='#{:06x}'.format(random.randint(0, 0xFFFFFF)))
             else:
                 graph_elem.Move(-1, 0)
-                graph_elem.DrawLine(
-                    (i, 0), (i, random.randint(0, 300)), width=1, color='#{:06x}'.format(random.randint(0, 0xFFFFFF))
-                )
+                graph_elem.DrawLine((i, 0), (i, random.randint(0, 300)), width=1, color='#{:06x}'.format(random.randint(0, 0xFFFFFF)))
 
         window.FindElement('+PROGRESS+').UpdateBar(i % 600)
         window.FindElement('_PROGTEXT_').Update((i % 600) // 6)

--- a/FreeSimpleGUIQt/FreeSimpleGUIQt/FreeSimpleGUIQt.py
+++ b/FreeSimpleGUIQt/FreeSimpleGUIQt/FreeSimpleGUIQt.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python3
-version = __version__ = '0.35.0.18.1 Unreleased\nMassive update of docstrings (thanks nngogol), default for slider tick interval set automatically now, margins added to Window but not yet hooked up, VSeparator added (spelling error), added Radio.reset_group and removed clearing all when one of them is cleared (recent change), added default key for one_line_progress_meter, auto-add keys to tables & trees, InputText element gets new disabled-readonly foreground and background color settings and also a readonly parameter, InputText gets border_width parameter, fixed up some docstrings, popup gets new image and any_key_closes parms, input type popups also get image parameter, error checks for trying to manipulate a window prior to finalize, added a dummy Element.expand method, added theme_add_new, added Window.set_title, updated to the latest themes from tktiner port, big styles update (thanks nngogol!), more Styles work, changed popup text layout to match tkinter port, fixed vertical alignment in row, added margin to some elements, renamed styles related variables, window margin support but be careful. Added back the truncated portion'
+version = __version__ = (
+    '0.35.0.18.1 Unreleased\nMassive update of docstrings (thanks nngogol), default for slider tick interval set automatically now, margins added to Window but not yet hooked up, VSeparator added (spelling error), added Radio.reset_group and removed clearing all when one of them is cleared (recent change), added default key for one_line_progress_meter, auto-add keys to tables & trees, InputText element gets new disabled-readonly foreground and background color settings and also a readonly parameter, InputText gets border_width parameter, fixed up some docstrings, popup gets new image and any_key_closes parms, input type popups also get image parameter, error checks for trying to manipulate a window prior to finalize, added a dummy Element.expand method, added theme_add_new, added Window.set_title, updated to the latest themes from tktiner port, big styles update (thanks nngogol!), more Styles work, changed popup text layout to match tkinter port, fixed vertical alignment in row, added margin to some elements, renamed styles related variables, window margin support but be careful. Added back the truncated portion'
+)
 
-__version__ = version.split()[0]    # For PEP 396 and PEP 345
+__version__ = version.split()[0]  # For PEP 396 and PEP 345
 
 # The shortened version of version
 try:
@@ -13,8 +15,15 @@ except:
 port = 'PySimpleGUIQt'
 
 import sys, datetime, textwrap, pickle, random, warnings, time
-try:        # Because Raspberry Pi is still on 3.4....it's not critical if this module isn't imported on the Pi
-    from typing import List, Any, Union, Tuple, Dict    # because this code has to run on 2.7 can't use real type hints.  Must do typing only in comments
+
+try:  # Because Raspberry Pi is still on 3.4....it's not critical if this module isn't imported on the Pi
+    from typing import (
+        List,
+        Any,
+        Union,
+        Tuple,
+        Dict,
+    )  # because this code has to run on 2.7 can't use real type hints.  Must do typing only in comments
 except:
     print('*** Skipping import of Typing module. "pip3 install typing" to remove this warning ***')
 
@@ -22,10 +31,58 @@ except:
 # Copyright 2020 PySimpleGUI.org
 
 
-from PySide2.QtWidgets import QApplication, QLabel, QWidget, QLineEdit, QComboBox, QFormLayout, QVBoxLayout, QHBoxLayout, QListWidget, QDial, QTableWidget
-from PySide2.QtWidgets import QSlider, QCheckBox, QRadioButton, QSpinBox, QPushButton, QTextEdit, QMainWindow, QDialog, QAbstractItemView
-from PySide2.QtWidgets import QSpacerItem, QFrame, QGroupBox, QTextBrowser, QPlainTextEdit, QButtonGroup, QFileDialog, QTableWidget, QTabWidget, QTabBar, QTreeWidget, QTreeWidgetItem, QLayout, QTreeWidgetItemIterator, QProgressBar
-from PySide2.QtWidgets import QTableWidgetItem, QGraphicsView, QGraphicsScene, QGraphicsItemGroup, QMenu, QMenuBar, QAction, QSystemTrayIcon, QColorDialog
+from PySide2.QtWidgets import (
+    QApplication,
+    QLabel,
+    QWidget,
+    QLineEdit,
+    QComboBox,
+    QFormLayout,
+    QVBoxLayout,
+    QHBoxLayout,
+    QListWidget,
+    QDial,
+    QTableWidget,
+)
+from PySide2.QtWidgets import (
+    QSlider,
+    QCheckBox,
+    QRadioButton,
+    QSpinBox,
+    QPushButton,
+    QTextEdit,
+    QMainWindow,
+    QDialog,
+    QAbstractItemView,
+)
+from PySide2.QtWidgets import (
+    QSpacerItem,
+    QFrame,
+    QGroupBox,
+    QTextBrowser,
+    QPlainTextEdit,
+    QButtonGroup,
+    QFileDialog,
+    QTableWidget,
+    QTabWidget,
+    QTabBar,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QLayout,
+    QTreeWidgetItemIterator,
+    QProgressBar,
+)
+from PySide2.QtWidgets import (
+    QTableWidgetItem,
+    QGraphicsView,
+    QGraphicsScene,
+    QGraphicsItemGroup,
+    QMenu,
+    QMenuBar,
+    QAction,
+    QSystemTrayIcon,
+    QColorDialog,
+)
 from PySide2.QtGui import QPainter, QPixmap, QPen, QColor, QBrush, QPainterPath, QFont, QImage, QIcon
 from PySide2.QtCore import Qt, QEvent, QSize
 import PySide2.QtGui as QtGui
@@ -33,7 +90,6 @@ import PySide2.QtCore as QtCore
 import PySide2.QtWidgets as QtWidgets
 
 using_pyqt5 = False
-
 
 
 DEFAULT_BASE64_ICON = b'R0lGODlhIQAgAPcAAAAAADBpmDBqmTFqmjJrmzJsnDNtnTRrmTZtmzZumzRtnTdunDRunTRunjVvnzdwnzhwnjlxnzVwoDZxoTdyojhzozl0ozh0pDp1pjp2pjp2pzx0oj12pD52pTt3qD54pjt4qDx4qDx5qTx5qj16qj57qz57rD58rT98rkB4pkJ7q0J9rEB9rkF+rkB+r0d9qkZ/rEl7o0h8p0x9pk5/p0l+qUB+sEyBrE2Crk2Er0KAsUKAskSCtEeEtUWEtkaGuEiHuEiHukiIu0qKu0mJvEmKvEqLvk2Nv1GErVGFr1SFrVGHslaHsFCItFSIs1COvlaPvFiJsVyRuWCNsWSPsWeQs2SQtGaRtW+Wt2qVuGmZv3GYuHSdv3ievXyfvV2XxGWZwmScx2mfyXafwHikyP7TPP/UO//UPP/UPf/UPv7UP//VQP/WQP/WQf/WQv/XQ//WRP7XSf/XSv/YRf/YRv/YR//YSP/YSf/YSv/ZS//aSv/aS/7YTv/aTP/aTf/bTv/bT//cT/7aUf/cUP/cUf/cUv/cU//dVP/dVf7dVv/eVv/eV//eWP/eWf/fWv/fW/7cX/7cYf7cZP7eZf7dav7eb//gW//gXP/gXf/gXv/gX//gYP/hYf/hYv/iYf/iYv7iZP7iZf/iZv/kZv7iaP/kaP/ka//ma//lbP/lbv/mbP/mbv7hdP7lcP/ncP/nc//ndv7gef7gev7iff7ke/7kfv7lf//ocf/ocv/odP/odv/peP/pe//ofIClw4Ory4GszoSszIqqxI+vyoSv0JGvx5OxyZSxyZSzzJi0y5m2zpC10pi715++16C6z6a/05/A2qHC3aXB2K3I3bLH2brP4P7jgv7jh/7mgf7lhP7mhf7liv/qgP7qh/7qiP7rjf7sjP7nkv7nlv7nmP7pkP7qkP7rkv7rlv7slP7sl/7qmv7rnv7snv7sn/7un/7sqv7vq/7vrf7wpv7wqf7wrv7wsv7wtv7ytv7zvP7zv8LU48LV5c3a5f70wP7z0AAAACH5BAEAAP8ALAAAAAAhACAAAAj/AP8JHEiwoMGDCA1uoYIF4bhK1vwlPOjlQICLApwVpFTGzBk1siYSrCLgoskFyQZKMsOypRyR/GKYnBkgQbF/s8603KnmWkIaNIMaw6lzZ8tYB2cIWMo0KIJj/7YV9XgGDRo14gpOIUBggNevXpkKGCDsXySradSoZcMmDsFnDxpEKEC3bl2uXCFQ+7emjV83bt7AgTNroJINAq0wWBxBgYHHdgt0+cdnMJw5c+jQqYNnoARkAx04kPEvS4PTqBswuPIPUp06duzcuYMHT55wAjkwEahsQgqBNSQIHy582D9BePTs2dOnjx8/f1gJ9GXhRpTqApFQoDChu3cOAps///9D/g+gQvYGjrlw4cU/fUnYX6hAn34HgZMABQo0iJB/Qoe8UxAXOQiEg3wIXvCBQLUU4mAhh0R4SCLqJOSEBhhqkAEGHIYgUDaGICIiIoossogj6yBUTQ4htNgiCCB4oIJAtJTIyI2MOOLIIxMtQQIJIwQZpAgwCKRNI43o6Igll1ySSTsI7dOECSaUYOWVKwhkiyVMYuJlJpp0IpA6oJRTkBQopHnCmmu2IBA2mmQi5yZ0fgJKPP+0IwoooZwzkDQ2uCCoCywUyoIW/5DDyaKefOLoJ6LU8w87pJgDTzqmDNSMDpzqYMOnn/7yTyiglBqKKKOMUopA7JgCy0DdeMEjUDM71GqrrcH8QwqqqpbiayqToqJKLwN5g45A0/TAw7LL2krGP634aoopp5yiiiqrZLuKK+jg444uBIHhw7g+MMsDFP/k4wq22rririu4xItLLriAUxAQ5ObrwzL/0PPKu7fIK3C8uxz0w8EIIwzMP/cM7HC88hxEzBBCBGGxxT8AwQzDujws7zcJQVMEEUKUbPITAt1D78OSivSFEUXEXATKA+HTscC80CPSQNGEccQRYhjUDzfxcjPPzkgnLVBAADs='
@@ -47,7 +103,6 @@ g_time_end = 0
 g_time_delta = 0
 
 
-
 def TimerStart():
     global g_time_start
 
@@ -59,7 +114,7 @@ def TimerStop():
 
     g_time_end = time.time()
     g_time_delta = g_time_end - g_time_start
-    print(int(g_time_delta*1000))
+    print(int(g_time_delta * 1000))
 
 
 """
@@ -82,14 +137,14 @@ def TimerStop():
 # ----====----====----==== Constants the user CAN safely change ====----====----====----#
 DEFAULT_WINDOW_ICON = DEFAULT_BASE64_ICON
 DEFAULT_ELEMENT_SIZE = (250, 22)  # In PIXELS
-DEFAULT_BUTTON_ELEMENT_SIZE = (80, 25 )  # In PIXELS
-DEFAULT_MARGINS = (0,0)   # For Qt, use a Column element with padding to get same effect as tkinter port
+DEFAULT_BUTTON_ELEMENT_SIZE = (80, 25)  # In PIXELS
+DEFAULT_MARGINS = (0, 0)  # For Qt, use a Column element with padding to get same effect as tkinter port
 DEFAULT_ELEMENT_PADDING = (4, 2)  # Padding between elements (row, col) in pixels
 # DEFAULT_ELEMENT_PADDING = (0, 0)  # Padding between elements (row, col) in pixels
-DEFAULT_PIXELS_TO_CHARS_SCALING = (10,35)      # 1 character represents x by y pixels
-DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT = (10,20)      # 1 character represents x by y pixels
-DEFAULT_PIXEL_TO_CHARS_CUTOFF = 15             # number of chars that triggers using pixels instead of chars
-DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE = 70             # number of chars that triggers using pixels instead of chars
+DEFAULT_PIXELS_TO_CHARS_SCALING = (10, 35)  # 1 character represents x by y pixels
+DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT = (10, 20)  # 1 character represents x by y pixels
+DEFAULT_PIXEL_TO_CHARS_CUTOFF = 15  # number of chars that triggers using pixels instead of chars
+DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE = 70  # number of chars that triggers using pixels instead of chars
 DEFAULT_AUTOSIZE_TEXT = True
 DEFAULT_AUTOSIZE_BUTTONS = True
 DEFAULT_FONT = ('Helvetica', 10)
@@ -100,19 +155,21 @@ DEFAULT_DEBUG_WINDOW_SIZE = (800, 400)
 DEFAULT_WINDOW_LOCATION = (None, None)
 MAX_SCROLLED_TEXT_BOX_HEIGHT = 50
 DEFAULT_TOOLTIP_TIME = 400
-DEFAULT_TOOLTIP_OFFSET = (20,-20)
+DEFAULT_TOOLTIP_OFFSET = (20, -20)
 #################### COLOR STUFF ####################
 BLUES = ('#082567', '#0A37A3', '#00345B')
 PURPLES = ('#480656', '#4F2398', '#380474')
 GREENS = ('#01826B', '#40A860', '#96D2AB', '#00A949', '#003532')
 YELLOWS = ('#F3FB62', '#F0F595')
 TANS = ('#FFF9D5', '#F4EFCF', '#DDD8BA')
-NICE_BUTTON_COLORS = ((GREENS[3], TANS[0]),
-                      ('#000000', '#FFFFFF'),
-                      ('#FFFFFF', '#000000'),
-                      (YELLOWS[0], PURPLES[1]),
-                      (YELLOWS[0], GREENS[3]),
-                      (YELLOWS[0], BLUES[2]))
+NICE_BUTTON_COLORS = (
+    (GREENS[3], TANS[0]),
+    ('#000000', '#FFFFFF'),
+    ('#FFFFFF', '#000000'),
+    (YELLOWS[0], PURPLES[1]),
+    (YELLOWS[0], GREENS[3]),
+    (YELLOWS[0], BLUES[2]),
+)
 
 COLOR_SYSTEM_DEFAULT = '1234567890'  # Colors should never be this long
 
@@ -151,7 +208,10 @@ RELIEF_TICK_POSITION_BELOW = 'below'
 RELIEF_TICK_POSITION_LEFT = 'left'
 RELIEF_TICK_POSITION_RIGHT = 'right'
 
-DEFAULT_PROGRESS_BAR_COMPUTE = ('#000000', '#000000') # Means that the progress bar colors should be computed from other colors
+DEFAULT_PROGRESS_BAR_COMPUTE = (
+    '#000000',
+    '#000000',
+)  # Means that the progress bar colors should be computed from other colors
 DEFAULT_PROGRESS_BAR_COLOR = (GREENS[0], '#D0D0D0')  # a nice green progress bar
 DEFAULT_PROGRESS_BAR_COLOR_OFFICIAL = (GREENS[0], '#D0D0D0')  # a nice green progress bar
 DEFAULT_PROGRESS_BAR_SIZE = (200, 20)  # Size of Progress Bar (characters for length, pixels for width)
@@ -235,7 +295,8 @@ SUPPRESS_ERROR_POPUPS = False
 # ====================================================================== #
 # One-liner functions that are handy as f_ck                             #
 # ====================================================================== #
-def RGB(red, green, blue): return '#%02x%02x%02x' % (red, green, blue)
+def RGB(red, green, blue):
+    return '#%02x%02x%02x' % (red, green, blue)
 
 
 # ====================================================================== #
@@ -256,7 +317,7 @@ BUTTON_TYPE_REALTIME = 9
 BUTTON_TYPE_CALENDAR_CHOOSER = 30
 BUTTON_TYPE_COLOR_CHOOSER = 40
 
-BROWSE_FILES_DELIMITER = ';'            # the delimeter to be used between each file in the returned string
+BROWSE_FILES_DELIMITER = ';'  # the delimeter to be used between each file in the returned string
 
 # -------------------------  Element types  ------------------------- #
 # Used in Element - Was an enum once ElementType(Enum):
@@ -302,6 +363,7 @@ POPUP_BUTTONS_NO_BUTTONS = 5
 # def apply_new_font(css_dict, font_string):
 #     return css_dict.update({k.strip().replace('_', '-') : v.strip() for k,v in font_string.replace('\n', '').split(';')})
 
+
 # ---------------------------------------------------------------------- #
 # Cascading structure.... Objects get larger                             #
 #   Button                                                               #
@@ -312,9 +374,23 @@ POPUP_BUTTONS_NO_BUTTONS = 5
 # ------------------------------------------------------------------------- #
 #                       Element CLASS                                       #
 # ------------------------------------------------------------------------- #
-class Element():
-    def __init__(self, elem_type, size=(None, None), auto_size_text=None, font=None, background_color=None, text_color=None,
-                 key=None, k=None, pad=None, tooltip=None, visible=True, size_px=(None, None), metadata=None):
+class Element:
+    def __init__(
+        self,
+        elem_type,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param elem_type: ???
         :type elem_type: ???
@@ -376,12 +452,10 @@ class Element():
         self.Tooltip = tooltip
         self.TooltipObject = None
         self.Visible = visible
-        self.metadata = metadata                # type: Any
-        self.row_frame = None                   # type: QHBoxLayout
-        self.qt_styles = []                     # type: List[QtStyle]
-        self.Widget = None                      # type: QWidget
-
-
+        self.metadata = metadata  # type: Any
+        self.row_frame = None  # type: QHBoxLayout
+        self.qt_styles = []  # type: List[QtStyle]
+        self.Widget = None  # type: QWidget
 
     def _FindReturnKeyBoundButton(self, form):
         for row in form.Rows:
@@ -407,7 +481,6 @@ class Element():
                         return rc
         return None
 
-
     def _ReturnKeyHandler(self, event):
         MyForm = self.ParentForm
         button_element = self._FindReturnKeyBoundButton(MyForm)
@@ -424,13 +497,18 @@ class Element():
         if self.Widget is not None:
             return True
         else:
-            warnings.warn('You cannot Update element with key = {} until the window has been Read or Finalized'.format(self.Key), UserWarning)
+            warnings.warn(
+                'You cannot Update element with key = {} until the window has been Read or Finalized'.format(self.Key),
+                UserWarning,
+            )
             if not SUPPRESS_ERROR_POPUPS:
-                popup_error('Unable to complete operation on element with key {}'.format(self.Key),
+                popup_error(
+                    'Unable to complete operation on element with key {}'.format(self.Key),
                     'You cannot perform operations (such as calling update) on an Element until Window is read or finalized.',
-                         'Adding a "finalize=True" parameter to your Window creation will likely fix this.', image=_random_error_icon())
+                    'Adding a "finalize=True" parameter to your Window creation will likely fix this.',
+                    image=_random_error_icon(),
+                )
             return False
-
 
     def Update(self, widget, background_color=None, text_color=None, font=None, visible=None):
         if not self._widget_was_created():
@@ -438,7 +516,7 @@ class Element():
 
         a_style = self.qt_styles[0]
         # print(f'a_style = {a_style}')
-        if font is not None:  #= apply_new_font(css_props_dict, create_style_from_font(font))
+        if font is not None:  # = apply_new_font(css_props_dict, create_style_from_font(font))
             a_style['font'] = create_style_from_font(font)
         if text_color is not None:
             a_style['color'] = text_color
@@ -450,7 +528,6 @@ class Element():
         # print(f'a_style = {a_style}')
         widget.setStyleSheet(a_style.build_css_string())
         set_widget_visiblity(widget, visible)
-
 
     def set_stylesheet(self, stylesheet):
         """
@@ -500,7 +577,6 @@ class Element():
 
         return
 
-
     def __call__(self, *args, **kwargs):
         """
         Makes it possible to "call" an already existing element.  When you do make the "call", it actually calls
@@ -516,8 +592,6 @@ class Element():
         """
         return self.Update(*args, **kwargs)
 
-
-
     update = Update
 
 
@@ -525,10 +599,32 @@ class Element():
 #                           Input Class                                  #
 # ---------------------------------------------------------------------- #
 class InputText(Element):
-    def __init__(self, default_text='', size=(None,None), disabled=False, password_char='',
-                 justification=None, background_color=None, text_color=None, font=None, tooltip=None, disabled_readonly_background_color=None, disabled_readonly_text_color=None,
-                 change_submits=False, enable_events=False, readonly=False, border_width=None,
-                 do_not_clear=True, key=None, k=None, focus=False, pad=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        default_text='',
+        size=(None, None),
+        disabled=False,
+        password_char='',
+        justification=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        tooltip=None,
+        disabled_readonly_background_color=None,
+        disabled_readonly_text_color=None,
+        change_submits=False,
+        enable_events=False,
+        readonly=False,
+        border_width=None,
+        do_not_clear=True,
+        key=None,
+        k=None,
+        focus=False,
+        pad=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         Input a line of text Element
         :param default_text: Text initially shown in the input box as a default value(Default value = '')
@@ -592,11 +688,21 @@ class InputText(Element):
         self.disabled_readonly_text_color = disabled_readonly_text_color
         self.ChangeSubmits = change_submits or enable_events
         self.BorderWidth = border_width if border_width is not None else DEFAULT_BORDER_WIDTH
-        self.Widget = self.QT_QLineEdit = None          # type: QLineEdit
+        self.Widget = self.QT_QLineEdit = None  # type: QLineEdit
         self.ValueWasChanged = False
-        super().__init__(ELEM_TYPE_INPUT_TEXT, size=size, background_color=bg, text_color=fg, key=key, pad=pad,
-                         font=font, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
-
+        super().__init__(
+            ELEM_TYPE_INPUT_TEXT,
+            size=size,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            font=font,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
 
     def _dragEnterEvent(self, e):
         if e.mimeData().hasText():
@@ -606,8 +712,6 @@ class InputText(Element):
 
     def _dropEvent(self, e):
         self.QT_QLineEdit.setText(e.mimeData().text())
-
-
 
     class InputTextWidget(QWidget):
         def __init__(self, qt_qlineedit, element):
@@ -621,11 +725,8 @@ class InputText(Element):
                 self.Element.ParentForm.FocusElement = self.Element
             return QWidget.eventFilter(self, widget, event)
 
-
-
-    def _QtCallbackFocusInEvent(self,value):
+    def _QtCallbackFocusInEvent(self, value):
         return
-
 
     def _QtCallbackFocusInEvent(self, value):
         if not self.ChangeSubmits:
@@ -641,7 +742,9 @@ class InputText(Element):
         self._ReturnKeyHandler(None)
         return
 
-    def Update(self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None
+    ):
         if disabled is True:
             self.QT_QLineEdit.setDisabled(True)
         elif disabled is False:
@@ -653,10 +756,10 @@ class InputText(Element):
             # to dupliate this
             # self.ValueWasChanged = True
         if select:
-            self.QT_QLineEdit.setSelection(0,QtGui.QTextCursor.End )
-        super().Update(self.QT_QLineEdit, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
-
+            self.QT_QLineEdit.setSelection(0, QtGui.QTextCursor.End)
+        super().Update(
+            self.QT_QLineEdit, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         return self.QT_QLineEdit.text()
@@ -669,6 +772,7 @@ class InputText(Element):
     set_focus = SetFocus
     update = Update
 
+
 # -------------------------  INPUT TEXT lazy functions  ------------------------- #
 In = InputText
 Input = InputText
@@ -679,9 +783,29 @@ I = InputText
 #                           Combo                                        #
 # ---------------------------------------------------------------------- #
 class Combo(Element):
-    def __init__(self, values, default_value=None, size=(None, None), auto_size_text=None, background_color=None,
-                 text_color=None, change_submits=False, enable_events=False, disabled=False, key=None, k=None, pad=None, tooltip=None,
-                 readonly=False, visible_items=10, font=None, auto_complete=True, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        readonly=False,
+        visible_items=10,
+        font=None,
+        auto_complete=True,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         Input Combo Box Element (also called Dropdown box)
 
@@ -738,17 +862,38 @@ class Combo(Element):
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
         self.VisibleItems = visible_items
         self.AutoComplete = auto_complete
-        self.Widget = self.QT_ComboBox = None               # type: QComboBox
-        super().__init__(ELEM_TYPE_INPUT_COMBO, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=size_px, metadata=metadata)
-
+        self.Widget = self.QT_ComboBox = None  # type: QComboBox
+        super().__init__(
+            ELEM_TYPE_INPUT_COMBO,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
 
     def _QtCurrentItemChanged(self, state):
         if self.ChangeSubmits:
             _element_callback_quit_mainloop(self)
 
-
-    def Update(self, value=None, values=None, set_to_index=None, disabled=None, readonly=None,  background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self,
+        value=None,
+        values=None,
+        set_to_index=None,
+        disabled=None,
+        readonly=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        visible=None,
+    ):
         if values is not None:
             self.Values = values
             for i in range(self.QT_ComboBox.count()):
@@ -768,7 +913,9 @@ class Combo(Element):
         if readonly is not None:
             self.Readonly = readonly
 
-        super().Update(self.QT_ComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.QT_ComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     update = Update
 
@@ -783,8 +930,23 @@ Drop = InputCombo
 #                           Option Menu                                  #
 # ---------------------------------------------------------------------- #
 class OptionMenu(Element):
-    def __init__(self, values, default_value=None, size=(None, None), disabled=False, auto_size_text=None,
-                 background_color=None, text_color=None, key=None, k=None, pad=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        disabled=False,
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         InputOptionMenu - NOT USED IN QT
         :param values: Values to be displayed
@@ -824,13 +986,25 @@ class OptionMenu(Element):
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
 
-        super().__init__(ELEM_TYPE_INPUT_OPTION_MENU, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_OPTION_MENU,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
 
     def Update(self, value=None, values=None, disabled=None):
         return
 
     update = Update
+
 
 # -------------------------  OPTION MENU Element lazy functions  ------------------------- #
 InputOptionMenu = OptionMenu
@@ -840,8 +1014,28 @@ InputOptionMenu = OptionMenu
 #                           Listbox                                      #
 # ---------------------------------------------------------------------- #
 class Listbox(Element):
-    def __init__(self, values, default_values=None, select_mode=None, change_submits=False, enable_events=False, bind_return_key=False, size=(None, None), disabled=False, auto_size_text=None, font=None, background_color=None,
-                 text_color=None, key=None, k=None, pad=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        values,
+        default_values=None,
+        select_mode=None,
+        change_submits=False,
+        enable_events=False,
+        bind_return_key=False,
+        size=(None, None),
+        disabled=False,
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param values: list of values to display. Can be any type including mixed types as long as they have __str__ method
         :type values: List[Any] or Tuple[Any]
@@ -903,20 +1097,40 @@ class Listbox(Element):
             self.SelectMode = DEFAULT_LISTBOX_SELECT_MODE
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        self.Widget = self.QT_ListWidget = None                 # type: QListWidget
-        tsize = size                # convert tkinter size to pixels
+        self.Widget = self.QT_ListWidget = None  # type: QListWidget
+        tsize = size  # convert tkinter size to pixels
         if size[0] is not None and size[0] < 100:
-            tsize = size[0]*DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1]*DEFAULT_PIXELS_TO_CHARS_SCALING[1]
+            tsize = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
 
-        super().__init__(ELEM_TYPE_INPUT_LISTBOX, size=tsize, auto_size_text=auto_size_text, font=font,
-                         background_color=bg, text_color=fg, key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_LISTBOX,
+            size=tsize,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
 
     def _QtCurrentRowChanged(self, state):
         if self.ChangeSubmits:
             _element_callback_quit_mainloop(self)
 
-
-    def Update(self, values=None, disabled=None, set_to_index=None,background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self,
+        values=None,
+        disabled=None,
+        set_to_index=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        visible=None,
+    ):
         if values is not None:
             self.Values = values
             for i in range(self.QT_ListWidget.count()):
@@ -929,7 +1143,9 @@ class Listbox(Element):
             self.QT_ListWidget.setDisabled(False)
         if set_to_index is not None:
             self.QT_ListWidget.setCurrentRow(set_to_index)
-        super().Update(self.QT_ListWidget, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.QT_ListWidget, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
         return
 
@@ -940,10 +1156,8 @@ class Listbox(Element):
             if value in values:
                 self.QT_ListWidget.setItemSelected(item, True)
 
-
     def GetListValues(self):
         return self.Values
-
 
     def get(self):
         """
@@ -968,13 +1182,32 @@ class Listbox(Element):
 LBox = Listbox
 LB = Listbox
 
+
 # ---------------------------------------------------------------------- #
 #                           Radio                                        #
 # ---------------------------------------------------------------------- #
 class Radio(Element):
-    def __init__(self, text, group_id, default=False, disabled=False, size=(None, None), auto_size_text=None,
-                 background_color=None, text_color=None, font=None, key=None, k=None, pad=None, tooltip=None,
-                 change_submits=False,  enable_events=False, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        text,
+        group_id,
+        default=False,
+        disabled=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        change_submits=False,
+        enable_events=False,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param text: Text to display next to button
         :type text: (str)
@@ -1021,12 +1254,23 @@ class Radio(Element):
         self.Disabled = disabled
         self.TextColor = text_color or DEFAULT_TEXT_COLOR
         self.ChangeSubmits = change_submits or enable_events
-        self.Widget = self.QT_Radio_Button = None           # type: QRadioButton
-        self.QT_RadioButtonGroup = None                     # type: QButtonGroup
+        self.Widget = self.QT_Radio_Button = None  # type: QRadioButton
+        self.QT_RadioButtonGroup = None  # type: QButtonGroup
 
-        super().__init__(ELEM_TYPE_INPUT_RADIO, size=size, auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_RADIO,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
 
     def Update(self, value=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
@@ -1041,15 +1285,15 @@ class Radio(Element):
             self.QT_RadioButtonGroup.setExclusive(False)
             self.QT_Radio_Button.setChecked(False)
             self.QT_RadioButtonGroup.setExclusive(True)
-        super().Update(self.QT_Radio_Button, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.QT_Radio_Button, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def reset_group(self):
         self.QT_Radio_Button.setChecked(True)
         self.QT_RadioButtonGroup.setExclusive(False)
         self.QT_Radio_Button.setChecked(False)
         self.QT_RadioButtonGroup.setExclusive(True)
-
 
     def _QtCallbackValueChanged(self, value):
         if not self.ChangeSubmits:
@@ -1058,15 +1302,35 @@ class Radio(Element):
 
     update = Update
 
+
 R = Radio
 Rad = Radio
+
 
 # ---------------------------------------------------------------------- #
 #                           Checkbox                                     #
 # ---------------------------------------------------------------------- #
 class Checkbox(Element):
-    def __init__(self, text, default=False, size=(None, None), auto_size_text=None, font=None, background_color=None,
-                 text_color=None, change_submits=False, enable_events=False, disabled=False, key=None, k=None, pad=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        text,
+        default=False,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param text: Text to display next to checkbox
         :type text: (str)
@@ -1111,16 +1375,26 @@ class Checkbox(Element):
         self.Disabled = disabled
         self.TextColor = text_color if text_color else DEFAULT_TEXT_COLOR
         self.ChangeSubmits = change_submits or enable_events
-        self.Widget = self.QT_Checkbox = None           # type: QCheckBox
+        self.Widget = self.QT_Checkbox = None  # type: QCheckBox
 
-        super().__init__(ELEM_TYPE_INPUT_CHECKBOX, size=size, auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_CHECKBOX,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
 
     def QtCallbackStateChanged(self, state):
         if self.ChangeSubmits:
             _element_callback_quit_mainloop(self)
-
 
     def Get(self):
         return self.QT_Checkbox.isChecked()
@@ -1131,10 +1405,13 @@ class Checkbox(Element):
             self.QT_Checkbox.setDisabled(True)
         elif disabled == False:
             self.QT_Checkbox.setDisabled(False)
-        super().Update(self.QT_Checkbox, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.QT_Checkbox, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     get = Get
     update = Update
+
 
 # -------------------------  CHECKBOX Element lazy functions  ------------------------- #
 CB = Checkbox
@@ -1146,12 +1423,30 @@ Check = Checkbox
 #                           Spin                                         #
 # ---------------------------------------------------------------------- #
 
+
 class Spin(Element):
     # Values = None
     # TKSpinBox = None
-    def __init__(self, values, initial_value=None, disabled=False, change_submits=False,  enable_events=False, size=(None, None),
-                 auto_size_text=None, font=None, background_color=None, text_color=None, key=None, k=None, pad=None,
-                 tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        values,
+        initial_value=None,
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         Spinner Element
         :param values: List of valid values
@@ -1196,10 +1491,22 @@ class Spin(Element):
         self.Disabled = disabled
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        self.Widget = self.QT_Spinner = None            # type: StringBox
+        self.Widget = self.QT_Spinner = None  # type: StringBox
 
-        super().__init__(ELEM_TYPE_INPUT_SPIN, size, auto_size_text, font=font, background_color=bg, text_color=fg,
-                         key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_SPIN,
+            size,
+            auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
 
     class StringBox(QSpinBox):
@@ -1221,13 +1528,14 @@ class Spin(Element):
         def valueFromText(self, text):
             return self._values[text]
 
-
     def _QtCallbackValueChanged(self, value):
         if not self.ChangeSubmits:
             return
         _element_callback_quit_mainloop(self)
 
-    def Update(self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None
+    ):
         if values != None:
             self.Values = values
             self.QT_Spinner.setStrings(values)
@@ -1243,7 +1551,9 @@ class Spin(Element):
             self.QT_Spinner.setDisabled(True)
         elif disabled == False:
             self.QT_Spinner.setDisabled(False)
-        super().Update(self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         return self.QT_Spinner.value()
@@ -1256,10 +1566,30 @@ class Spin(Element):
 #                           Multiline                                    #
 # ---------------------------------------------------------------------- #
 class Multiline(Element):
-    def __init__(self, default_text='', enter_submits=False, disabled=False, autoscroll=False, size=(None, None),
-                 auto_size_text=None, background_color=None, text_color=None, change_submits=False, enable_events=False, do_not_clear=True,
-                 key=None, k=None, write_only=False, focus=False, font=None, pad=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
-
+    def __init__(
+        self,
+        default_text='',
+        enter_submits=False,
+        disabled=False,
+        autoscroll=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        k=None,
+        write_only=False,
+        focus=False,
+        font=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param default_text: Initial text to show
         :type default_text: (str)
@@ -1315,14 +1645,33 @@ class Multiline(Element):
         self.Disabled = disabled
         self.ChangeSubmits = change_submits or enable_events
         self.WriteOnly = write_only
-        tsize = _convert_tkinter_size_to_Qt(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT,height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE) if size[0] is not None else size_px
+        tsize = (
+            _convert_tkinter_size_to_Qt(
+                size,
+                scaling=DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT,
+                height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE,
+            )
+            if size[0] is not None
+            else size_px
+        )
 
-        self.Widget = self.QT_TextEdit = None               # type: QTextEdit
+        self.Widget = self.QT_TextEdit = None  # type: QTextEdit
 
-        super().__init__(ELEM_TYPE_INPUT_MULTILINE, size=(None, None), auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=tsize, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_MULTILINE,
+            size=(None, None),
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=tsize,
+            metadata=metadata,
+        )
         return
-
 
     class MultiQWidget(QWidget):
         def __init__(self, qt_textedit, element):
@@ -1339,13 +1688,10 @@ class Multiline(Element):
                 self.Element.ParentForm.FocusElement = self.Element
             return QWidget.eventFilter(self, widget, event)
 
-
     def _QtCallbackFocusInEvent(self):
         if not self.ChangeSubmits:
             return
         _element_callback_quit_mainloop(self)
-
-
 
     def _dragEnterEvent(self, e):
         if e.mimeData().hasText():
@@ -1356,8 +1702,20 @@ class Multiline(Element):
     def _dropEvent(self, e):
         self.Widget.setText(e.mimeData().text())
 
-
-    def Update(self, value=None, disabled=None, append=False, autoscroll=False, background_color=None, text_color=None, font=None, text_color_for_value=None, background_color_for_value=None, visible=None, readonly=None):
+    def Update(
+        self,
+        value=None,
+        disabled=None,
+        append=False,
+        autoscroll=False,
+        background_color=None,
+        text_color=None,
+        font=None,
+        text_color_for_value=None,
+        background_color_for_value=None,
+        visible=None,
+        readonly=None,
+    ):
         """
         Changes some of the settings for the Multiline Element. Must call `Window.read` or `Window.finalize` or "finalize" the window using finalize parameter prior
 
@@ -1399,15 +1757,15 @@ class Multiline(Element):
             self.QT_TextEdit.setReadOnly(True)
         elif readonly is False:
             self.QT_TextEdit.setReadOnly(False)
-        super().Update(self.QT_TextEdit, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.QT_TextEdit, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         return self.QT_TextEdit.toPlainText()
 
     def SetFocus(self):
         self.QT_TextEdit.setFocus()
-
 
     def print(self, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True):
         """
@@ -1426,14 +1784,20 @@ class Multiline(Element):
         :param autoscroll: (bool) If True cursor is moved to end after print
         :type autoscroll: (bool)
         """
-        _print_to_element(self, *args, end=end, sep=sep, text_color=text_color, background_color=background_color, autoscroll=autoscroll)
-
-
-
+        _print_to_element(
+            self,
+            *args,
+            end=end,
+            sep=sep,
+            text_color=text_color,
+            background_color=background_color,
+            autoscroll=autoscroll,
+        )
 
     get = Get
     set_focus = SetFocus
     update = Update
+
 
 ML = Multiline
 MLine = Multiline
@@ -1443,7 +1807,29 @@ MLine = Multiline
 #                           ScrolledOutput                               #
 # ---------------------------------------------------------------------- #
 class MultilineOutput(Element):
-    def __init__(self, default_text='', enter_submits=False, disabled=False, autoscroll=False, size=(None, None), auto_size_text=None, background_color=None, text_color=None, change_submits=False, enable_events=False, do_not_clear=True, key=None, k=None, focus=False, font=None, pad=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        default_text='',
+        enter_submits=False,
+        disabled=False,
+        autoscroll=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        k=None,
+        focus=False,
+        font=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param default_text: default value to put into input area
         :type default_text: (str)
@@ -1496,14 +1882,45 @@ class MultilineOutput(Element):
         self.Autoscroll = autoscroll
         self.Disabled = disabled
         self.ChangeSubmits = change_submits or enable_events
-        self.Widget = self.QT_TextBrowser = None            # type: QTextBrowser
-        tsize = _convert_tkinter_size_to_Qt(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT,height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE) if size[0] is not None else size_px
-        super().__init__(ELEM_TYPE_MULTILINE_OUTPUT, size=(None, None), auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=tsize, metadata=metadata)
+        self.Widget = self.QT_TextBrowser = None  # type: QTextBrowser
+        tsize = (
+            _convert_tkinter_size_to_Qt(
+                size,
+                scaling=DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT,
+                height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE,
+            )
+            if size[0] is not None
+            else size_px
+        )
+        super().__init__(
+            ELEM_TYPE_MULTILINE_OUTPUT,
+            size=(None, None),
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=tsize,
+            metadata=metadata,
+        )
         return
 
-
-    def Update(self, value=None, disabled=None, append=False, autoscroll=None, background_color=None, text_color=None, font=None, text_color_for_value=None, background_color_for_value=None, visible=None):
+    def Update(
+        self,
+        value=None,
+        disabled=None,
+        append=False,
+        autoscroll=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        text_color_for_value=None,
+        background_color_for_value=None,
+        visible=None,
+    ):
         if value is not None and not append:
             self.QT_TextBrowser.setText(str(value))
         elif value is not None and append:
@@ -1515,12 +1932,12 @@ class MultilineOutput(Element):
             self.QT_TextBrowser.setDisabled(False)
         if self.Autoscroll or autoscroll and autoscroll is not False:
             self.QT_TextBrowser.moveCursor(QtGui.QTextCursor.End)
-        super().Update(self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         return self.QT_TextBrowser.toPlainText()
-
 
     def print(self, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True):
         """
@@ -1539,21 +1956,48 @@ class MultilineOutput(Element):
         :param autoscroll: If True cursor is moved to end after print
         :typep autoscroll: (bool)
         """
-        _print_to_element(self, *args, end=end, sep=sep, text_color=text_color, background_color=background_color, autoscroll=autoscroll)
-
-
+        _print_to_element(
+            self,
+            *args,
+            end=end,
+            sep=sep,
+            text_color=text_color,
+            background_color=background_color,
+            autoscroll=autoscroll,
+        )
 
     get = Get
     update = Update
 
+
 MLineOut = Multiline
+
 
 # ---------------------------------------------------------------------- #
 #                                       Text                             #
 # ---------------------------------------------------------------------- #
 class Text(Element):
-    def __init__(self, text='', size=(None, None),  auto_size_text=None, click_submits=None, enable_events=False, relief=None, font=None, text_color=None, background_color=None, justification=None, pad=None, margins=None, key=None, k=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
-
+    def __init__(
+        self,
+        text='',
+        size=(None, None),
+        auto_size_text=None,
+        click_submits=None,
+        enable_events=False,
+        relief=None,
+        font=None,
+        text_color=None,
+        background_color=None,
+        justification=None,
+        pad=None,
+        margins=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param text: The text to display. Can include /n to achieve multiple lines.  Will convert (optional) parameter into a string
         :type text: (Any)
@@ -1603,10 +2047,22 @@ class Text(Element):
             bg = DEFAULT_TEXT_ELEMENT_BACKGROUND_COLOR
         else:
             bg = background_color
-        self.Widget = self.QT_Label = None              # type: QLabel
+        self.Widget = self.QT_Label = None  # type: QLabel
 
-        super().__init__(ELEM_TYPE_TEXT, size, auto_size_text, background_color=bg, font=font if font else DEFAULT_FONT,
-                         text_color=self.TextColor, visible=visible, pad=pad, key=key, tooltip=tooltip, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TEXT,
+            size,
+            auto_size_text,
+            background_color=bg,
+            font=font if font else DEFAULT_FONT,
+            text_color=self.TextColor,
+            visible=visible,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
 
     def _QtCallbackTextClicked(self, event):
@@ -1627,9 +2083,12 @@ class Text(Element):
         if value is not None:
             self.DisplayText = str(value)
             self.QT_Label.setText(str(value))
-        super().Update(self.QT_Label, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.QT_Label, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     update = Update
+
 
 # -------------------------  Text Element lazy functions  ------------------------- #
 Txt = Text
@@ -1641,8 +2100,20 @@ T = Text
 #  Routes stdout, stderr to a scrolled window                            #
 # ---------------------------------------------------------------------- #
 class Output(Element):
-    def __init__(self, size=(None, None), background_color=None, text_color=None, pad=None, font=None, tooltip=None,
-                 key=None, k=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        size=(None, None),
+        background_color=None,
+        text_color=None,
+        pad=None,
+        font=None,
+        tooltip=None,
+        key=None,
+        k=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param size: (width, height) w=characters-wide, h=rows-high
         :type size: Tuple[int, int]
@@ -1671,18 +2142,40 @@ class Output(Element):
         self._TKOut = None
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        self.Widget = self.QT_TextBrowser = None            # type: QTextBrowser
-        tsize = size_px if size_px != (None,None) else _convert_tkinter_size_to_Qt(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT,height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE) if size[0] is not None else size
+        self.Widget = self.QT_TextBrowser = None  # type: QTextBrowser
+        tsize = (
+            size_px
+            if size_px != (None, None)
+            else (
+                _convert_tkinter_size_to_Qt(
+                    size,
+                    scaling=DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT,
+                    height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE,
+                )
+                if size[0] is not None
+                else size
+            )
+        )
 
-        super().__init__(ELEM_TYPE_OUTPUT, size=(None, None), background_color=bg, text_color=fg, pad=pad, font=font,
-                         tooltip=tooltip, key=key, visible=visible, size_px=tsize, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_OUTPUT,
+            size=(None, None),
+            background_color=bg,
+            text_color=fg,
+            pad=pad,
+            font=font,
+            tooltip=tooltip,
+            key=key,
+            visible=visible,
+            size_px=tsize,
+            metadata=metadata,
+        )
 
     def _reroute_stdout(self):
         self.my_stdout = sys.stdout
         self.my_stderr = sys.stderr
         sys.stdout = self
         sys.stderr = self
-
 
     def write(self, m):
         """
@@ -1691,17 +2184,17 @@ class Output(Element):
         :return:
         """
         self.QT_TextBrowser.moveCursor(QtGui.QTextCursor.End)
-        self.QT_TextBrowser.insertPlainText( str(m))
+        self.QT_TextBrowser.insertPlainText(str(m))
 
         # if self.my_stdout:
         #     self.my_stdout.write(str(m))
 
-
-    def Update(self,value=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.QT_TextBrowser.setText(value)
-        super().Update(self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.QT_TextBrowser, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def __del__(self):
         sys.stdout = self.my_stdout
@@ -1715,11 +2208,35 @@ class Output(Element):
 #                           Button Class                                 #
 # ---------------------------------------------------------------------- #
 class Button(Element):
-    def __init__(self, button_text='', button_type=BUTTON_TYPE_READ_FORM, target=(None, None), tooltip=None,
-                 file_types=(('ALL Files', '*'),), initial_folder=None, disabled=False, change_submits=False, enable_events=False,
-                 image_filename=None, image_data=None, image_size=(None, None), image_subsample=None, border_width=None,
-                 size=(None, None), auto_size_button=None, button_color=None, font=None, bind_return_key=False,
-                 focus=False, pad=None, key=None, k=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        button_text='',
+        button_type=BUTTON_TYPE_READ_FORM,
+        target=(None, None),
+        tooltip=None,
+        file_types=(('ALL Files', '*'),),
+        initial_folder=None,
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        image_filename=None,
+        image_data=None,
+        image_size=(None, None),
+        image_subsample=None,
+        border_width=None,
+        size=(None, None),
+        auto_size_button=None,
+        button_color=None,
+        font=None,
+        bind_return_key=False,
+        focus=False,
+        pad=None,
+        key=None,
+        k=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param button_text: Text to be displayed on the button
         :type button_text: (str)
@@ -1787,7 +2304,7 @@ class Button(Element):
             button_color = DEFAULT_BUTTON_COLOR
         else:
             try:
-                if isinstance(button_color,str):
+                if isinstance(button_color, str):
                     button_color = button_color.split(' on ')
             except Exception as e:
                 print('* cprint warning * you messed up with color formatting', e)
@@ -1809,11 +2326,23 @@ class Button(Element):
         self.InitialFolder = initial_folder
         self.Disabled = disabled
         self.ChangeSubmits = change_submits or enable_events
-        self.Widget = self.QT_QPushButton = None            # type: QPushButton
+        self.Widget = self.QT_QPushButton = None  # type: QPushButton
         self.ColorChosen = None
         # self.temp_size = size if size != (NONE, NONE) else
 
-        super().__init__(ELEM_TYPE_BUTTON, size=size, font=font, pad=pad, key=key, tooltip=tooltip, text_color=self.TextColor, background_color=self.BackgroundColor, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_BUTTON,
+            size=size,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            text_color=self.TextColor,
+            background_color=self.BackgroundColor,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
 
     # Realtime button release callback
@@ -1884,7 +2413,7 @@ class Button(Element):
         elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:
             qcolor = QColorDialog.getColor()
             rgb_color = qcolor.getRgb()
-            color= '#' + ''.join('%02x'% i for i in rgb_color[:3])
+            color = '#' + ''.join('%02x' % i for i in rgb_color[:3])
             if self.Target == (None, None):
                 self.FileOrFolderName = color
             else:
@@ -1916,7 +2445,7 @@ class Button(Element):
             self.ParentForm.FormRemainedOpen = False
             self.ParentForm._Close()
             if self.ParentForm.CurrentlyRunningMainloop:
-                self.ParentForm.QTApplication.exit()            # Exit the mainloop
+                self.ParentForm.QTApplication.exit()  # Exit the mainloop
             self.ParentForm.QT_QMainWindow.close()
             if self.ParentForm.NonBlocking:
                 # TODO DESTROY WIN
@@ -1937,7 +2466,9 @@ class Button(Element):
             if self.ParentForm.CurrentlyRunningMainloop:  # if this window is running the mainloop, kick out
                 self.ParentForm.QTApplication.exit()
             Window.DecrementOpenCount()
-        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
+        elif (
+            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
+        ):  # this is a return type button so GET RESULTS and destroy window
             should_submit_window = False
 
         if should_submit_window:
@@ -1945,10 +2476,19 @@ class Button(Element):
             self.ParentForm.FormRemainedOpen = True
             if self.ParentForm.CurrentlyRunningMainloop:
                 self.ParentForm.QTApplication.exit()
-                pass # TODO # kick the users out of the mainloop
+                pass  # TODO # kick the users out of the mainloop
         return
 
-    def Update(self, text=None, button_color=(None, None), disabled=None, image_data=None, image_filename=None, font=None, visible=None):
+    def Update(
+        self,
+        text=None,
+        button_color=(None, None),
+        disabled=None,
+        image_data=None,
+        image_filename=None,
+        font=None,
+        visible=None,
+    ):
         if text is not None:
             self.QT_QPushButton.setText(str(text))
             self.ButtonText = text
@@ -1964,7 +2504,7 @@ class Button(Element):
             self.ButtonColor = button_color
             fg, bg = button_color
         if self.Disabled != disabled and disabled is not None:
-            if not disabled:            # if enabling buttons, set the color
+            if not disabled:  # if enabling buttons, set the color
                 fg, bg = self.ButtonColor
             self.Disabled = disabled
             if disabled:
@@ -1974,7 +2514,6 @@ class Button(Element):
         # fg, bg = self.ButtonColor
         # print(f'Button update fg, bg {fg}, {bg}')
         super().Update(self.QT_QPushButton, background_color=bg, text_color=fg, font=font, visible=visible)
-
 
     def GetText(self):
         return self.ButtonText
@@ -1995,19 +2534,38 @@ class Button(Element):
     set_focus = SetFocus
     update = Update
 
+
 # -------------------------  Button lazy functions  ------------------------- #
 B = Button
 Btn = Button
-
 
 
 # ---------------------------------------------------------------------- #
 #                           ButtonMenu Class                             #
 # ---------------------------------------------------------------------- #
 class ButtonMenu(Element):
-    def __init__(self, button_text ,menu_def, tooltip=None,disabled=False,
-                 image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,border_width=None,
-                 size=(None, None), auto_size_button=None, button_color=None, font=None, pad=None, key=None, k=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        button_text,
+        menu_def,
+        tooltip=None,
+        disabled=False,
+        image_filename=None,
+        image_data=None,
+        image_size=(None, None),
+        image_subsample=None,
+        border_width=None,
+        size=(None, None),
+        auto_size_button=None,
+        button_color=None,
+        font=None,
+        pad=None,
+        key=None,
+        k=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param button_text: Text to be displayed on the button
         :type button_text: (str)
@@ -2061,21 +2619,31 @@ class ButtonMenu(Element):
         self.ImageSize = image_size
         self.ImageSubsample = image_subsample
         self.Disabled = disabled
-        self.Widget = self.QT_QPushButton = None        # type: QPushButton
+        self.Widget = self.QT_QPushButton = None  # type: QPushButton
         self.IsButtonMenu = True
         self.MenuItemChosen = None
 
         # self.temp_size = size if size != (NONE, NONE) else
 
-        super().__init__(ELEM_TYPE_BUTTONMENU, size=size, font=font, pad=pad, key=key, tooltip=tooltip, text_color=self.TextColor, background_color=self.BackgroundColor, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_BUTTONMENU,
+            size=size,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            text_color=self.TextColor,
+            background_color=self.BackgroundColor,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
-
 
     def _QT_MenuItemChosenCallback(self, item_chosen):
         # print('IN BUTTON MENU ITEM CALLBACK', item_chosen)
-        self.Key = item_chosen.replace('&','')                   # fool the quit function into thinking this was a key
+        self.Key = item_chosen.replace('&', '')  # fool the quit function into thinking this was a key
         _element_callback_quit_mainloop(self)
-
 
     def Update(self, menu_definition=None, text=None, button_color=(None, None), font=None, visible=None):
         if menu_definition is not None:
@@ -2084,8 +2652,13 @@ class ButtonMenu(Element):
             qmenu.setTitle(menu_def[0])
             AddMenuItem(qmenu, menu_def[1], self)
             self.QT_QPushButton.setMenu(qmenu)
-        super().Update(self.QT_QPushButton, background_color=button_color[1], text_color=button_color[0], font=font, visible=visible)
-
+        super().Update(
+            self.QT_QPushButton,
+            background_color=button_color[1],
+            text_color=button_color[0],
+            font=font,
+            visible=visible,
+        )
 
     def Click(self):
         """ """
@@ -2097,15 +2670,32 @@ class ButtonMenu(Element):
     click = Click
     update = Update
 
+
 BMenu = ButtonMenu
+
 
 # ---------------------------------------------------------------------- #
 #                           ProgreessBar                                 #
 # ---------------------------------------------------------------------- #
 class ProgressBar(Element):
-    def __init__(self, max_value, orientation=None, size=(None, None),start_value=0,  auto_size_text=None, bar_color=(None, None),
-                 style=None, border_width=None, relief=None, key=None, k=None, pad=None, visible=True, size_px=(None,None), metadata=None):
-
+    def __init__(
+        self,
+        max_value,
+        orientation=None,
+        size=(None, None),
+        start_value=0,
+        auto_size_text=None,
+        bar_color=(None, None),
+        style=None,
+        border_width=None,
+        relief=None,
+        key=None,
+        k=None,
+        pad=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param max_value: max value of progressbar
         :type max_value: (int)
@@ -2153,10 +2743,19 @@ class ProgressBar(Element):
         tsize = size
         if size[0] is not None and size[0] < 100:
             # tsize = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
-            tsize = size[0]*10, size[1]
-        self.Widget = self.QT_QProgressBar = None               # type: QProgressBar
+            tsize = size[0] * 10, size[1]
+        self.Widget = self.QT_QProgressBar = None  # type: QProgressBar
 
-        super().__init__(ELEM_TYPE_PROGRESS_BAR, size=tsize, auto_size_text=auto_size_text, key=key, pad=pad, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_PROGRESS_BAR,
+            size=tsize,
+            auto_size_text=auto_size_text,
+            key=key,
+            pad=pad,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
 
     # returns False if update failed
     def UpdateBar(self, current_count, max=None):
@@ -2166,21 +2765,38 @@ class ProgressBar(Element):
         self.ParentForm.QTApplication.processEvents()  # refresh the window
         return True
 
-
     def Update(self, visible=None):
         super().Update(self.QT_QProgressBar, visible=visible)
 
     update = Update
     update_bar = UpdateBar
 
+
 PBar = ProgressBar
 Prog = ProgressBar
+
 
 # ---------------------------------------------------------------------- #
 #                           Image                                        #
 # ---------------------------------------------------------------------- #
 class Image(Element):
-    def __init__(self, filename=None, data=None, data_base64=None, background_color=None, size=(None, None), pad=None, key=None, k=None, tooltip=None, click_submits=False,  enable_events=False, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        filename=None,
+        data=None,
+        data_base64=None,
+        background_color=None,
+        size=(None, None),
+        pad=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        click_submits=False,
+        enable_events=False,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param filename: image filename if there is a button image. GIFs and PNGs only.
         :type filename: (str)
@@ -2220,18 +2836,25 @@ class Image(Element):
         self.ClickSubmits = click_submits or enable_events
         if data is None and filename is None and data_base64 is None:
             print('* Warning... no image specified in Image Element! *')
-        self.Widget = self.QT_QLabel = None             # type: QLabel
+        self.Widget = self.QT_QLabel = None  # type: QLabel
 
-        super().__init__(ELEM_TYPE_IMAGE, size=size, background_color=background_color, pad=pad, key=key,
-                         tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_IMAGE,
+            size=size,
+            background_color=background_color,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
-
 
     def QtCallbackImageClicked(self, event):
         if not self.ClickSubmits:
             return
         _element_callback_quit_mainloop(self)
-
 
     def Update(self, filename=None, data=None, data_base64=None, size=(None, None), visible=None):
         if filename is not None:
@@ -2264,7 +2887,17 @@ class Image(Element):
 #                           Canvas                                       #
 # ---------------------------------------------------------------------- #
 class Canvas(Element):
-    def __init__(self, canvas=None, background_color=None, size=(None, None), pad=None, key=None, k=None, tooltip=None, metadata=None):
+    def __init__(
+        self,
+        canvas=None,
+        background_color=None,
+        size=(None, None),
+        pad=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        metadata=None,
+    ):
         """
         Canvas Element - NOT USED IN QT PORT ?
         :param canvas: Your own tk.Canvas if you already created it. Leave blank to create a Canvas
@@ -2288,8 +2921,15 @@ class Canvas(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self._TKCanvas = canvas
 
-        super().__init__(ELEM_TYPE_CANVAS, background_color=background_color, size=size, pad=pad, key=key,
-                         tooltip=tooltip, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_CANVAS,
+            background_color=background_color,
+            size=size,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            metadata=metadata,
+        )
         return
 
     @property
@@ -2299,12 +2939,27 @@ class Canvas(Element):
             print('*** form = sg.Window("My Form").Layout(layout).Finalize() ***')
         return self._TKCanvas
 
+
 # ---------------------------------------------------------------------- #
 #                           Graph                                        #
 # ---------------------------------------------------------------------- #
 class Graph(Element):
-    def __init__(self, canvas_size, graph_bottom_left, graph_top_right, background_color=None, pad=None, key=None, k=None,
-                 tooltip=None, visible=True, change_submits=False, enable_events=False, drag_submits=False, metadata=None):
+    def __init__(
+        self,
+        canvas_size,
+        graph_bottom_left,
+        graph_top_right,
+        background_color=None,
+        pad=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        visible=True,
+        change_submits=False,
+        enable_events=False,
+        drag_submits=False,
+        metadata=None,
+    ):
         """
         :param canvas_size: size of the canvas area in pixels
         :type canvas_size: Tuple[int, int]
@@ -2337,15 +2992,21 @@ class Graph(Element):
         self.CanvasSize = canvas_size
         self.BottomLeft = graph_bottom_left
         self.TopRight = graph_top_right
-        self.x  = self.y = 0
-        self.Widget = self.QT_QGraphicsScene = None       # type: QGraphicsScene
+        self.x = self.y = 0
+        self.Widget = self.QT_QGraphicsScene = None  # type: QGraphicsScene
 
-        super().__init__(ELEM_TYPE_GRAPH, background_color=background_color, size=(None, None), pad=pad, key=key,
-                         tooltip=tooltip, visible=visible, size_px=canvas_size, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_GRAPH,
+            background_color=background_color,
+            size=(None, None),
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=canvas_size,
+            metadata=metadata,
+        )
         return
-
-
-
 
     def _convert_xy_to_canvas_xy(self, x_in, y_in):
         scale_x = (self.CanvasSize[0] - 0) / (self.TopRight[0] - self.BottomLeft[0])
@@ -2360,24 +3021,33 @@ class Graph(Element):
 
         qcolor = QColor(color)
         pen = QPen(qcolor, width)
-        line = self.QT_QGraphicsScene.addLine(self.x+converted_point_from[0],self.y+ converted_point_from[1], self.x+converted_point_to[0],self.y+ converted_point_to[1], pen=pen)
+        line = self.QT_QGraphicsScene.addLine(
+            self.x + converted_point_from[0],
+            self.y + converted_point_from[1],
+            self.x + converted_point_to[0],
+            self.y + converted_point_to[1],
+            pen=pen,
+        )
         # self.QT_QGraphicsItemGroup.addToGroup(line)
         return line
 
     def DrawRectangle(self, top_left, bottom_right, fill_color=None, line_color=None):
         converted_point_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
-        converted_point_bottom_right = self._convert_xy_to_canvas_xy(bottom_right[0],  bottom_right[1])
+        converted_point_bottom_right = self._convert_xy_to_canvas_xy(bottom_right[0], bottom_right[1])
 
         qcolor = QColor(line_color)
         pen = QPen(qcolor, 1)
         qcolor = QColor(fill_color)
         brush = QBrush(qcolor)
-        line = self.QT_QGraphicsScene.addRect(converted_point_top_left[0],converted_point_top_left[1],
-                                              converted_point_bottom_right[0]-converted_point_top_left[0],
-                                              converted_point_bottom_right[1]-converted_point_top_left[1],
-                                             pen, brush)
+        line = self.QT_QGraphicsScene.addRect(
+            converted_point_top_left[0],
+            converted_point_top_left[1],
+            converted_point_bottom_right[0] - converted_point_top_left[0],
+            converted_point_bottom_right[1] - converted_point_top_left[1],
+            pen,
+            brush,
+        )
         # self.QT_QGraphicsItemGroup.addToGroup(line)
-
 
     def DrawCircle(self, center_location, radius, fill_color=None, line_color='black'):
         converted_point = self._convert_xy_to_canvas_xy(center_location[0], center_location[1])
@@ -2385,17 +3055,21 @@ class Graph(Element):
         pen = QPen(qcolor)
         qcolor = QColor(fill_color)
         brush = QBrush(qcolor)
-        circle_id = self.QT_QGraphicsScene.addEllipse(self.x + converted_point[0] - radius, self.y + converted_point[1] - radius,
-                                                      radius * 2, radius * 2, pen=pen, brush=brush)
-        return circle_id            # type: QGraphicsEllipseItem
+        circle_id = self.QT_QGraphicsScene.addEllipse(
+            self.x + converted_point[0] - radius,
+            self.y + converted_point[1] - radius,
+            radius * 2,
+            radius * 2,
+            pen=pen,
+            brush=brush,
+        )
+        return circle_id  # type: QGraphicsEllipseItem
 
     def RelocateFigure(self, id, x, y):
-        id=id           # type: QtWidgets.QGraphicsEllipseItem
+        id = id  # type: QtWidgets.QGraphicsEllipseItem
         converted_point = self._convert_xy_to_canvas_xy(x, y)
         id.setX(converted_point[0])
         id.setY(converted_point[1])
-
-
 
     def DrawText(self, text, location, color='black', font=None, angle=0):
         converted_point = self._convert_xy_to_canvas_xy(location[0], location[1])
@@ -2406,7 +3080,7 @@ class Graph(Element):
         qfont = QFont(_font[0], _font[1])
         # qfont.setWeight(.5)
 
-        text_id = qpath.addText(self.x+converted_point[0], self.y+converted_point[1], qfont, str(text))
+        text_id = qpath.addText(self.x + converted_point[0], self.y + converted_point[1], qfont, str(text))
         self.QT_QGraphicsScene.addPath(qpath, qcolor)
         return text_id
 
@@ -2416,7 +3090,7 @@ class Graph(Element):
         zero_converted = self._convert_xy_to_canvas_xy(0, 0)
         shift_converted = self._convert_xy_to_canvas_xy(x_direction, y_direction)
         shift_amount = (shift_converted[0] - zero_converted[0], shift_converted[1] - zero_converted[1])
-        rect =  self.QT_QGraphicsScene.sceneRect()
+        rect = self.QT_QGraphicsScene.sceneRect()
         rect.translate(shift_amount[0], shift_amount[1])
         self.x += shift_amount[0]
         self.y += shift_amount[1]
@@ -2430,8 +3104,6 @@ class Graph(Element):
 
         # print(rect)
 
-
-
     def DrawOval(self, top_left, bottom_right, fill_color=None, line_color=None):
         converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
         converted_bottom_right = self._convert_xy_to_canvas_xy(bottom_right[0], bottom_right[1])
@@ -2439,8 +3111,14 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_oval(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                           converted_bottom_right[1], fill=fill_color, outline=line_color)
+        return self._TKCanvas2.create_oval(
+            converted_top_left[0],
+            converted_top_left[1],
+            converted_bottom_right[0],
+            converted_bottom_right[1],
+            fill=fill_color,
+            outline=line_color,
+        )
 
     def DrawPoint(self, point, size=2, color='black'):
         converted_point = self._convert_xy_to_canvas_xy(point[0], point[1])
@@ -2448,10 +3126,14 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_oval(converted_point[0] - size, converted_point[1] - size,
-                                           converted_point[0] + size, converted_point[1] + size, fill=color,
-                                           outline=color)
-
+        return self._TKCanvas2.create_oval(
+            converted_point[0] - size,
+            converted_point[1] - size,
+            converted_point[0] + size,
+            converted_point[1] + size,
+            fill=color,
+            outline=color,
+        )
 
     def DrawArc(self, top_left, bottom_right, extent, start_angle, style=None, arc_color='black'):
         converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
@@ -2460,9 +3142,16 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_arc(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                          converted_bottom_right[1], extent=extent, start=start_angle, style='tkstyle',
-                                          outline=arc_color)
+        return self._TKCanvas2.create_arc(
+            converted_top_left[0],
+            converted_top_left[1],
+            converted_bottom_right[0],
+            converted_bottom_right[1],
+            extent=extent,
+            start=start_angle,
+            style='tkstyle',
+            outline=arc_color,
+        )
 
     def DrawRectangleOld(self, top_left, bottom_right, fill_color=None, line_color=None):
         converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
@@ -2471,9 +3160,14 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_rectangle(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                                converted_bottom_right[1], fill=fill_color, outline=line_color)
-
+        return self._TKCanvas2.create_rectangle(
+            converted_top_left[0],
+            converted_top_left[1],
+            converted_bottom_right[0],
+            converted_bottom_right[1],
+            fill=fill_color,
+            outline=line_color,
+        )
 
     def Erase(self):
         if self.QT_QGraphicsScene is None:
@@ -2501,7 +3195,6 @@ class Graph(Element):
             return None
         self._TKCanvas2.move(figure, shift_amount[0], shift_amount[1])
 
-
     def change_coordinates(self, graph_bottom_left, graph_top_right):
         """
         Changes the corrdinate system to a new one.  The same 2 points in space are used to define the coorinate
@@ -2513,14 +3206,12 @@ class Graph(Element):
         self.BottomLeft = graph_bottom_left
         self.TopRight = graph_top_right
 
-
     @property
     def TKCanvas(self):
         if self._TKCanvas2 is None:
             print('*** Did you forget to call Finalize()? Your code should look something like: ***')
             print('*** form = sg.Window("My Form").Layout(layout).Finalize() ***')
         return self._TKCanvas2
-
 
     draw_arc = DrawArc
     draw_circle = DrawCircle
@@ -2541,9 +3232,27 @@ class Graph(Element):
 #                           Frame                                        #
 # ---------------------------------------------------------------------- #
 class Frame(Element):
-    def __init__(self, title, layout, title_color=None, background_color=None, title_location=None, frame_color=None,
-                 relief=DEFAULT_FRAME_RELIEF, element_justification='float', size=(None, None), font=None, pad=None, border_width=None, key=None, k=None,
-                 tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        background_color=None,
+        title_location=None,
+        frame_color=None,
+        relief=DEFAULT_FRAME_RELIEF,
+        element_justification='float',
+        size=(None, None),
+        font=None,
+        pad=None,
+        border_width=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param title: text that is displayed as the Frame's "label" or title
         :type title: (str)
@@ -2599,15 +3308,26 @@ class Frame(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.ElementJustification = element_justification
         self.FrameColor = frame_color
-        self.Widget = self.QT_QGroupBox = None              # type: QGroupBox
+        self.Widget = self.QT_QGroupBox = None  # type: QGroupBox
         self.Layout(layout)
 
-        super().__init__(ELEM_TYPE_FRAME, background_color=background_color, text_color=title_color, size=size,
-                         font=font, pad=pad, key=key, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_FRAME,
+            background_color=background_color,
+            text_color=title_color,
+            size=size,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
 
     def AddRow(self, *args):
-        """ Parms are a variable number of Elements """
+        """Parms are a variable number of Elements"""
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2653,8 +3373,6 @@ class VerticalSeparator(Element):
         super().__init__(ELEM_TYPE_SEPARATOR, pad=pad)
 
 
-
-
 VSeperator = VerticalSeparator
 VSeparator = VerticalSeparator
 VSep = VerticalSeparator
@@ -2664,7 +3382,7 @@ VSep = VerticalSeparator
 #                           Separator                                    #
 # ---------------------------------------------------------------------- #
 class HorizontalSeparator(Element):
-    def __init__(self, pad=None, size_px=(None,None)):
+    def __init__(self, pad=None, size_px=(None, None)):
         """
         VerticalSeperator - A separator that spans only 1 row in a vertical fashion
         :param pad:
@@ -2674,18 +3392,31 @@ class HorizontalSeparator(Element):
         super().__init__(ELEM_TYPE_SEPARATOR, pad=pad)
 
 
-
 HSeperator = HorizontalSeparator
 HSep = HorizontalSeparator
-
 
 
 # ---------------------------------------------------------------------- #
 #                           Tab                                          #
 # ---------------------------------------------------------------------- #
 class Tab(Element):
-    def __init__(self, title, layout, title_color=None, element_justification='float', background_color=None, font=None, pad=None, disabled=False,
-                 border_width=None, key=None, k=None, tooltip=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        element_justification='float',
+        background_color=None,
+        font=None,
+        pad=None,
+        disabled=False,
+        border_width=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param title: text to show on the tab
         :type title: (str)
@@ -2728,22 +3459,29 @@ class Tab(Element):
         self.Title = title
         self.BorderWidth = border_width
         self.Disabled = disabled
-        self.ParentTabGroup = None                          # type: TabGroup
+        self.ParentTabGroup = None  # type: TabGroup
         self.TabID = None
         self.ElementJustification = element_justification
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
-        self.Widget = self.QT_QWidget = None                # type: QWidget
-
-
+        self.Widget = self.QT_QWidget = None  # type: QWidget
 
         self.Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB, background_color=background_color, text_color=title_color, font=font, pad=pad,
-                         key=key, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TAB,
+            background_color=background_color,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def AddRow(self, *args):
-        """ Parms are a variable number of Elements """
+        """Parms are a variable number of Elements"""
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2778,7 +3516,6 @@ class Tab(Element):
         element = row[col_num]
         return element
 
-
     def Select(self):
         """
         Selects this tab.  Mimics user clicking on this tab. Must have called window.Finalize / Read first!
@@ -2794,12 +3531,30 @@ class Tab(Element):
     select = Select
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                           TabGroup                                     #
 # ---------------------------------------------------------------------- #
 class TabGroup(Element):
-    def __init__(self, layout, tab_location=None, title_color=None, selected_title_color=None, background_color=None,
-                 font=None, change_submits=False, enable_events=False, pad=None, border_width=None, theme=None, key=None, k=None, tooltip=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        layout,
+        tab_location=None,
+        title_color=None,
+        selected_title_color=None,
+        background_color=None,
+        font=None,
+        change_submits=False,
+        enable_events=False,
+        pad=None,
+        border_width=None,
+        theme=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param layout: Layout of Tabs. Different than normal layouts. ALL Tabs should be on first row
         :type layout: List[List[Tab]]
@@ -2850,17 +3605,26 @@ class TabGroup(Element):
         self.BackgroundColor = background_color if background_color is not None else COLOR_SYSTEM_DEFAULT
         self.ChangeSubmits = change_submits or enable_events
         self.TabLocation = tab_location
-        self.TabList = []                                   # type: List[Tab]
-        self.Widget = self.QT_QTabWidget = None             # type: QTabWidget
-        self.ElementJustification = 'float'                 # not actually used, but needed for packer to work
+        self.TabList = []  # type: List[Tab]
+        self.Widget = self.QT_QTabWidget = None  # type: QTabWidget
+        self.ElementJustification = 'float'  # not actually used, but needed for packer to work
         self.Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB_GROUP, background_color=self.BackgroundColor, text_color=title_color, font=font,
-                         pad=pad, key=key, tooltip=tooltip, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TAB_GROUP,
+            background_color=self.BackgroundColor,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def AddRow(self, *args):
-        """ Parms are a variable number of Elements """
+        """Parms are a variable number of Elements"""
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2892,7 +3656,6 @@ class TabGroup(Element):
                 if element.Title == tab_name:
                     return element.Key
         return None
-
 
     def Update(self, visible=None):
         super().Update(self.QT_QTabWidget, visible=visible)
@@ -2930,9 +3693,30 @@ class TabGroup(Element):
 #                           Slider                                       #
 # ---------------------------------------------------------------------- #
 class Slider(Element):
-    def __init__(self, range=(None, None), default_value=None, resolution=None, tick_interval=None, orientation=None,
-                 border_width=None, relief=None, change_submits=False, enable_events=False, disabled=False, size=(None, None), font=None,
-                 background_color=None, text_color=None, key=None, k=None, pad=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        range=(None, None),
+        default_value=None,
+        resolution=None,
+        tick_interval=None,
+        orientation=None,
+        border_width=None,
+        relief=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        size=(None, None),
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param range: slider's range (min value, max value)
         :type range: Union[Tuple[int, int], Tuple[float, float]]
@@ -2985,18 +3769,28 @@ class Slider(Element):
         self.Resolution = 1 if resolution is None else resolution
         self.ChangeSubmits = change_submits or enable_events
         self.Disabled = disabled
-        self.TickInterval = tick_interval if tick_interval is not None else self.Range[1]//10
+        self.TickInterval = tick_interval if tick_interval is not None else self.Range[1] // 10
         temp_size = size
         if temp_size == (None, None):
             temp_size = (150, 30) if self.Orientation.startswith('h') else (30, 150)
         elif size[0] is not None and size[0] < 100:
-            temp_size = size[0]*10, size[1]*3
-        self.Widget = self.QT_Slider = None         # type:QSlider
+            temp_size = size[0] * 10, size[1] * 3
+        self.Widget = self.QT_Slider = None  # type:QSlider
 
-        super().__init__(ELEM_TYPE_INPUT_SLIDER, size=temp_size, font=font, background_color=background_color,
-                         text_color=text_color, key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_SLIDER,
+            size=temp_size,
+            font=font,
+            background_color=background_color,
+            text_color=text_color,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
-
 
     def _QtCallbackValueChanged(self, value):
         if not self.ChangeSubmits:
@@ -3017,18 +3811,37 @@ class Slider(Element):
             self.QT_Slider.setMaximum(range[1])
         super().Update(self.QT_Slider, visible=visible)
 
-
     update = Update
-
 
 
 # ---------------------------------------------------------------------- #
 #                           Dial                                         #
 # ---------------------------------------------------------------------- #
 class Dial(Element):
-    def __init__(self, range=(None, None), default_value=None, resolution=None, tick_interval=None, orientation=None,
-                 border_width=None, relief=None, change_submits=False, enable_events=False, disabled=False, size=(None, None), font=None,
-                 background_color=None, text_color=None, key=None, k=None, pad=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        range=(None, None),
+        default_value=None,
+        resolution=None,
+        tick_interval=None,
+        orientation=None,
+        border_width=None,
+        relief=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        size=(None, None),
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param range: slider's range (min value, max value)
         :type range: Union[Tuple[int, int], Tuple[float, float]]
@@ -3087,15 +3900,25 @@ class Dial(Element):
         temp_size = size
         if temp_size == (None, None):
             temp_size = (20, 20) if self.Orientation.startswith('h') else (8, 20)
-        self.Widget = self.QT_Dial = None           # type: QDial
+        self.Widget = self.QT_Dial = None  # type: QDial
 
-        super().__init__(ELEM_TYPE_INPUT_DIAL, size=temp_size, font=font, background_color=background_color,
-                         text_color=text_color, key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_INPUT_DIAL,
+            size=temp_size,
+            font=font,
+            background_color=background_color,
+            text_color=text_color,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
 
-
     def Update(self, value=None, range=(None, None), disabled=None, visible=None):
-        if value is not None:           # TODO clearly not done!
+        if value is not None:  # TODO clearly not done!
             pass
             self.DefaultValue = value
         if disabled == True:
@@ -3104,7 +3927,6 @@ class Dial(Element):
             pass
         super().Update(self.QT_Dial, visible=visible)
 
-
     def _QtCallbackValueChanged(self, value):
         if not self.ChangeSubmits:
             return
@@ -3112,11 +3934,22 @@ class Dial(Element):
 
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                           Stretch                                       #
 # ---------------------------------------------------------------------- #
 class Stretch(Element):
-    def __init__(self, size=(None, None), font=None, background_color=None, text_color=None, key=None, k=None, pad=None, tooltip=None):
+    def __init__(
+        self,
+        size=(None, None),
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        k=None,
+        pad=None,
+        tooltip=None,
+    ):
         """
         :param size: (width, height) of the button in characters wide, rows high
         :type size: Tuple[int, int]
@@ -3136,20 +3969,37 @@ class Stretch(Element):
         :type tooltip: (str)
         """
         key = key if key is not None else k
-        self.Widget = None          # type: Stretch
-        super().__init__(ELEM_TYPE_STRETCH, size=size, font=font, background_color=background_color,
-                         text_color=text_color, key=key, pad=pad, tooltip=tooltip)
+        self.Widget = None  # type: Stretch
+        super().__init__(
+            ELEM_TYPE_STRETCH,
+            size=size,
+            font=font,
+            background_color=background_color,
+            text_color=text_color,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+        )
         return
-
-
 
 
 # ---------------------------------------------------------------------- #
 #                           Column                                       #
 # ---------------------------------------------------------------------- #
 class Column(Element):
-    def __init__(self, layout, background_color=None, element_justification='float', size=(None, None), pad=None, scrollable=False, key=None, k=None, visible=True, metadata=None):
-
+    def __init__(
+        self,
+        layout,
+        background_color=None,
+        element_justification='float',
+        size=(None, None),
+        pad=None,
+        scrollable=False,
+        key=None,
+        k=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param layout: Layout that will be shown in the Column container
         :type layout: List[List[Element]]
@@ -3188,15 +4038,17 @@ class Column(Element):
         # self.ImageSubsample = image_subsample
         bg = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.ElementJustification = element_justification
-        self.Widget = self.QT_QGroupBox = None          # type: QGroupBox
-        self.vbox_layout = None                         # type: QVBoxLayout
+        self.Widget = self.QT_QGroupBox = None  # type: QGroupBox
+        self.vbox_layout = None  # type: QVBoxLayout
         self.Layout(layout)
 
-        super().__init__(ELEM_TYPE_COLUMN, background_color=bg, size=size, pad=pad, key=key, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_COLUMN, background_color=bg, size=size, pad=pad, key=key, visible=visible, metadata=metadata
+        )
         return
 
     def AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -3220,7 +4072,6 @@ class Column(Element):
         element = row[col_num]
         return element
 
-
     def Update(self, visible=None):
 
         super().Update(self.QT_QGroupBox, visible=visible)
@@ -3229,13 +4080,26 @@ class Column(Element):
     layout = Layout
     update = Update
 
+
 Col = Column
+
 
 # ---------------------------------------------------------------------- #
 #                           Menu                                       #
 # ---------------------------------------------------------------------- #
 class Menu(Element):
-    def __init__(self, menu_definition, background_color=None, size=(None, None), tearoff=False, pad=None, key=None, k=None, visible=True, metadata=None):
+    def __init__(
+        self,
+        menu_definition,
+        background_color=None,
+        size=(None, None),
+        tearoff=False,
+        pad=None,
+        key=None,
+        k=None,
+        visible=True,
+        metadata=None,
+    ):
         """
         :param menu_definition: a menu definition (in menu definition format)
         :type menu_definition: List[List[Tuple[str, List[str]]]
@@ -3265,14 +4129,21 @@ class Menu(Element):
         self.Tearoff = tearoff
         self.IsButtonMenu = False
         self.MenuItemChosen = None
-        self.Widget = self.QT_QMenuBar = None           # type: QMenuBar
+        self.Widget = self.QT_QMenuBar = None  # type: QMenuBar
 
-        super().__init__(ELEM_TYPE_MENUBAR, background_color=background_color, size=size, pad=pad, key=key, visible=visible, metadata=metadata)
-
+        super().__init__(
+            ELEM_TYPE_MENUBAR,
+            background_color=background_color,
+            size=size,
+            pad=pad,
+            key=key,
+            visible=visible,
+            metadata=metadata,
+        )
 
     def _QT_MenuItemChosenCallback(self, item_chosen):
         # print('IN MENU ITEM CALLBACK', item_chosen)
-        self.MenuItemChosen = item_chosen.replace('&','')
+        self.MenuItemChosen = item_chosen.replace('&', '')
         _element_callback_quit_mainloop(self)
         # self.ParentForm.LastButtonClicked = item_chosen
         # self.ParentForm.FormRemainedOpen = True
@@ -3301,14 +4172,43 @@ class Menu(Element):
 
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                           Table                                        #
 # ---------------------------------------------------------------------- #
 class Table(Element):
-    def __init__(self, values, headings=None, visible_column_map=None, col_widths=None, def_col_width=10,
-                 auto_size_columns=True, max_col_width=20, select_mode=None, display_row_numbers=False, num_rows=None,
-                 font=None, justification='right',header_text_color=None, header_background_color=None, header_font=None,  text_color=None, background_color=None, alternating_row_color=None,
-                 size=(None, None), change_submits=False, enable_events=False, bind_return_key=False, pad=None, key=None, k=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        values,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        display_row_numbers=False,
+        num_rows=None,
+        font=None,
+        justification='right',
+        header_text_color=None,
+        header_background_color=None,
+        header_font=None,
+        text_color=None,
+        background_color=None,
+        alternating_row_color=None,
+        size=(None, None),
+        change_submits=False,
+        enable_events=False,
+        bind_return_key=False,
+        pad=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param values: ???
         :type values: List[List[Union[str, int, float]]]
@@ -3380,7 +4280,9 @@ class Table(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
         self.HeaderTextColor = header_text_color if header_text_color is not None else theme_input_text_color()
-        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else theme_input_background_color()
+        self.HeaderBackgroundColor = (
+            header_background_color if header_background_color is not None else theme_input_background_color()
+        )
         self.HeaderFont = header_font
         self.Justification = justification
         self.InitialState = None
@@ -3392,12 +4294,22 @@ class Table(Element):
         self.SelectedRows = []
         self.ChangeSubmits = change_submits or enable_events
         self.BindReturnKey = bind_return_key
-        self.Widget = self.QT_TableWidget = None                    # type: QTableWidget
+        self.Widget = self.QT_TableWidget = None  # type: QTableWidget
 
-        super().__init__(ELEM_TYPE_TABLE, text_color=text_color, background_color=background_color, font=font,
-                         size=size, pad=pad, key=key, tooltip=tooltip, visible=visible, size_px=size_px, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TABLE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            size=size,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
-
 
     def _QtCallbackCellActivated(self, value=None):
         # print('CELL ACTIVATED ', value)
@@ -3407,10 +4319,8 @@ class Table(Element):
             return
         _element_callback_quit_mainloop(self)
 
-
     def _QtCallbackVerticalHeader(self, value):
         print('Vertical Header value ', value)
-
 
     def Update(self, values=None, num_rows=None, visible=None):
         if values is not None:
@@ -3428,7 +4338,6 @@ class Table(Element):
             self.QT_TableWidget.setFixedHeight(num_rows * 35 + 25)  # convert num rows into pixels...crude but effective
 
         super().Update(self.QT_TableWidget, visible=visible)
-
 
     def Get(self):
         num_rows = self.QT_TableWidget.rowCount()
@@ -3452,8 +4361,7 @@ class Table(Element):
                 self.ParentForm.LastButtonClicked = ''
             self.ParentForm.FormRemainedOpen = True
             if self.ParentForm.CurrentlyRunningMainloop:
-                pass # TODO Quit mainloop
-
+                pass  # TODO Quit mainloop
 
     def treeview_double_click(self, event):
         if self.BindReturnKey:
@@ -3464,8 +4372,7 @@ class Table(Element):
                 self.ParentForm.LastButtonClicked = ''
             self.ParentForm.FormRemainedOpen = True
             if self.ParentForm.CurrentlyRunningMainloop:
-                pass # TODO Quit mainloop
-
+                pass  # TODO Quit mainloop
 
     class QTTableWidget(QTableWidget):
         def __init__(self, enable_key_events, window):
@@ -3499,15 +4406,42 @@ class Table(Element):
     get = Get
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                           Tree                                         #
 # ---------------------------------------------------------------------- #
 class Tree(Element):
-    def __init__(self, data=None, headings=None, visible_column_map=None, col_widths=None, col0_width=10,
-                 def_col_width=10, auto_size_columns=True, max_col_width=20, select_mode=None, show_expanded=False,
-                 change_submits=False, enable_events=False, font=None, size=(200,600),
-                 justification='right', header_text_color=None, header_background_color=None, header_font=None,  text_color=None, background_color=None, num_rows=None, pad=None, key=None, k=None,
-                 tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        data=None,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        col0_width=10,
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        show_expanded=False,
+        change_submits=False,
+        enable_events=False,
+        font=None,
+        size=(200, 600),
+        justification='right',
+        header_text_color=None,
+        header_background_color=None,
+        header_font=None,
+        text_color=None,
+        background_color=None,
+        num_rows=None,
+        pad=None,
+        key=None,
+        k=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         :param data: The data represented using a PySimpleGUI provided TreeData class
         :type data: (TreeData)
@@ -3577,7 +4511,9 @@ class Tree(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.TextColor = text_color
         self.HeaderTextColor = header_text_color if header_text_color is not None else theme_input_text_color()
-        self.HeaderBackgroundColor = header_background_color if header_background_color is not None else theme_input_background_color()
+        self.HeaderBackgroundColor = (
+            header_background_color if header_background_color is not None else theme_input_background_color()
+        )
         self.HeaderFont = header_font
         self.Justification = justification
         self.InitialState = None
@@ -3589,9 +4525,20 @@ class Tree(Element):
         self.SelectedRows = []
         self.ChangeSubmits = change_submits or enable_events
         self.Size = size
-        self.Widget = self.QT_QTreeWidget = None      # type: QTreeWidget
-        super().__init__(ELEM_TYPE_TREE, text_color=text_color, background_color=background_color, font=font, pad=pad,
-                         key=key, tooltip=tooltip, size=size, visible=visible, size_px=size_px, metadata=metadata)
+        self.Widget = self.QT_QTreeWidget = None  # type: QTreeWidget
+        super().__init__(
+            ELEM_TYPE_TREE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            size=size,
+            visible=visible,
+            size_px=size_px,
+            metadata=metadata,
+        )
         return
 
     def _treeview_selected(self, event):
@@ -3619,7 +4566,6 @@ class Tree(Element):
         #     if self.ParentForm.CurrentlyRunningMainloop:
         #         self.ParentForm.TKroot.quit()
 
-
     def Update(self, values=None, key=None, value=None, text=None, visible=None):
         if values is not None:
             self.TreeData = values
@@ -3642,7 +4588,6 @@ class Tree(Element):
             #             child.setIcon(0, qicon)
             #     for node in node.children:
             #         add_treeview_data(node, child)
-
 
             def add_treeview_data(node, widget):
                 # print(f'Inserting {node.key} under parent {node.parent}')
@@ -3676,6 +4621,7 @@ class Tree(Element):
 
     update = Update
 
+
 class TreeData(object):
     class Node(object):
         def __init__(self, parent, key, text, values, icon=None):
@@ -3708,8 +4654,9 @@ class TreeData(object):
 
     def _NodeStr(self, node, level):
         return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text)] +
-            [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
+            [str(node.key) + ' : ' + str(node.text)]
+            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
+        )
 
     insert = Insert
 
@@ -3733,11 +4680,13 @@ class ErrorElement(Element):
         return
 
     def Update(self, *args, **kwargs):
-        PopupError('Keyword error in Update',
-                   'You need to stop this madness and check your spelling',
-                   'Bad key = {}'.format(self.Key),
-                   'Your bad line of code may resemble this:',
-                   'window.FindElement("{}")'.format(self.Key))
+        PopupError(
+            'Keyword error in Update',
+            'You need to stop this madness and check your spelling',
+            'Bad key = {}'.format(self.Key),
+            'Your bad line of code may resemble this:',
+            'window.FindElement("{}")'.format(self.Key),
+        )
         return self
 
     def Get(self):
@@ -3753,6 +4702,7 @@ class ErrorElement(Element):
 
 # This is for source code compatibility with tkinter version. No Qt equivalent
 Pane = ErrorElement
+
 
 # ------------------------------------------------------------------------- #
 #                       Tray CLASS                                      #
@@ -3785,7 +4735,7 @@ class SystemTray:
         if Window.QTApplication is None:
             Window.QTApplication = QApplication(sys.argv)
         self.App = Window.QTApplication
-        self.Widget = self.QWidget = QWidget()              # type: QWidget
+        self.Widget = self.QWidget = QWidget()  # type: QWidget
 
         if filename is None and data is None and data_base64 is None:
             data_base64 = DEFAULT_BASE64_ICON
@@ -3822,14 +4772,13 @@ class SystemTray:
         self.TrayIcon.show()
 
     def _QT_MenuItemChosenCallback(self, item_chosen):
-        self.MenuItemChosen = item_chosen.replace('&','')
-        self.App.exit()                         # kick the users out of the mainloop
+        self.MenuItemChosen = item_chosen.replace('&', '')
+        self.App.exit()  # kick the users out of the mainloop
 
     # callback function when message is clicked
     def _message_clicked(self):
         self.MenuItemChosen = EVENT_SYSTEM_TRAY_MESSAGE_CLICKED
         self.App.exit()
-
 
     def _double_clicked(self, reason):
         # print(reason)
@@ -3839,7 +4788,6 @@ class SystemTray:
         if reason == QSystemTrayIcon.Trigger:
             self.MenuItemChosen = EVENT_SYSTEM_TRAY_ICON_ACTIVATED
             self.App.exit()
-
 
     def Read(self, timeout=None):
         """
@@ -3871,10 +4819,8 @@ class SystemTray:
     def Hide(self):
         self.TrayIcon.hide()
 
-
     def UnHide(self):
         self.TrayIcon.show()
-
 
     def ShowMessage(self, title, message, filename=None, data=None, data_base64=None, messageicon=None, time=10000):
         """
@@ -3921,8 +4867,14 @@ class SystemTray:
         # Don't close app because windows could be depending on it
         # self.App.quit()
 
-
-    def Update(self, menu=None, tooltip=None,filename=None, data=None, data_base64=None,):
+    def Update(
+        self,
+        menu=None,
+        tooltip=None,
+        filename=None,
+        data=None,
+        data_base64=None,
+    ):
         """
         Updates the menu, tooltip or icon
         :param menu: menu defintion
@@ -3966,6 +4918,7 @@ class SystemTray:
     un_hide = UnHide
     update = Update
 
+
 # ------------------------------------------------------------------------- #
 #                       Window CLASS                                      #
 # ------------------------------------------------------------------------- #
@@ -3977,8 +4930,42 @@ class Window:
     QTApplication = None
     active_popups = {}
 
-    def __init__(self, title, layout=None, default_element_size=DEFAULT_ELEMENT_SIZE, default_button_element_size=(None, None),
-                 auto_size_text=None, auto_size_buttons=None, location=(None, None), size=(None, None), element_padding=None, margins=(None, None),button_color=None, font=None, progress_bar_color=(None, None), background_color=None, border_depth=None, auto_close=False, auto_close_duration=DEFAULT_AUTOCLOSE_TIME, icon=DEFAULT_WINDOW_ICON, force_toplevel=False, alpha_channel=1, return_keyboard_events=False, use_default_focus=True, text_justification=None, element_justification='float', no_titlebar=False, grab_anywhere=False, keep_on_top=False, resizable=True, disable_close=False, disable_minimize=False, background_image=None, finalize=False, metadata=None):
+    def __init__(
+        self,
+        title,
+        layout=None,
+        default_element_size=DEFAULT_ELEMENT_SIZE,
+        default_button_element_size=(None, None),
+        auto_size_text=None,
+        auto_size_buttons=None,
+        location=(None, None),
+        size=(None, None),
+        element_padding=None,
+        margins=(None, None),
+        button_color=None,
+        font=None,
+        progress_bar_color=(None, None),
+        background_color=None,
+        border_depth=None,
+        auto_close=False,
+        auto_close_duration=DEFAULT_AUTOCLOSE_TIME,
+        icon=DEFAULT_WINDOW_ICON,
+        force_toplevel=False,
+        alpha_channel=1,
+        return_keyboard_events=False,
+        use_default_focus=True,
+        text_justification=None,
+        element_justification='float',
+        no_titlebar=False,
+        grab_anywhere=False,
+        keep_on_top=False,
+        resizable=True,
+        disable_close=False,
+        disable_minimize=False,
+        background_image=None,
+        finalize=False,
+        metadata=None,
+    ):
         """
         :param title: The title that will be displayed in the Titlebar and on the Taskbar
         :type title: (str)
@@ -4052,8 +5039,11 @@ class Window:
         self.Title = title
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = _convert_tkinter_size_to_Qt(default_element_size)
-        self.DefaultButtonElementSize = _convert_tkinter_size_to_Qt(default_button_element_size) if default_button_element_size != (
-            None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
+        self.DefaultButtonElementSize = (
+            _convert_tkinter_size_to_Qt(default_button_element_size)
+            if default_button_element_size != (None, None)
+            else DEFAULT_BUTTON_ELEMENT_SIZE
+        )
         self.Location = location
         self.ButtonColor = button_color if button_color else DEFAULT_BUTTON_COLOR
         self.BackgroundColor = background_color if background_color else DEFAULT_BACKGROUND_COLOR
@@ -4097,8 +5087,8 @@ class Window:
         self._Hidden = False
         self.QTApplication = None
         self.QT_QMainWindow = None
-        self.QTWindow = None        # type Window.QTMainWindow
-        self._Size=size
+        self.QTWindow = None  # type Window.QTMainWindow
+        self._Size = size
         self.ElementPadding = element_padding or DEFAULT_ELEMENT_PADDING
         self.FocusElement = None
         self.BackgroundImage = background_image
@@ -4125,41 +5115,49 @@ class Window:
         self.NumOpenWindows -= 1 * (self.NumOpenWindows != 0)  # decrement if not 0
         # print('----- DECREMENTING Num Open Windows = {} ---'.format(Window.NumOpenWindows))
 
-
     # ------------------------- Add ONE Row to Form ------------------------- #
     def AddRow(self, *args):
-        """ Parms are a variable number of Elements """
+        """Parms are a variable number of Elements"""
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
         # -------------------------  Add the elements to a row  ------------------------- #
         for i, element in enumerate(args):  # Loop through list of elements and add them to the row
             if type(element) is list:
-                PopupError('Error creating layout',
-                      'Layout has a LIST instead of an ELEMENT',
-                      'This means you have a badly placed ]',
-                      'The offensive list is:',
-                      element,
-                      'This list will be stripped from your layout'
-                      )
+                PopupError(
+                    'Error creating layout',
+                    'Layout has a LIST instead of an ELEMENT',
+                    'This means you have a badly placed ]',
+                    'The offensive list is:',
+                    element,
+                    'This list will be stripped from your layout',
+                )
                 continue
             elif callable(element) and not isinstance(element, Element):
-                PopupError('Error creating layout',
-                      'Layout has a FUNCTION instead of an ELEMENT',
-                      'This means you are missing () from your layout',
-                      'The offensive list is:',
-                      element,
-                      'This item will be stripped from your layout')
+                PopupError(
+                    'Error creating layout',
+                    'Layout has a FUNCTION instead of an ELEMENT',
+                    'This means you are missing () from your layout',
+                    'The offensive list is:',
+                    element,
+                    'This item will be stripped from your layout',
+                )
                 continue
             if element.ParentContainer is not None:
-                warnings.warn('*** YOU ARE ATTEMPTING TO RESUSE A LAYOUT! You must not attempt this kind of re-use ***', UserWarning)
-                PopupError('Error creating layout',
-                      'The layout specified has already been used',
-                      'You MUST start witha "clean", unused layout every time you create a window',
-                      'The offensive Element = ',
-                      element,
-                      'and has a key = ', element.Key,
-                      'This item will be stripped from your layout')
+                warnings.warn(
+                    '*** YOU ARE ATTEMPTING TO RESUSE A LAYOUT! You must not attempt this kind of re-use ***',
+                    UserWarning,
+                )
+                PopupError(
+                    'Error creating layout',
+                    'The layout specified has already been used',
+                    'You MUST start witha "clean", unused layout every time you create a window',
+                    'The offensive Element = ',
+                    element,
+                    'and has a key = ',
+                    element.Key,
+                    'This item will be stripped from your layout',
+                )
                 continue
             element.Position = (CurrentRowNumber, i)
             element.ParentContainer = self
@@ -4173,11 +5171,13 @@ class Window:
             try:
                 iter(row)
             except TypeError:
-                PopupError('Error creating layout',
-                      'Your row is not an iterable (e.g. a list)',
-                      'The offensive row = ',
-                      row,
-                      'This item will be stripped from your layout')
+                PopupError(
+                    'Error creating layout',
+                    'Your row is not an iterable (e.g. a list)',
+                    'The offensive row = ',
+                    row,
+                    'This item will be stripped from your layout',
+                )
                 continue
             self.AddRow(*row)
 
@@ -4187,7 +5187,9 @@ class Window:
         return self
 
     def LayoutAndRead(self, rows, non_blocking=False):
-        raise DeprecationWarning('LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()')
+        raise DeprecationWarning(
+            'LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()'
+        )
         # self.AddRows(rows)
         # self.Show(non_blocking=non_blocking)
         # return self.ReturnValues
@@ -4232,7 +5234,7 @@ class Window:
 
     # ------------------------- SetIcon - set the window's fav icon ------------------------- #
     def SetIcon(self, icon=None, pngbase64=None):
-            pass
+        pass
 
     def _GetElementAtLocation(self, location):
         (row_num, col_num) = location
@@ -4277,7 +5279,6 @@ class Window:
             # print("quitting window")
             self.QTApplication.exit()  # kick the users out of the mainloop
 
-
     def Read(self, timeout=None, timeout_key=TIMEOUT_KEY, close=False):
         """
         THE biggest deal method in the Window class! This is how you get all of your data from your Window.
@@ -4295,8 +5296,6 @@ class Window:
             self.close()
 
         return results
-
-
 
     def _read(self, timeout=None, timeout_key=TIMEOUT_KEY):
         if timeout == 0:  # timeout of zero runs the old readnonblocking
@@ -4368,11 +5367,15 @@ class Window:
                 self.LastButtonClicked = None
             return results
         else:
-            if not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None:       # Special Qt case because returning for no reason so fake timeout
-                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]   # fake a timeout
-            elif not self.XFound and self.ReturnValues[0] is None:                   # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
+            if (
+                not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None
+            ):  # Special Qt case because returning for no reason so fake timeout
+                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
+            elif (
+                not self.XFound and self.ReturnValues[0] is None
+            ):  # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
                 # print("*** Faking timeout ***")
-                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]   # fake a timeout
+                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
             return self.ReturnValues
 
     def _ReadNonBlocking(self):
@@ -4381,14 +5384,13 @@ class Window:
         if not self.Shown:
             self.Show(non_blocking=True)
         else:
-            self.QTApplication.processEvents()              # refresh the window
-        if 0:       # TODO add window closed with X logic
+            self.QTApplication.processEvents()  # refresh the window
+        if 0:  # TODO add window closed with X logic
             self.TKrootDestroyed = True
             _my_windows.Decrement()
             # print("read failed")
             # return None, None
         return BuildResults(self, False, self)
-
 
     def Finalize(self):
         if self.TKrootDestroyed:
@@ -4397,16 +5399,15 @@ class Window:
             self.Show(non_blocking=True)
         else:
             try:
-                self.QTApplication.processEvents()              # refresh the window
+                self.QTApplication.processEvents()  # refresh the window
             except:
                 print('* ERROR FINALIZING *')
                 self.TKrootDestroyed = True
                 Window.DecrementOpenCount()
         return self
 
-
     def Refresh(self):
-        self.QTApplication.processEvents()              # refresh the window
+        self.QTApplication.processEvents()  # refresh the window
         return self
 
     def VisibilityChanged(self):
@@ -4430,20 +5431,22 @@ class Window:
         if element is None:
             if not silent_on_error:
                 print('*** WARNING = FindElement did not find the key. Please check your key\'s spelling ***')
-                PopupError('Keyword error in FindElement Call',
-                           'Bad key = {}'.format(key),
-                           'Your bad line of code may resemble this:',
-                           'window.FindElement("{}")'.format(key))
+                PopupError(
+                    'Keyword error in FindElement Call',
+                    'Bad key = {}'.format(key),
+                    'Your bad line of code may resemble this:',
+                    'window.FindElement("{}")'.format(key),
+                )
                 return ErrorElement(key=key)
             else:
                 return False
         return element
 
-    Element =  FindElement          # Shortcut function
+    Element = FindElement  # Shortcut function
 
     def _BuildKeyDict(self):
         dict = {}
-        self.AllKeysDict = self._BuildKeyDictForWindow(self,self, dict)
+        self.AllKeysDict = self._BuildKeyDictForWindow(self, self, dict)
 
     def _BuildKeyDictForWindow(self, top_window, window, key_dict):
         for row_num, row in enumerate(window.Rows):
@@ -4456,25 +5459,44 @@ class Window:
                     key_dict = self._BuildKeyDictForWindow(top_window, element, key_dict)
                 if element.Type == ELEM_TYPE_TAB:
                     key_dict = self._BuildKeyDictForWindow(top_window, element, key_dict)
-                if element.Key is None:   # if no key has been assigned.... create one for input elements
+                if element.Key is None:  # if no key has been assigned.... create one for input elements
                     if element.Type == ELEM_TYPE_BUTTON:
                         element.Key = element.ButtonText
                     elif element.Type == ELEM_TYPE_TAB:
                         element.Key = element.Title
-                    if element.Type in (ELEM_TYPE_MENUBAR, ELEM_TYPE_BUTTONMENU, ELEM_TYPE_CANVAS,
-                                        ELEM_TYPE_INPUT_SLIDER, ELEM_TYPE_GRAPH, ELEM_TYPE_IMAGE,
-                                        ELEM_TYPE_INPUT_CHECKBOX, ELEM_TYPE_INPUT_LISTBOX, ELEM_TYPE_INPUT_COMBO,
-                                        ELEM_TYPE_INPUT_MULTILINE, ELEM_TYPE_INPUT_OPTION_MENU, ELEM_TYPE_INPUT_SPIN,
-                                        ELEM_TYPE_TABLE, ELEM_TYPE_TREE,
-                                        ELEM_TYPE_INPUT_TEXT):
+                    if element.Type in (
+                        ELEM_TYPE_MENUBAR,
+                        ELEM_TYPE_BUTTONMENU,
+                        ELEM_TYPE_CANVAS,
+                        ELEM_TYPE_INPUT_SLIDER,
+                        ELEM_TYPE_GRAPH,
+                        ELEM_TYPE_IMAGE,
+                        ELEM_TYPE_INPUT_CHECKBOX,
+                        ELEM_TYPE_INPUT_LISTBOX,
+                        ELEM_TYPE_INPUT_COMBO,
+                        ELEM_TYPE_INPUT_MULTILINE,
+                        ELEM_TYPE_INPUT_OPTION_MENU,
+                        ELEM_TYPE_INPUT_SPIN,
+                        ELEM_TYPE_TABLE,
+                        ELEM_TYPE_TREE,
+                        ELEM_TYPE_INPUT_TEXT,
+                    ):
                         element.Key = top_window.DictionaryKeyCounter
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        print('*** Duplicate key found in your layout {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None
+                        (
+                            print('*** Duplicate key found in your layout {} ***'.format(element.Key))
+                            if element.Type != ELEM_TYPE_BUTTON
+                            else None
+                        )
                         element.Key = str(element.Key) + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
-                        print('*** Replaced new key with {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None
+                        (
+                            print('*** Replaced new key with {} ***'.format(element.Key))
+                            if element.Type != ELEM_TYPE_BUTTON
+                            else None
+                        )
                     key_dict[element.Key] = element
         return key_dict
 
@@ -4523,7 +5545,6 @@ class Window:
         if not self._is_window_created():
             return
         self.QT_QMainWindow.setWindowState(Qt.WindowMaximized)
-
 
     def StartMove(self, event):
         try:
@@ -4594,7 +5615,6 @@ class Window:
     CloseNonBlockingForm = Close
     CloseNonBlocking = Close
 
-
     def Disable(self):
         if not self._is_window_created():
             return
@@ -4655,13 +5675,11 @@ class Window:
         self.QTMainWindow.activateWindow(self.QT_QMainWindow)
         self.QTMainWindow.raise_(self.QT_QMainWindow)
 
-
     def CurrentLocation(self):
         if not self._is_window_created():
             return
         location = self.QT_QMainWindow.geometry()
         return location.left(), location.top()
-
 
     def set_title(self, title):
         """
@@ -4675,10 +5693,8 @@ class Window:
         self.Title = str(title)
         self.QT_QMainWindow.setWindowTitle(self.Title)
 
-
-
     class QTMainWindow(QWidget):
-        def __init__(self,enable_key_events, window):
+        def __init__(self, enable_key_events, window):
             self.KeyEventsEnabled = enable_key_events
             self.Window = window
             super().__init__(window.QT_QMainWindow)
@@ -4706,9 +5722,8 @@ class Window:
                     self.Window.QTApplication.exit()
             return QWidget.eventFilter(self, widget, event)
 
-
     class QT_QMainWindowClass(QMainWindow):
-        def __init__(self,enable_key_events, window):
+        def __init__(self, enable_key_events, window):
             self.KeyEventsEnabled = enable_key_events
             self.Window = window
             super().__init__()
@@ -4760,7 +5775,7 @@ class Window:
     def Size(self):
         if not self._is_window_created():
             return
-        size =  self.QT_QMainWindow.sizeHint()
+        size = self.QT_QMainWindow.sizeHint()
         return [size.width(), size.height()]
 
     @Size.setter
@@ -4769,17 +5784,20 @@ class Window:
             return
         self.QT_QMainWindow.resize(QSize(size[0], size[1]))
 
-
     def _is_window_created(self):
         if self.QT_QMainWindow is None:
-            warnings.warn('You cannot perform operations on a Window until it is read or finalized. Adding a "finalize=True" parameter to your Window creation will fix this', UserWarning)
-            popup_error('You cannot perform operations on a Window until it is read or finalized.',
-                        'Yea, I know, it\'s a weird thing, but easy to fix.... ',
-                         'Adding a "finalize=True" parameter to your Window creation will likely fix this', image=FACE_PALM)
+            warnings.warn(
+                'You cannot perform operations on a Window until it is read or finalized. Adding a "finalize=True" parameter to your Window creation will fix this',
+                UserWarning,
+            )
+            popup_error(
+                'You cannot perform operations on a Window until it is read or finalized.',
+                'Yea, I know, it\'s a weird thing, but easy to fix.... ',
+                'Adding a "finalize=True" parameter to your Window creation will likely fix this',
+                image=FACE_PALM,
+            )
             return False
         return True
-
-
 
     def __getitem__(self, key):
         """
@@ -4812,10 +5830,6 @@ class Window:
         """
         return self.Read(*args, **kwargs)
 
-
-
-
-
     add_row = AddRow
     add_rows = AddRows
     alpha_channel = AlphaChannel
@@ -4847,39 +5861,37 @@ class Window:
     un_hide = UnHide
     visibility_changed = VisibilityChanged
 
+
 FlexForm = Window
-
-
-
 
 
 class QtStyle(object):
     '''
-        API
+    API
 
-        # step 1 - make a style
-        ss = QtStyle(QLabel)
+    # step 1 - make a style
+    ss = QtStyle(QLabel)
 
-        # step 2 - add fields
-        ss['font'] = create_style_from_font()
-        ss['background_color'] = (color, color_default)
-        ss['color'] = (color, color_default)
-        # step 2.1 - add additions
-        ss.append_css_to_end.append(" QScrollBar:vertical { ... some css here ...  } ")
-        # step 2.2 - add anchor
-        ss.my_anchor = '::chunk'
+    # step 2 - add fields
+    ss['font'] = create_style_from_font()
+    ss['background_color'] = (color, color_default)
+    ss['color'] = (color, color_default)
+    # step 2.1 - add additions
+    ss.append_css_to_end.append(" QScrollBar:vertical { ... some css here ...  } ")
+    # step 2.2 - add anchor
+    ss.my_anchor = '::chunk'
 
-        # step 3 - build result
-        css_str = ss.build_css_string()
-        qt_widget.setStyleSheet(css_str)
+    # step 3 - build result
+    css_str = ss.build_css_string()
+    qt_widget.setStyleSheet(css_str)
 
-        ====== Special fields
-        - font
-        - margin
-        Why they are special? Because of the formatting.
+    ====== Special fields
+    - font
+    - margin
+    Why they are special? Because of the formatting.
 
-        === === ===
-        made by nngogol
+    === === ===
+    made by nngogol
     '''
 
     def __init__(self, widget_name=''):
@@ -4925,12 +5937,14 @@ class QtStyle(object):
 
                 if len(value) == 4:
                     # skip all zeros
-                    if value[0] == value[1] == value[2] == value[3] == 0: result_css_string = ''
+                    if value[0] == value[1] == value[2] == value[3] == 0:
+                        result_css_string = ''
 
                     result_css_string = '{} : {}px {}px {}px {}px;'.format(key, *value)
                 elif len(value) == 1:
                     # skip all zeros
-                    if value[0] == 0: continue
+                    if value[0] == 0:
+                        continue
 
                     result_css_string = '{} : {}px;'.format(key, value[0])
                 else:
@@ -4975,18 +5989,18 @@ class QtStyle(object):
         # if needed: append some css from self.append_css_to_end
         final_str += ' '.join(self.append_css_to_end)
 
-        if self.logging: print(f'final css string (self.widget_name): {final_str}')
+        if self.logging:
+            print(f'final css string (self.widget_name): {final_str}')
         return final_str
 
     def __repr__(self):
         return self.build_css_string()
 
 
-
-
 # =========================================================================== #
 # Stops the mainloop and sets the event information                           #
 # =========================================================================== #
+
 
 def _element_callback_quit_mainloop(element):
     if element.Key is not None:
@@ -5001,17 +6015,18 @@ def _element_callback_quit_mainloop(element):
 # =========================================================================== #
 # Convert from characters to pixels                                           #
 # =========================================================================== #
-def _convert_tkinter_size_to_Qt(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF):
+def _convert_tkinter_size_to_Qt(
+    size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF
+):
     """
     Converts size in characters to size in pixels
     :param size:  size in characters, rows
     :return: size in pixels, pixels
     """
     qtsize = size
-    if size[1] is not None and size[1] < height_cutoff:        # change from character based size to pixels (roughly)
-        qtsize = size[0]*scaling[0], size[1]*scaling[1]
+    if size[1] is not None and size[1] < height_cutoff:  # change from character based size to pixels (roughly)
+        qtsize = size[0] * scaling[0], size[1] * scaling[1]
     return qtsize
-
 
 
 # =========================================================================== #
@@ -5020,9 +6035,10 @@ def _convert_tkinter_size_to_Qt(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, h
 def convert_tkinter_filetypes_to_qt(filetypes):
     qt_filetypes = ''
     for i, item in enumerate(filetypes):
-        filetype = item[0] + ' (' + item[1] + ')' + (';;' if i != len(filetypes)-1 else '')
+        filetype = item[0] + ' (' + item[1] + ')' + (';;' if i != len(filetypes) - 1 else '')
         qt_filetypes += filetype
     return qt_filetypes
+
 
 # =========================================================================== #
 # Converts a "Font" string or tuple into Qt Style Sheet Entries               #
@@ -5034,7 +6050,8 @@ def create_style_from_font(font):
     :return: style string that can be combined with other style strings
     """
 
-    if font is None: return ''
+    if font is None:
+        return ''
     _font = font.split(' ') if type(font) is str else font
 
     # parsing name + size
@@ -5047,18 +6064,20 @@ def create_style_from_font(font):
             if some_option == 'underline':
                 is_underline = True
         else:
-                is_bold = True
+            is_bold = True
 
     # build
-    is_bold_text      = 'font-weight : bold;'         if is_bold else ''
+    is_bold_text = 'font-weight : bold;' if is_bold else ''
     is_underline_text = 'text-decoration: underline;' if is_underline else ''
 
-    return textwrap.dedent(f'''
+    return textwrap.dedent(
+        f'''
         {is_underline_text}
         {is_bold_text}
         font-family: "{font_name}";
         font-size: {font_size}pt;
-        '''.strip()).replace('\n', '')
+        '''.strip()
+    ).replace('\n', '')
 
 
 def set_widget_visiblity(widget, visible):
@@ -5081,177 +6100,689 @@ def set_widget_visiblity(widget, visible):
 
 
 # -------------------------  FOLDER BROWSE Element lazy function  ------------------------- #
-def FolderBrowse(button_text='Browse', target=(ThisRow, -1), initial_folder=None, tooltip=None, size=(None, None),
-                 auto_size_button=None, button_color=None, disabled=False, change_submits=False, enable_events=False, font=None, pad=None,
-                 key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FOLDER, target=target,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  disabled=disabled, button_color=button_color, change_submits=change_submits, enable_events=enable_events, font=font, pad=pad,
-                  key=key, k=k, metadata=metadata)
+def FolderBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FOLDER,
+        target=target,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        font=font,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileBrowse(button_text='Browse', target=(ThisRow, -1), file_types=(('ALL Files', '*'),), initial_folder=None,
-               tooltip=None, size=(None, None), auto_size_button=None, button_color=None, change_submits=False, enable_events=False,
-               font=None, disabled=False,
-               pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  change_submits=change_submits, enable_events=enable_events, disabled=disabled, button_color=button_color, font=font, pad=pad,
-                  key=key, k=k, metadata=metadata)
+def FileBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*'),),
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    disabled=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  FILES BROWSE Element (Multiple file selection) lazy function  ------------------------- #
-def FilesBrowse(button_text='Browse', target=(ThisRow, -1), file_types=(('ALL Files', '*'),), disabled=False,
-                initial_folder=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                change_submits=False, enable_events=False,
-                font=None, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILES, target=target, file_types=file_types,
-                  initial_folder=initial_folder, change_submits=change_submits, enable_events=enable_events, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button,
-                  disabled=disabled, button_color=button_color, font=font, pad=pad, key=key, k=k, metadata=metadata)
+def FilesBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*'),),
+    disabled=False,
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILES,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileSaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=(('ALL Files', '*'),), initial_folder=None,
-               disabled=False, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-               change_submits=False, enable_events=False, font=None,
-               pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits, enable_events=enable_events,
-                  font=font, pad=pad, key=key, metadata=metadata)
+def FileSaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*'),),
+    initial_folder=None,
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        font=font,
+        pad=pad,
+        key=key,
+        metadata=metadata,
+    )
 
 
 # -------------------------  SAVE AS Element lazy function  ------------------------- #
-def SaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=(('ALL Files', '*'),), initial_folder=None,
-           disabled=False, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-           change_submits=False, enable_events=False, font=None,
-           pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits, enable_events=enable_events,
-                  font=font, pad=pad, key=key, k=k, metadata=metadata)
+def SaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*'),),
+    initial_folder=None,
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    enable_events=False,
+    font=None,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        enable_events=enable_events,
+        font=font,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  SAVE BUTTON Element lazy function  ------------------------- #
-def Save(button_text='Save', size=(None, None), auto_size_button=None, button_color=None, bind_return_key=True,
-         disabled=False, tooltip=None, font=None, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Save(
+    button_text='Save',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    bind_return_key=True,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  SUBMIT BUTTON Element lazy function  ------------------------- #
-def Submit(button_text='Submit', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Submit(
+    button_text='Submit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  OPEN BUTTON Element lazy function  ------------------------- #
 # -------------------------  OPEN BUTTON Element lazy function  ------------------------- #
-def Open(button_text='Open', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-         bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Open(
+    button_text='Open',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  OK BUTTON Element lazy function  ------------------------- #
-def OK(button_text='OK', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def OK(
+    button_text='OK',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  YES BUTTON Element lazy function  ------------------------- #
-def Ok(button_text='Ok', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Ok(
+    button_text='Ok',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  CANCEL BUTTON Element lazy function  ------------------------- #
-def Cancel(button_text='Cancel', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           tooltip=None, font=None, bind_return_key=False, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Cancel(
+    button_text='Cancel',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  QUIT BUTTON Element lazy function  ------------------------- #
-def Quit(button_text='Quit', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Quit(
+    button_text='Quit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  Exit BUTTON Element lazy function  ------------------------- #
-def Exit(button_text='Exit', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Exit(
+    button_text='Exit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  YES BUTTON Element lazy function  ------------------------- #
-def Yes(button_text='Yes', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Yes(
+    button_text='Yes',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  NO BUTTON Element lazy function  ------------------------- #
-def No(button_text='No', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-       font=None, bind_return_key=False, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def No(
+    button_text='No',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  NO BUTTON Element lazy function  ------------------------- #
-def Help(button_text='Help', size=(None, None), auto_size_button=None, button_color=None, disabled=False, font=None,
-         tooltip=None, bind_return_key=False, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def Help(
+    button_text='Help',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    tooltip=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  GENERIC BUTTON Element lazy function  ------------------------- #
-def SimpleButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                 border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                 font=None, bind_return_key=False, disabled=False, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def SimpleButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  CLOSE BUTTON Element lazy function  ------------------------- #
-def CloseButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-                bind_return_key=False, disabled=False, focus=False, pad=None, key=None, k=None, metadata=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def CloseButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 CButton = CloseButton
 
 
 # -------------------------  GENERIC BUTTON Element lazy function  ------------------------- #
-def ReadButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-               border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-               bind_return_key=False, disabled=False, focus=False, pad=None, key=None, k=None, metadata=None):
+def ReadButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
     """
     :param button_text: text in the button
     :type button_text: (str)
@@ -5291,11 +6822,27 @@ def ReadButton(button_text, image_filename=None, image_data=None, image_size=(No
     :type metadata: (Any)
     """
 
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 ReadFormButton = ReadButton
@@ -5303,9 +6850,26 @@ RButton = ReadFormButton
 
 
 # -------------------------  Realtime BUTTON Element lazy function  ------------------------- #
-def RealtimeButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                   border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                   font=None, disabled=False, bind_return_key=False, focus=False, pad=None, key=None, k=None, metadata=None):
+def RealtimeButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
     """
     :param button_text: text in the button
     :type button_text: (str)
@@ -5344,17 +6908,50 @@ def RealtimeButton(button_text, image_filename=None, image_data=None, image_size
     :param metadata: Anything you want to store along with this button
     :type metadata: (Any)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_REALTIME, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_REALTIME,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  Dummy BUTTON Element lazy function  ------------------------- #
-def DummyButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-                disabled=False, bind_return_key=False, focus=False, pad=None, key=None, k=None, metadata=None):
+def DummyButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
     """
     :param button_text: text in the button
     :type button_text: (str)
@@ -5393,34 +6990,102 @@ def DummyButton(button_text, image_filename=None, image_data=None, image_size=(N
     :param metadata: Anything you want to store along with this button
     :type metadata: (Any)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN_ONLY, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  button_color=button_color, font=font, disabled=disabled, bind_return_key=bind_return_key, focus=focus,
-                  pad=pad, key=key, k=k, metadata=metadata)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN_ONLY,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def CalendarButton(button_text, target=(None, None), close_when_date_chosen=True, default_date_m_d_y=(None, None, None),
-                   image_filename=None, image_data=None, image_size=(None, None),
-                   image_subsample=None, tooltip=None, border_width=None, size=(None, None), auto_size_button=None,
-                   button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None,
-                   key=None, k=None, metadata=None):
-    button = Button(button_text=button_text, button_type=BUTTON_TYPE_CALENDAR_CHOOSER, target=target,
-                    image_filename=image_filename, image_data=image_data, image_size=image_size,
-                    image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size,
-                    auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                    bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+def CalendarButton(
+    button_text,
+    target=(None, None),
+    close_when_date_chosen=True,
+    default_date_m_d_y=(None, None, None),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
+    button = Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CALENDAR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
     button.CalendarCloseWhenChosen = close_when_date_chosen
     button.DefaultDate_M_D_Y = default_date_m_d_y
     return button
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def ColorChooserButton(button_text, target=(None, None), image_filename=None, image_data=None, image_size=(None, None),
-                       image_subsample=None, tooltip=None, border_width=None, size=(None, None), auto_size_button=None,
-                       button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None,
-                       key=None, k=None, metadata=None):
+def ColorChooserButton(
+    button_text,
+    target=(None, None),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+    k=None,
+    metadata=None,
+):
     """
     :param button_text: text in the button
     :type button_text: (str)
@@ -5457,14 +7122,32 @@ def ColorChooserButton(button_text, target=(None, None), image_filename=None, im
     :param metadata: Anything you want to store along with this button
     :type metadata: (Any)
     """
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_COLOR_CHOOSER, target=target,
-                  image_filename=image_filename, image_data=image_data, image_size=image_size,
-                  image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key, k=k, metadata=metadata)
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_COLOR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+        k=k,
+        metadata=metadata,
+    )
 
 
 #####################################  -----  RESULTS   ------ ##################################################
+
 
 def AddToReturnDictionary(form, element, value):
     form.ReturnValuesDictionary[element.Key] = value
@@ -5578,7 +7261,11 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
             if not initialize_only:
                 if element.Type == ELEM_TYPE_INPUT_TEXT:
                     value = element.QT_QLineEdit.text()
-                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
+                    if (
+                        not top_level_form.NonBlocking
+                        and not element.do_not_clear
+                        and not top_level_form.ReturnKeyboardEvents
+                    ):
                         element.QT_QLineEdit.setText('')
 
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
@@ -5602,16 +7289,18 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                         except:
                             value = None
                 elif element.Type == ELEM_TYPE_INPUT_COMBO:
-                    element = element           # type: Combo
-                    index = element.QT_ComboBox.currentIndex()  # index into the list of values, but can be larger if manual entry
+                    element = element  # type: Combo
+                    index = (
+                        element.QT_ComboBox.currentIndex()
+                    )  # index into the list of values, but can be larger if manual entry
                     if index < len(element.Values):
                         value = element.Values[index]
-                    else:       # if not a valid index, then get what was typed in
+                    else:  # if not a valid index, then get what was typed in
                         value = element.QT_ComboBox.currentText()
                 elif element.Type == ELEM_TYPE_INPUT_OPTION_MENU:
                     value = 0
                 elif element.Type == ELEM_TYPE_INPUT_LISTBOX:
-                    element = element            # type: Listbox
+                    element = element  # type: Listbox
                     # print(f'selected indexes = {element.QT_ListWidget.selectedIndexes()}')
                     value = []
                     # value = [element.Values[int(i)] for i in element.QT_ListWidget.selectedIndexes()]
@@ -5637,10 +7326,14 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                     if element.WriteOnly:
                         continue
                     value = element.QT_TextEdit.toPlainText()
-                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
+                    if (
+                        not top_level_form.NonBlocking
+                        and not element.do_not_clear
+                        and not top_level_form.ReturnKeyboardEvents
+                    ):
                         element.QT_TextEdit.setText('')
                 elif element.Type == ELEM_TYPE_TAB_GROUP:
-                    element = element   # type: TabGroup
+                    element = element  # type: TabGroup
                     cur_index = element.QT_QTabWidget.currentIndex()
                     tab_element = element.TabList[cur_index]
                     value = tab_element.Key
@@ -5667,26 +7360,43 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 value = None
 
             # if an input type element, update the results
-            if element.Type != ELEM_TYPE_BUTTON and \
-                    element.Type != ELEM_TYPE_TEXT and \
-                    element.Type != ELEM_TYPE_IMAGE and \
-                    element.Type != ELEM_TYPE_OUTPUT and \
-                    element.Type != ELEM_TYPE_PROGRESS_BAR and \
-                    element.Type != ELEM_TYPE_COLUMN and \
-                    element.Type != ELEM_TYPE_FRAME \
-                    and element.Type != ELEM_TYPE_TAB:
+            if (
+                element.Type != ELEM_TYPE_BUTTON
+                and element.Type != ELEM_TYPE_TEXT
+                and element.Type != ELEM_TYPE_IMAGE
+                and element.Type != ELEM_TYPE_OUTPUT
+                and element.Type != ELEM_TYPE_PROGRESS_BAR
+                and element.Type != ELEM_TYPE_COLUMN
+                and element.Type != ELEM_TYPE_FRAME
+                and element.Type != ELEM_TYPE_TAB
+            ):
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
-            elif (element.Type == ELEM_TYPE_BUTTON and
-                  element.BType == BUTTON_TYPE_CALENDAR_CHOOSER and
-                  element.Target == (None, None)) or \
-                    (element.Type == ELEM_TYPE_BUTTON and
-                     element.BType == BUTTON_TYPE_COLOR_CHOOSER and
-                     element.Target == (None, None)) or \
-                    (element.Type == ELEM_TYPE_BUTTON
-                     and element.Key is not None and
-                     (element.BType in (BUTTON_TYPE_SAVEAS_FILE, BUTTON_TYPE_BROWSE_FILE, BUTTON_TYPE_BROWSE_FILES,
-                                        BUTTON_TYPE_BROWSE_FOLDER))):
+            elif (
+                (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER
+                    and element.Target == (None, None)
+                )
+                or (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.BType == BUTTON_TYPE_COLOR_CHOOSER
+                    and element.Target == (None, None)
+                )
+                or (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.Key is not None
+                    and (
+                        element.BType
+                        in (
+                            BUTTON_TYPE_SAVEAS_FILE,
+                            BUTTON_TYPE_BROWSE_FILE,
+                            BUTTON_TYPE_BROWSE_FILES,
+                            BUTTON_TYPE_BROWSE_FOLDER,
+                        )
+                    )
+                )
+            ):
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
 
@@ -5815,11 +7525,11 @@ def AddTrayMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=Fa
                 action.setSeparator(True)
             else:
                 try:
-                    item_without_key = sub_menu_info[:sub_menu_info.index(MENU_KEY_SEPARATOR)]
+                    item_without_key = sub_menu_info[: sub_menu_info.index(MENU_KEY_SEPARATOR)]
                 except:
                     item_without_key = sub_menu_info
                 if item_without_key[0] == MENU_DISABLED_CHARACTER:
-                    action.setText(item_without_key[len(MENU_DISABLED_CHARACTER):])
+                    action.setText(item_without_key[len(MENU_DISABLED_CHARACTER) :])
                     action.setDisabled(True)
                 else:
                     action.setText(item_without_key)
@@ -5834,11 +7544,11 @@ def AddTrayMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=Fa
                     new_menu = QMenu(top_menu)
                     item = sub_menu_info[i]
                     try:
-                        item_without_key = item[:item.index(MENU_KEY_SEPARATOR)]
+                        item_without_key = item[: item.index(MENU_KEY_SEPARATOR)]
                     except:
                         item_without_key = item
                     if item_without_key[0] == MENU_DISABLED_CHARACTER:
-                        new_menu.setTitle(item_without_key[len(MENU_DISABLED_CHARACTER):])
+                        new_menu.setTitle(item_without_key[len(MENU_DISABLED_CHARACTER) :])
                         new_menu.setDisabled(True)
                     else:
                         new_menu.setTitle(item_without_key)
@@ -5865,11 +7575,11 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False)
 
                 # Key handling.... strip off key before setting text
                 try:
-                    item_without_key = sub_menu_info[:sub_menu_info.index(MENU_KEY_SEPARATOR)]
+                    item_without_key = sub_menu_info[: sub_menu_info.index(MENU_KEY_SEPARATOR)]
                 except:
                     item_without_key = sub_menu_info
                 if item_without_key[0] == MENU_DISABLED_CHARACTER:
-                    action.setText(item_without_key[len(MENU_DISABLED_CHARACTER):])
+                    action.setText(item_without_key[len(MENU_DISABLED_CHARACTER) :])
                     action.setDisabled(True)
                 else:
                     action.setText(item_without_key)
@@ -5899,11 +7609,11 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False)
                     # Key handling.... strip off key before setting text
                     item = sub_menu_info[i]
                     try:
-                        item_without_key = item[:item.index(MENU_KEY_SEPARATOR)]
+                        item_without_key = item[: item.index(MENU_KEY_SEPARATOR)]
                     except:
                         item_without_key = item
                     if item_without_key[0] == MENU_DISABLED_CHARACTER:
-                        new_menu.setTitle(item_without_key[len(MENU_DISABLED_CHARACTER):])
+                        new_menu.setTitle(item_without_key[len(MENU_DISABLED_CHARACTER) :])
                         new_menu.setDisabled(True)
                     else:
                         new_menu.setTitle(item_without_key)
@@ -5964,9 +7674,204 @@ Q:::::::QQ::::::::Q      t::::::tttt:::::t
 # to_css_prop(css_prop.replace('_','-'), value)
 def _to_css_prop(key_, val_):
     return '{}:{}; '.format(key_.replace('_', '-'), val_)
+
+
 # def style_generate(qt_element_type, css_props_str):
 #     return '%s {\n %s \n}' % (qt_element_type, css_props_str)
-_valid_css_fields = ['align-content', 'align-items', 'align-self', 'background', 'background-attachment', 'background-color', 'background-image', 'background-position', 'background-size', 'border', 'border-collapse', 'border-image', 'border-radius', 'border-spacing', 'bottom', 'box-decoration-break', 'caret-color', 'clear', 'clip-path', 'color', 'color-adjust', 'column-count', 'column-fill', 'column-gap', 'column-rule', 'column-rule-color', 'column-rule-style', 'column-rule-width', 'column-span', 'column-width', 'columns', 'contain', 'content', 'counter-increment', 'counter-reset', 'counter-set', 'cursor', 'direction', 'display', 'empty-cells', 'fill', 'filter', 'flex', 'flex-basis', 'flex-direction', 'flex-flow', 'flex-grow', 'flex-shrink', 'flex-wrap', 'float', 'font', 'font-display', 'font-family', 'font-feature-settings', 'font-kerning', 'font-optical-sizing', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-synthesis', 'font-variant', 'font-variant-numeric', 'font-weight', 'gap', 'grid-column', 'grid-row', 'grid-template-columns', 'grid-template-rows', 'hanging-punctuation', 'height', 'hyphens', 'image-rendering', 'initial-letter', 'inline-size', 'inset', 'inset-block', 'inset-block-end', 'inset-block-start', 'inset-inline', 'inset-inline-end', 'inset-inline-start', 'isolation', 'justify-content', 'left', 'letter-spacing', 'line-clamp', 'line-height', 'list-style', 'margin', 'mask-image', 'mask-position', 'mask-repeat', 'mask-size', 'max-height', 'max-width', 'min-height', 'min-width', 'mix-blend-mode', 'object-fit', 'object-position', 'offset-anchor', 'offset-distance', 'offset-path', 'offset-rotate', 'opacity', 'order', 'orphans', 'outline', 'outline-offset', 'overflow', 'overflow-anchor', 'overflow-wrap', 'overscroll-behavior', 'padding', 'page-break', 'paint-order', 'perspective', 'perspective-origin', 'place-items', 'pointer-events', 'position', 'quotes', 'resize', 'right', 'row-gap', 'scroll-behavior', 'scroll-margin', 'scroll-padding', 'scroll-snap-align', 'scroll-snap-stop', 'scroll-snap-type', 'scrollbar', 'scrollbar-color', 'scrollbar-gutter', 'scrollbar-width', 'shape-image-threshold', 'shape-margin', 'shape-outside', 'speak', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-width', 'tab-size', 'table-layout', 'text-align', 'text-align-last', 'text-decoration', 'text-decoration-color', 'text-decoration-line', 'text-decoration-skip', 'text-decoration-skip-ink', 'text-decoration-style', 'text-decoration-thickness', 'text-indent', 'text-justify', 'text-overflow', 'text-rendering', 'text-shadow', 'text-stroke', 'text-transform', 'text-underline-offset', 'text-underline-position', 'top', 'touch-action', 'transform', 'transform-origin', 'transform-style', 'transition', 'transition-delay', 'transition-duration', 'transition-property', 'transition-timing-function', 'unicode-bidi', 'unicode-range', 'user-select', 'vertical-align', 'visibility', 'white-space', 'widows', 'width', 'will-change', 'word-break', 'word-spacing', 'writing-mode', 'z-index', 'zoom']
+_valid_css_fields = [
+    'align-content',
+    'align-items',
+    'align-self',
+    'background',
+    'background-attachment',
+    'background-color',
+    'background-image',
+    'background-position',
+    'background-size',
+    'border',
+    'border-collapse',
+    'border-image',
+    'border-radius',
+    'border-spacing',
+    'bottom',
+    'box-decoration-break',
+    'caret-color',
+    'clear',
+    'clip-path',
+    'color',
+    'color-adjust',
+    'column-count',
+    'column-fill',
+    'column-gap',
+    'column-rule',
+    'column-rule-color',
+    'column-rule-style',
+    'column-rule-width',
+    'column-span',
+    'column-width',
+    'columns',
+    'contain',
+    'content',
+    'counter-increment',
+    'counter-reset',
+    'counter-set',
+    'cursor',
+    'direction',
+    'display',
+    'empty-cells',
+    'fill',
+    'filter',
+    'flex',
+    'flex-basis',
+    'flex-direction',
+    'flex-flow',
+    'flex-grow',
+    'flex-shrink',
+    'flex-wrap',
+    'float',
+    'font',
+    'font-display',
+    'font-family',
+    'font-feature-settings',
+    'font-kerning',
+    'font-optical-sizing',
+    'font-size',
+    'font-size-adjust',
+    'font-stretch',
+    'font-style',
+    'font-synthesis',
+    'font-variant',
+    'font-variant-numeric',
+    'font-weight',
+    'gap',
+    'grid-column',
+    'grid-row',
+    'grid-template-columns',
+    'grid-template-rows',
+    'hanging-punctuation',
+    'height',
+    'hyphens',
+    'image-rendering',
+    'initial-letter',
+    'inline-size',
+    'inset',
+    'inset-block',
+    'inset-block-end',
+    'inset-block-start',
+    'inset-inline',
+    'inset-inline-end',
+    'inset-inline-start',
+    'isolation',
+    'justify-content',
+    'left',
+    'letter-spacing',
+    'line-clamp',
+    'line-height',
+    'list-style',
+    'margin',
+    'mask-image',
+    'mask-position',
+    'mask-repeat',
+    'mask-size',
+    'max-height',
+    'max-width',
+    'min-height',
+    'min-width',
+    'mix-blend-mode',
+    'object-fit',
+    'object-position',
+    'offset-anchor',
+    'offset-distance',
+    'offset-path',
+    'offset-rotate',
+    'opacity',
+    'order',
+    'orphans',
+    'outline',
+    'outline-offset',
+    'overflow',
+    'overflow-anchor',
+    'overflow-wrap',
+    'overscroll-behavior',
+    'padding',
+    'page-break',
+    'paint-order',
+    'perspective',
+    'perspective-origin',
+    'place-items',
+    'pointer-events',
+    'position',
+    'quotes',
+    'resize',
+    'right',
+    'row-gap',
+    'scroll-behavior',
+    'scroll-margin',
+    'scroll-padding',
+    'scroll-snap-align',
+    'scroll-snap-stop',
+    'scroll-snap-type',
+    'scrollbar',
+    'scrollbar-color',
+    'scrollbar-gutter',
+    'scrollbar-width',
+    'shape-image-threshold',
+    'shape-margin',
+    'shape-outside',
+    'speak',
+    'stroke',
+    'stroke-dasharray',
+    'stroke-dashoffset',
+    'stroke-linecap',
+    'stroke-linejoin',
+    'stroke-width',
+    'tab-size',
+    'table-layout',
+    'text-align',
+    'text-align-last',
+    'text-decoration',
+    'text-decoration-color',
+    'text-decoration-line',
+    'text-decoration-skip',
+    'text-decoration-skip-ink',
+    'text-decoration-style',
+    'text-decoration-thickness',
+    'text-indent',
+    'text-justify',
+    'text-overflow',
+    'text-rendering',
+    'text-shadow',
+    'text-stroke',
+    'text-transform',
+    'text-underline-offset',
+    'text-underline-position',
+    'top',
+    'touch-action',
+    'transform',
+    'transform-origin',
+    'transform-style',
+    'transition',
+    'transition-delay',
+    'transition-duration',
+    'transition-property',
+    'transition-timing-function',
+    'unicode-bidi',
+    'unicode-range',
+    'user-select',
+    'vertical-align',
+    'visibility',
+    'white-space',
+    'widows',
+    'width',
+    'will-change',
+    'word-break',
+    'word-spacing',
+    'writing-mode',
+    'z-index',
+    'zoom',
+]
+
+
 def is_valid_css_prop(a_css_prop):
     '''Check if a given property EXISTS in qt Spec'''
     return True
@@ -6025,20 +7930,23 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
             text_color = element.TextColor
             # Determine Element size
             element_size = element.Size
-            if (element_size == (None, None) and element_type not in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU)):  # user did not specify a size
+            if element_size == (None, None) and element_type not in (
+                ELEM_TYPE_BUTTON,
+                ELEM_TYPE_BUTTONMENU,
+            ):  # user did not specify a size
                 element_size = toplevel_win.DefaultElementSize
-            elif (element_size == (None, None) and element_type in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU)):
+            elif element_size == (None, None) and element_type in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU):
                 element_size = toplevel_win.DefaultButtonElementSize
             else:
                 auto_size_text = False  # if user has specified a size then it shouldn't autosize
-            full_element_pad = [0,0,0,0]       # Top, Right, Bottom, Left
+            full_element_pad = [0, 0, 0, 0]  # Top, Right, Bottom, Left
             elementpad = element.Pad if element.Pad is not None else toplevel_win.ElementPadding
-            if type(elementpad[0]) is not tuple:   # left and right
+            if type(elementpad[0]) is not tuple:  # left and right
                 full_element_pad[1] = full_element_pad[3] = elementpad[0]
             else:
                 full_element_pad[3], full_element_pad[1] = elementpad[0]
 
-            if type(elementpad[1]) is not tuple:   # top and bottom
+            if type(elementpad[1]) is not tuple:  # top and bottom
                 full_element_pad[0] = full_element_pad[2] = elementpad[1]
             else:
                 full_element_pad[0], full_element_pad[2] = elementpad[1]
@@ -6052,7 +7960,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
 
             # -------------------------  COLUMN placement element  ------------------------- #
             if element_type == ELEM_TYPE_COLUMN:
-                element = element           # type: Column
+                element = element  # type: Column
                 # column_widget = QWidget()
                 column_widget = QGroupBox()
                 element.Widget = element.QT_QGroupBox = column_widget
@@ -6063,7 +7971,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 style['font'] = create_style_from_font(font)
                 if element.BackgroundColor is not None:
                     style['background_color'] = element.BackgroundColor
-                style['border'] = '0px solid gray' # FIXv2
+                style['border'] = '0px solid gray'  # FIXv2
                 column_widget.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
                 # === style === end
@@ -6130,14 +8038,16 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 if element.Margins is not None:
                     m = element.Margins
                     qlabel.setContentsMargins(m[0], m[2], m[1], m[3])  # L T B R
-                if element.Tooltip:         element.QT_Label.setToolTip(element.Tooltip)
-                if element.ClickSubmits:    element.QT_Label.mousePressEvent = element._QtCallbackTextClicked
+                if element.Tooltip:
+                    element.QT_Label.setToolTip(element.Tooltip)
+                if element.ClickSubmits:
+                    element.QT_Label.mousePressEvent = element._QtCallbackTextClicked
                 if not element.Visible:
                     element.QT_Label.setVisible(False)
                 qt_row_layout.addWidget(element.QT_Label, alignment=Qt.AlignVCenter)
             # -------------------------  BUTTON placement element  ------------------------- #
             elif element_type == ELEM_TYPE_BUTTON:
-                element = element            #type: Button
+                element = element  # type: Button
                 btext = element.ButtonText
                 btype = element.BType
                 element.Widget = element.QT_QPushButton = QPushButton(btext)
@@ -6145,7 +8055,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 style = QtStyle('QPushButton')
                 style['font'] = create_style_from_font(font)
                 style['color'] = (element.TextColor, COLOR_SYSTEM_DEFAULT)
-                style['background_color'] = (element.BackgroundColor)
+                style['background_color'] = element.BackgroundColor
                 if element.BorderWidth == 0:
                     style['border'] = 'none'
                 style['margin'] = full_element_pad
@@ -6155,7 +8065,11 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style === end
 
                 # element.QT_QPushButton.setFlat(False)
-                if (element.AutoSizeButton is False or toplevel_win.AutoSizeButtons is False or element.Size[0] is not None) and element.ImageData is None:
+                if (
+                    element.AutoSizeButton is False
+                    or toplevel_win.AutoSizeButtons is False
+                    or element.Size[0] is not None
+                ) and element.ImageData is None:
                     if element_size[0] is not None:
                         element.QT_QPushButton.setFixedWidth(element_size[0])
                     if element_size[1] is not None:
@@ -6166,7 +8080,8 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                     element.QT_QPushButton.setIconSize(QtGui.QPixmap(element.ImageFilename).rect().size())
                 if element.ImageData:
                     ba = QtCore.QByteArray.fromBase64(element.ImageData)
-                    pixmap = QtGui.QPixmap(); pixmap.loadFromData(ba)
+                    pixmap = QtGui.QPixmap()
+                    pixmap.loadFromData(ba)
                     element.QT_QPushButton.setIcon(pixmap)
                     element.QT_QPushButton.setIconSize(pixmap.rect().size())
 
@@ -6182,7 +8097,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_QPushButton, alignment=Qt.AlignVCenter)
             # -------------------------  INPUT placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_TEXT:
-                element = element       # type: InputText
+                element = element  # type: InputText
                 default_text = element.DefaultText
                 element.Widget = element.QT_QLineEdit = qlineedit = QLineEdit()
 
@@ -6248,7 +8163,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_QLineEdit, alignment=Qt.AlignVCenter)
             # -------------------------  COMBO placement BOX (Drop Down) element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_COMBO:
-                element = element   # type: Combo
+                element = element  # type: Combo
                 element.Widget = element.QT_ComboBox = QComboBox()
 
                 items_as_strings = [str(v) for v in element.Values]
@@ -6267,7 +8182,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 style2['color'] = (element.TextColor, COLOR_SYSTEM_DEFAULT)
                 style2['background_color'] = (element.BackgroundColor, COLOR_SYSTEM_DEFAULT)
 
-                element.QT_ComboBox.setStyleSheet(str(style)+str(style2))
+                element.QT_ComboBox.setStyleSheet(str(style) + str(style2))
                 element.qt_styles = (style, style2)
                 # === style === end
 
@@ -6302,7 +8217,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 pass
             # -------------------------  LISTBOX placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_LISTBOX:
-                element = element       # type: Listbox
+                element = element  # type: Listbox
                 element.Widget = element.QT_ListWidget = QListWidget()
 
                 # === style ===
@@ -6311,7 +8226,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 if element.TextColor is not None and element.TextColor != COLOR_SYSTEM_DEFAULT:
                     style['color'] = element.TextColor
                 if element.BackgroundColor is not None and element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
-                    style['background-color'] = element.BackgroundColor # example for mike here
+                    style['background-color'] = element.BackgroundColor  # example for mike here
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray; '.format(border_depth)
                 element.QT_ListWidget.setStyleSheet(style.build_css_string())
@@ -6332,8 +8247,10 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                     element.QT_ListWidget.setSelectionMode(QAbstractItemView.ContiguousSelection)
                 elif element.SelectMode == SELECT_MODE_SINGLE:
                     element.QT_ListWidget.setSelectionMode(QAbstractItemView.SingleSelection)
-                if element.Disabled: element.QT_ListWidget.setDisabled(True)
-                if element.ChangeSubmits: element.QT_ListWidget.currentRowChanged.connect(element._QtCurrentRowChanged)
+                if element.Disabled:
+                    element.QT_ListWidget.setDisabled(True)
+                if element.ChangeSubmits:
+                    element.QT_ListWidget.currentRowChanged.connect(element._QtCurrentRowChanged)
 
                 # add all Values to the ListWidget
                 element.QT_ListWidget.addItems([str(v) for v in element.Values])
@@ -6350,7 +8267,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_ListWidget, alignment=Qt.AlignVCenter)
             # -------------------------  INPUT MULTILINE placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_MULTILINE:
-                element = element           # type: Multiline
+                element = element  # type: Multiline
                 default_text = element.DefaultText
                 width, height = element_size
                 element.Widget = element.QT_TextEdit = QTextEdit()
@@ -6362,14 +8279,15 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style ===
                 style = QtStyle('QTextEdit')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray; '.format(border_depth)
                 element.QT_TextEdit.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
                 # === style === end
-
 
                 if element.AutoSizeText is False or element.Size[0] is not None:
                     if element_size[0] is not None:
@@ -6400,7 +8318,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_TextEdit, alignment=Qt.AlignVCenter)
             # ------------------------- OUTPUT MULTILINE placement element  ------------------------- #
             elif element_type == ELEM_TYPE_MULTILINE_OUTPUT:
-                element = element           # type: MultilineOutput
+                element = element  # type: MultilineOutput
                 default_text = element.DefaultText
                 element.Widget = element.QT_TextBrowser = QTextBrowser()
                 element.QT_TextBrowser.setDisabled(False)
@@ -6408,14 +8326,15 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style ===
                 style = QtStyle('QTextBrowser')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
                 element.QT_TextBrowser.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
                 # === style === end
-
 
                 if element.AutoSizeText is False or element.Size[0] is not None:
                     if element_size[0] is not None:
@@ -6433,7 +8352,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_TextBrowser, alignment=Qt.AlignVCenter)
             # -------------------------  INPUT CHECKBOX placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_CHECKBOX:
-                element = element           # type: Checkbox
+                element = element  # type: Checkbox
                 element.QT_Checkbox = QCheckBox(element.Text)
                 element.QT_Checkbox.setChecked(element.InitialState)
                 if element.Disabled:
@@ -6442,13 +8361,14 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style ===
                 style = QtStyle('QCheckBox')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 element.QT_Checkbox.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
                 # === style === end
-
 
                 if element.AutoSizeText is False or element.Size[0] is not None:
                     if element_size[0] is not None:
@@ -6463,7 +8383,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 if not element.Visible:
                     element.QT_Checkbox.setVisible(False)
                 qt_row_layout.addWidget(element.QT_Checkbox, alignment=Qt.AlignVCenter)
-              # -------------------------  PROGRESSBAR placement element  ------------------------- #
+            # -------------------------  PROGRESSBAR placement element  ------------------------- #
             elif element_type == ELEM_TYPE_PROGRESS_BAR:
                 element.Widget = element.QT_QProgressBar = QProgressBar()
                 orientation = element.Orientation.lower()[0]
@@ -6490,12 +8410,11 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
 
                     style['border'] = '%spx solid grey' % border_depth
                     style['border-radius'] = '0px'
-                    style['background-color'] = str(element.BarColor[1] \
-                                                if element.BarColor[1] is not None \
-                                                else DEFAULT_PROGRESS_BAR_COLOR[1])
+                    style['background-color'] = str(
+                        element.BarColor[1] if element.BarColor[1] is not None else DEFAULT_PROGRESS_BAR_COLOR[1]
+                    )
 
-
-                element.QT_QProgressBar.setStyleSheet(style.build_css_string()+style_chunk.build_css_string())
+                element.QT_QProgressBar.setStyleSheet(style.build_css_string() + style_chunk.build_css_string())
                 element.qt_styles = (style, style_chunk)
                 # === style === end
 
@@ -6508,19 +8427,22 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_QProgressBar, alignment=Qt.AlignVCenter)
             # -------------------------  INPUT RADIO placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_RADIO:
-                element = element           # type: Radio
+                element = element  # type: Radio
                 default_value = element.InitialState
                 element.Widget = qradio = QRadioButton(element.Text)
                 element.QT_Radio_Button = qradio
                 if element.Disabled:
                     element.QT_Radio_Button.setDisabled(True)
-                if default_value:    qradio.setChecked(True)
+                if default_value:
+                    qradio.setChecked(True)
 
                 # === style ===
                 style = QtStyle('QRadioButton')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 element.QT_Radio_Button.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
@@ -6553,9 +8475,9 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # -------------------------  INPUT SPIN placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_SPIN:
                 # element.QT_Spinner = QSpinBox()
-                element = element               # type: Spin
+                element = element  # type: Spin
                 element.Widget = element.QT_Spinner = Spin.StringBox(element.Values)
-                if element.DefaultValue is not None:         # try to set the default value without crashing on error
+                if element.DefaultValue is not None:  # try to set the default value without crashing on error
                     try:
                         element.QT_Spinner.setValue(element.QT_Spinner.valueFromText(element.DefaultValue))
                     except:
@@ -6563,8 +8485,10 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style ===
                 style = QtStyle('QSpinBox')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
                 element.QT_Spinner.setStyleSheet(style.build_css_string())
@@ -6589,15 +8513,17 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_Spinner, alignment=Qt.AlignVCenter)
             # -------------------------  OUTPUT placement element  ------------------------- #
             elif element_type == ELEM_TYPE_OUTPUT:
-                element = element       # type: Output
+                element = element  # type: Output
                 element.Widget = element.QT_TextBrowser = QTextBrowser()
                 element.QT_TextBrowser.setDisabled(False)
 
                 # === style ===
                 style = QtStyle('QTextBrowser')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
                 # style += "QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } "
@@ -6620,7 +8546,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_TextBrowser, alignment=Qt.AlignVCenter)
             # -------------------------  IMAGE placement element  ------------------------- #
             elif element_type == ELEM_TYPE_IMAGE:
-                element = element           # type: Image
+                element = element  # type: Image
                 element.Widget = element.QT_QLabel = qlabel = QLabel()
                 if element.Filename is not None:
                     qlabel.setText('')
@@ -6648,7 +8574,8 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 element.qt_styles = (style,)
                 # === style === end
 
-                if element.Tooltip:         element.QT_QLabel.setToolTip(element.Tooltip)
+                if element.Tooltip:
+                    element.QT_QLabel.setToolTip(element.Tooltip)
                 if element.ClickSubmits:
                     element.QT_QLabel.mousePressEvent = element.QtCallbackImageClicked
                 if not element.Visible:
@@ -6659,7 +8586,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 width, height = element_size
             # -------------------------  Graph placement element  ------------------------- #
             elif element_type == ELEM_TYPE_GRAPH:
-                element = element               # type: Graph
+                element = element  # type: Graph
                 width, height = element_size
                 # print(f'Graph element size = {element_size}')
                 element.Widget = element.QT_QGraphicsView = qgraphicsview = QGraphicsView()
@@ -6667,7 +8594,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # print(f'Graph Canvas size = {element.CanvasSize}')
 
                 element.QT_QGraphicsScene = QGraphicsScene()
-                element.QT_QGraphicsScene.setSceneRect(0,0,element.CanvasSize[0],element.CanvasSize[1])
+                element.QT_QGraphicsScene.setSceneRect(0, 0, element.CanvasSize[0], element.CanvasSize[1])
                 element.QT_QGraphicsView.setScene(element.QT_QGraphicsScene)
 
                 # === style ===
@@ -6690,7 +8617,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_QGraphicsView, alignment=Qt.AlignVCenter)
             # -------------------------  MENUBAR placement element  ------------------------- #
             elif element_type == ELEM_TYPE_MENUBAR:
-                element = element           # type: Menu
+                element = element  # type: Menu
                 menu_def = element.MenuDefinition
                 element.Widget = element.QT_QMenuBar = QMenuBar(toplevel_win.QT_QMainWindow)
 
@@ -6709,12 +8636,14 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                     menu_style['font'] = create_style_from_font(font)
                     if element.MenuItemTextColor is not None and element.MenuItemTextColor != COLOR_SYSTEM_DEFAULT:
                         menu_style['color'] = element.MenuItemTextColor
-                    if element.MenuItemBackgroundColor is not None and element.MenuItemBackgroundColor != COLOR_SYSTEM_DEFAULT:
+                    if (
+                        element.MenuItemBackgroundColor is not None
+                        and element.MenuItemBackgroundColor != COLOR_SYSTEM_DEFAULT
+                    ):
                         menu_style['background-color'] = element.MenuItemBackgroundColor
                     # style['margin'] = full_element_pad
                     baritem.setStyleSheet(menu_style.build_css_string())
                     # === style === end
-
 
                 if element.BackgroundColor != COLOR_SYSTEM_DEFAULT:
                     # === style ===
@@ -6746,8 +8675,11 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 element.qt_styles = (style,)
                 # === style === end
 
-
-                if (element.AutoSizeButton is False or toplevel_win.AutoSizeButtons is False or element.Size[0] is not None) and element.ImageData is None:
+                if (
+                    element.AutoSizeButton is False
+                    or toplevel_win.AutoSizeButtons is False
+                    or element.Size[0] is not None
+                ) and element.ImageData is None:
                     if element_size[0] is not None:
                         element.QT_QPushButton.setFixedWidth(element_size[0])
                     if element_size[1] is not None:
@@ -6793,22 +8725,23 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_QPushButton, alignment=Qt.AlignVCenter)
             # -------------------------  Frame placement element  ------------------------- #
             elif element_type == ELEM_TYPE_FRAME:
-                element = element       # type: Frame
+                element = element  # type: Frame
                 element.Widget = column_widget = QGroupBox()
                 element.QT_QGroupBox = column_widget
 
                 # === style ===
                 style = QtStyle('QGroupBox')
                 # style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 # style['origin'] = 'margin'
                 style['font'] = create_style_from_font(font)
                 if element.FrameColor is not None:
                     style['border'] = '{}px solid {} '.format(border_depth, element.FrameColor)
                 else:
-                    style['border'] = '{}px solid {} '.format(border_depth, 'gainsboro')    # default to a light gray
-
+                    style['border'] = '{}px solid {} '.format(border_depth, 'gainsboro')  # default to a light gray
 
                 # style['padding'] = (10,10,10,10)
                 # style['margin'] = full_element_pad
@@ -6821,9 +8754,9 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
 
                 style_title = QtStyle('QGroupBox::title')
                 # style_title['padding'] =  (0,5,0,5)
-                style_title['margin'] = (0,0,0,0)
+                style_title['margin'] = (0, 0, 0, 0)
 
-                style_title['left'] =  '15px'
+                style_title['left'] = '15px'
                 # style_title['margin-top'] =  '-20px'
                 # style_title['top'] =  '20px'
                 style_title['subcontrol-origin'] = 'margin'
@@ -6832,10 +8765,10 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # style_title['subcontrol-origin'] = 'padding'
                 style_title['subcontrol-position'] = 'top left'
 
-                column_widget.setStyleSheet(str(style)+str(style_title))
+                column_widget.setStyleSheet(str(style) + str(style_title))
                 # column_widget.setStyleSheet(str(style))
                 # print(element.Widget.styleSheet())
-                element.qt_styles = (style, )
+                element.qt_styles = (style,)
                 # === style === end
 
                 column_widget.setTitle(element.Title)
@@ -6859,20 +8792,19 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 style = QtStyle('QGroupBox')
                 # style['font'] = create_style_from_font(font)
                 style['border'] = '0px'
-                style['margin'] = (0,0,0,0)
+                style['margin'] = (0, 0, 0, 0)
                 # style['margin'] = full_element_pad
 
-                style['padding'] = (0,0,0,0)
+                style['padding'] = (0, 0, 0, 0)
                 style['margin-top'] = '0px'
                 style['origin'] = 'content'
                 style_title = QtStyle('QGroupBox::title')
                 style_title['subcontrol-origin'] = 'content'
 
-                style_title['padding'] =  (0,0,0,0)
-                style_title['margin'] = (0,0,0,0)
-                pad_groupbox.setStyleSheet(str(style)+str(style_title))
+                style_title['padding'] = (0, 0, 0, 0)
+                style_title['margin'] = (0, 0, 0, 0)
+                pad_groupbox.setStyleSheet(str(style) + str(style_title))
                 # === style === end
-
 
                 if element.Tooltip:
                     column_widget.setToolTip(element.Tooltip)
@@ -6907,7 +8839,6 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 element.qt_styles = (style,)
                 # === style === end
 
-
                 column_layout, column_vbox = QFormLayout(), QVBoxLayout()
 
                 PackFormIntoFrame(element, column_layout, toplevel_win)
@@ -6921,8 +8852,8 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 container_elem.QT_QTabWidget.addTab(tab_widget, element.Title)
             # -------------------------  TabGroup placement element  ------------------------- #
             elif element_type == ELEM_TYPE_TAB_GROUP:
-                element = element       # type:TabGroup
-                element.Widget = element.QT_QTabWidget = qtab =QTabWidget()
+                element = element  # type:TabGroup
+                element.Widget = element.QT_QTabWidget = qtab = QTabWidget()
 
                 # === style ===
                 style = QtStyle('QTabWidget')
@@ -6943,9 +8874,20 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style === end
 
                 if element.TabLocation is not None:
-                    position_dict = {'left': QtWidgets.QTabWidget.TabPosition.West, 'right': QtWidgets.QTabWidget.TabPosition.East, 'top': QtWidgets.QTabWidget.TabPosition.North, 'bottom': QtWidgets.QTabWidget.TabPosition.South, 'lefttop': QtWidgets.QTabWidget.TabPosition.North,
-                                     'leftbottom': QtWidgets.QTabWidget.TabPosition.South, 'righttop': QtWidgets.QTabWidget.TabPosition.North, 'rightbottom': QtWidgets.QTabWidget.TabPosition.South, 'bottomleft': QtWidgets.QTabWidget.TabPosition.South,
-                                     'bottomright': QtWidgets.QTabWidget.TabPosition.South, 'topleft': QtWidgets.QTabWidget.TabPosition.North, 'topright': QtWidgets.QTabWidget.TabPosition.North}
+                    position_dict = {
+                        'left': QtWidgets.QTabWidget.TabPosition.West,
+                        'right': QtWidgets.QTabWidget.TabPosition.East,
+                        'top': QtWidgets.QTabWidget.TabPosition.North,
+                        'bottom': QtWidgets.QTabWidget.TabPosition.South,
+                        'lefttop': QtWidgets.QTabWidget.TabPosition.North,
+                        'leftbottom': QtWidgets.QTabWidget.TabPosition.South,
+                        'righttop': QtWidgets.QTabWidget.TabPosition.North,
+                        'rightbottom': QtWidgets.QTabWidget.TabPosition.South,
+                        'bottomleft': QtWidgets.QTabWidget.TabPosition.South,
+                        'bottomright': QtWidgets.QTabWidget.TabPosition.South,
+                        'topleft': QtWidgets.QTabWidget.TabPosition.North,
+                        'topright': QtWidgets.QTabWidget.TabPosition.North,
+                    }
                     try:
                         element.Widget.setTabPosition(position_dict[element.TabLocation])
                     except:
@@ -6960,22 +8902,25 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                     element.QT_QTabWidget.currentChanged.connect(element.QtCallbackStateChanged)
             # -------------------------  SLIDER placement element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_SLIDER:
-                element = element           # type: Slider
+                element = element  # type: Slider
                 element.Widget = element.QT_Slider = QSlider()
                 element.QT_Slider.setOrientation(Qt.Horizontal if element.Orientation.startswith('h') else Qt.Vertical)
-                if element.Disabled: element.QT_Slider.setDisabled(True)
+                if element.Disabled:
+                    element.QT_Slider.setDisabled(True)
 
                 # === style ===
                 style = QtStyle('QSlider')
                 style['font'] = create_style_from_font(font)
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
                 element.QT_Slider.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
                 # === style === end
 
-                element.QT_Slider.setMinimum(element.Range[0]); element.QT_Slider.setMaximum(element.Range[1])
+                element.QT_Slider.setMinimum(element.Range[0])
+                element.QT_Slider.setMaximum(element.Range[1])
                 position = QSlider.TicksBothSides
                 if element.Relief == RELIEF_TICK_POSITION_NO_TICKS:
                     position = QSlider.NoTicks
@@ -6993,8 +8938,10 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
 
                 if element.TickInterval is not None:
                     element.QT_Slider.setTickInterval(element.TickInterval)
-                if element_size[0] is not None: element.QT_Slider.setFixedWidth(element_size[0])
-                if element_size[1] is not None: element.QT_Slider.setFixedHeight(element_size[1])
+                if element_size[0] is not None:
+                    element.QT_Slider.setFixedWidth(element_size[0])
+                if element_size[1] is not None:
+                    element.QT_Slider.setFixedHeight(element_size[1])
                 if element.Resolution is not None:
                     element.QT_Slider.setSingleStep(element.Resolution)
                     element.QT_Slider.setPageStep(element.Resolution)
@@ -7014,21 +8961,28 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style ===
                 style = QtStyle('QDial')
                 style['font'] = create_style_from_font(font)
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
                 element.QT_Dial.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
                 # === style === end
 
-                if element.Disabled: element.QT_Dial.setDisabled(True)
-                element.QT_Dial.setMinimum(element.Range[0]); element.QT_Dial.setMaximum(element.Range[1])
+                if element.Disabled:
+                    element.QT_Dial.setDisabled(True)
+                element.QT_Dial.setMinimum(element.Range[0])
+                element.QT_Dial.setMaximum(element.Range[1])
                 element.QT_Dial.setValue(element.DefaultValue)
                 qdial.setNotchesVisible(True)
-                if element.TickInterval is not None:    qdial.setNotchTarget(element.TickInterval)
-                if element.Resolution is not None:      element.QT_Dial.setSingleStep(element.Resolution)
-                if element_size[0] is not None:         element.QT_Dial.setFixedWidth(element_size[0])
-                if element_size[1] is not None:         element.QT_Dial.setFixedHeight(element_size[1])
+                if element.TickInterval is not None:
+                    qdial.setNotchTarget(element.TickInterval)
+                if element.Resolution is not None:
+                    element.QT_Dial.setSingleStep(element.Resolution)
+                if element_size[0] is not None:
+                    element.QT_Dial.setFixedWidth(element_size[0])
+                if element_size[1] is not None:
+                    element.QT_Dial.setFixedHeight(element_size[1])
                 if element.ChangeSubmits:
                     element.QT_Dial.valueChanged.connect(element._QtCallbackValueChanged)
                 if element.Tooltip:
@@ -7039,29 +8993,37 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_Dial, alignment=Qt.AlignVCenter)
             # -------------------------  Stretch placement element  ------------------------- #
             elif element_type == ELEM_TYPE_STRETCH:
-                element = element       # type: Stretch
+                element = element  # type: Stretch
                 element.Widget = qt_row_layout.addStretch(1)
             # -------------------------  TABLE placement element  ------------------------- #
             elif element_type == ELEM_TYPE_TABLE:
-                element = element       # type: Table
-                element.Widget = element.QT_TableWidget = Table.QTTableWidget(toplevel_win.ReturnKeyboardEvents, toplevel_win)
+                element = element  # type: Table
+                element.Widget = element.QT_TableWidget = Table.QTTableWidget(
+                    toplevel_win.ReturnKeyboardEvents, toplevel_win
+                )
                 if element.NumRows is not None:
-                    element.QT_TableWidget.setFixedHeight(element.NumRows*35+25)
+                    element.QT_TableWidget.setFixedHeight(element.NumRows * 35 + 25)
                 # element.QT_TableWidget = QTableWidget()
                 # === style ===
 
                 style = QtStyle('QTableWidget')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
 
                 # more css: ScrollBar
-                style.append_css_to_end.append(' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } ')
+                style.append_css_to_end.append(
+                    ' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } '
+                )
                 # more css: QHeaderView
                 header_style = QtStyle('QHeaderView::section')
-                header_style['font'] = create_style_from_font(element.HeaderFont if element.HeaderFont is not None else font)
+                header_style['font'] = create_style_from_font(
+                    element.HeaderFont if element.HeaderFont is not None else font
+                )
                 header_style['background-color'] = element.HeaderBackgroundColor
                 header_style['color'] = element.HeaderTextColor
 
@@ -7091,13 +9053,13 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_TableWidget, alignment=Qt.AlignVCenter)
             # -------------------------  Tree placement element  ------------------------- #
             elif element_type == ELEM_TYPE_TREE:
-                element = element   # type: Tree
+                element = element  # type: Tree
                 element.Widget = element.QT_QTreeWidget = QTreeWidget()
                 if element_size != (None, None):
                     element.QT_QTreeWidget.setFixedWidth(element_size[0])
                     element.QT_QTreeWidget.setFixedHeight(element_size[1])
                 height = element.NumRows
-                element.QT_QTreeWidget.setFixedHeight(height*25)        # convert num rows into pixels...crude but effective
+                element.QT_QTreeWidget.setFixedHeight(height * 25)  # convert num rows into pixels...crude but effective
 
                 if element.ColumnsToDisplay is None:  # Which cols to display
                     displaycolumns = element.ColumnHeadings
@@ -7118,6 +9080,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                         except:
                             width = element.DefaultColumnWidth
                     # treeview.column(heading, width=width * CharWidthInPixels(), anchor=anchor)
+
                 def add_treeview_data(node, widget):
                     # print(f'Inserting {node.key} under parent {node.parent}')
                     child = widget
@@ -7147,21 +9110,26 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 # === style ===
                 style = QtStyle('QTreeWidget')
                 style['font'] = create_style_from_font(font)
-                if element.TextColor is not None:       style['color'] = element.TextColor
-                if element.BackgroundColor is not None: style['background-color'] = element.BackgroundColor
+                if element.TextColor is not None:
+                    style['color'] = element.TextColor
+                if element.BackgroundColor is not None:
+                    style['background-color'] = element.BackgroundColor
                 style['margin'] = full_element_pad
                 style['border'] = '{}px solid gray'.format(border_depth)
-                style.append_css_to_end.append(' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } ')
+                style.append_css_to_end.append(
+                    ' QScrollBar:vertical {border: none; background:lightgray; width:12px; margin: 0px 0px 0px 0px; } '
+                )
 
                 header_style = QtStyle('QHeaderView::section')
-                header_style['font'] = create_style_from_font(element.HeaderFont if element.HeaderFont is not None else font)
+                header_style['font'] = create_style_from_font(
+                    element.HeaderFont if element.HeaderFont is not None else font
+                )
                 header_style['background-color'] = element.HeaderBackgroundColor
                 header_style['color'] = element.HeaderTextColor
 
                 element.QT_QTreeWidget.setStyleSheet(style.build_css_string() + header_style.build_css_string())
                 element.qt_styles = (style, header_style)
                 # === style === end
-
 
                 if element.ChangeSubmits:
                     element.QT_QTreeWidget.itemSelectionChanged.connect(element._QtCallbackCellActivated)
@@ -7176,7 +9144,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 qt_row_layout.addWidget(element.QT_QTreeWidget, alignment=Qt.AlignVCenter)
             # -------------------------  Separator placement element  ------------------------- #
             elif element_type == ELEM_TYPE_SEPARATOR:
-                element = element           # type: HorizontalSeparator
+                element = element  # type: HorizontalSeparator
                 element.Widget = element.QT_Label = qlabel = QLabel('', toplevel_win.QTWindow)
                 if not auto_size_text:
                     if element_size[0] is not None:
@@ -7192,7 +9160,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_win):
                 element.QT_Label.setStyleSheet(style.build_css_string())
                 element.qt_styles = (style,)
 
-                qlabel.setFrameStyle(QFrame.VLine if element.Orientation[0] =='v' else QFrame.HLine)
+                qlabel.setFrameStyle(QFrame.VLine if element.Orientation[0] == 'v' else QFrame.HLine)
 
                 qt_row_layout.addWidget(element.QT_Label, alignment=Qt.AlignVCenter)
 
@@ -7217,7 +9185,7 @@ def ConvertFlexToTK(window):
     master = 000000
     PackFormIntoFrame(window, window.QFormLayout, window)
     # ....................................... DONE creating and laying out window ..........................#
-    screen_width = 000000 # get window info to move to middle of screen
+    screen_width = 000000  # get window info to move to middle of screen
     screen_height = 000000
     if window.Location != (None, None):
         window.QT_QMainWindow.move(window.Location[0], window.Location[1])
@@ -7234,11 +9202,11 @@ def ConvertFlexToTK(window):
         if x + win_width > screen_width:
             x = screen_width - win_width
 
-
-
     return
 
+
 # ----====----====----====----====----==== Start timer ====----====----====----====----====----#
+
 
 def start_window_read_timer(window, amount):
     timer = QtCore.QTimer()
@@ -7261,8 +9229,10 @@ def start_window_autoclose_timer(window, amount):
     timer.start(amount)
     return timer
 
+
 def stop_timer(timer):
     timer.stop()
+
 
 # ----====----====----====----====----==== STARTUP TK ====----====----====----====----====----#
 def StartupTK(window):
@@ -7314,10 +9284,10 @@ def StartupTK(window):
         else:
             window.QT_QMainWindow.setWindowIcon(QtGui.QIcon(window.WindowIcon))
     if window.DisableMinimize:
-        window.QT_QMainWindow.setWindowFlags(window.QT_QMainWindow.windowFlags()&~Qt.WindowMinimizeButtonHint)
-        window.QT_QMainWindow.setWindowFlags(window.QT_QMainWindow.windowFlags()&~Qt.WindowMaximizeButtonHint)
+        window.QT_QMainWindow.setWindowFlags(window.QT_QMainWindow.windowFlags() & ~Qt.WindowMinimizeButtonHint)
+        window.QT_QMainWindow.setWindowFlags(window.QT_QMainWindow.windowFlags() & ~Qt.WindowMaximizeButtonHint)
     if window.DisableClose:
-        window.QT_QMainWindow.setWindowFlags(window.QT_QMainWindow.windowFlags()&~Qt.WindowCloseButtonHint)
+        window.QT_QMainWindow.setWindowFlags(window.QT_QMainWindow.windowFlags() & ~Qt.WindowCloseButtonHint)
 
     # window.QTWindow.setAttribute(Qt.WA_TranslucentBackground)
     # shadow = QtWidgets.QGraphicsDropShadowEffect()
@@ -7327,7 +9297,6 @@ def StartupTK(window):
 
     # if window.KeepOnTop:
     #     window.QTWindow.setWindowFlags(Qt.WindowStaysOnTopHint)
-
 
     style = QtStyle('QMainWindow')
     if window.BackgroundColor is not None and window.BackgroundColor != COLOR_SYSTEM_DEFAULT:
@@ -7355,16 +9324,14 @@ def StartupTK(window):
         qlabel.setText('')
         w = QtGui.QPixmap(window.BackgroundImage).width()
         h = QtGui.QPixmap(window.BackgroundImage).height()
-        qlabel.setGeometry(QtCore.QRect(0,0, w, h))
+        qlabel.setGeometry(QtCore.QRect(0, 0, w, h))
         # qlabel.setGeometry(window.QTWindow.geometry())
         qlabel.setPixmap(QtGui.QPixmap(window.BackgroundImage))
         # style += 'background-image: url(%s);' % window.BackgroundImage
 
-
     window.QT_QMainWindow.setWindowTitle(window.Title)
 
-    if (window.GrabAnywhere is not False and not (
-            window.NonBlocking and window.GrabAnywhere is not True)):
+    if window.GrabAnywhere is not False and not (window.NonBlocking and window.GrabAnywhere is not True):
         pass
 
     window.QFormLayout = QFormLayout()
@@ -7372,11 +9339,8 @@ def StartupTK(window):
     ConvertFlexToTK(window)
     window.QT_Box_Layout.addLayout(window.QFormLayout)
 
-
     # shadow = QtWidgets.QGraphicsDropShadowEffect( window.QFormLayout)
     # window.QTWindow.setGraphicsEffect(shadow)
-
-
 
     # Make window visible again
     pass
@@ -7406,25 +9370,21 @@ def StartupTK(window):
     if not window.Resizable:
         window.QT_QMainWindow.setFixedSize(*size)
 
-
-
     timer = None
     if window.AutoClose:
-        timer = start_window_autoclose_timer(window, window.AutoCloseDuration*1000)
+        timer = start_window_autoclose_timer(window, window.AutoCloseDuration * 1000)
 
     if not window.NonBlocking:
         if window.Timeout:
             timer = start_window_read_timer(window, window.Timeout)
-        window.QT_QMainWindow.show()              ####### The thing that causes the window to be visible ######
+        window.QT_QMainWindow.show()  ####### The thing that causes the window to be visible ######
         #### ------------------------------ RUN MAIN LOOP HERE ------------------------------ #####
         window.QTApplication.exec_()
         if timer:
             stop_timer(timer)
-    else:                                   # Non-blocking window
-        window.QT_QMainWindow.show()              ####### The thing that causes the window to be visible ######
+    else:  # Non-blocking window
+        window.QT_QMainWindow.show()  ####### The thing that causes the window to be visible ######
         window.QTApplication.processEvents()
-
-
 
         window.CurrentlyRunningMainloop = False
         window.TimerCancelled = True
@@ -7433,7 +9393,7 @@ def StartupTK(window):
             Window.DecrementOpenCount()
         if window.RootNeedsDestroying:
             # print('** Destroying window **')
-            window.QT_QMainWindow.close()         # destroy the window
+            window.QT_QMainWindow.close()  # destroy the window
             window.RootNeedsDestroying = False
     return
 
@@ -7456,8 +9416,17 @@ def _GetNumLinesNeeded(text, max_line_width):
 
 # ==============================  PROGRESS METER ========================================== #
 
+
 def ConvertArgsToSingleString(*args):
-    max_line_total, width_used, total_lines, = 0, 0, 0
+    (
+        max_line_total,
+        width_used,
+        total_lines,
+    ) = (
+        0,
+        0,
+        0,
+    )
     single_line_message = ''
     # loop through args and built a SINGLE string from them
     for message in args:
@@ -7479,12 +9448,25 @@ METER_REASON_REACHED_MAX = 'finished'
 METER_OK = True
 METER_STOPPED = False
 
+
 class QuickMeter(object):
     active_meters = {}
     exit_reasons = {}
 
-    def __init__(self, title, current_value, max_value, key, *args, orientation='v', bar_color=(None, None),
-                         button_color=(None, None), size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
+    def __init__(
+        self,
+        title,
+        current_value,
+        max_value,
+        key,
+        *args,
+        orientation='v',
+        bar_color=(None, None),
+        button_color=(None, None),
+        size=DEFAULT_PROGRESS_BAR_SIZE,
+        border_width=None,
+        grab_anywhere=False,
+    ):
         self.start_time = datetime.datetime.utcnow()
         self.key = key
         self.orientation = orientation
@@ -7502,16 +9484,39 @@ class QuickMeter(object):
     def BuildWindow(self, *args):
         layout = []
         if self.orientation.lower().startswith('h'):
-            col = [[T(''.join(map(lambda x: str(x)+'\n',args)),key='_OPTMSG_')]] ### convert all *args into one string that can be updated
-            col += [[T('', size=(25,5), key='_STATS_')],
-                   [ProgressBar(max_value=self.max_value, orientation='h', key='_PROG_', size=self.size,
-                                bar_color=self.bar_color)],
-                   [Cancel(button_color=self.button_color), Stretch()]]
+            col = [
+                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
+            ]  ### convert all *args into one string that can be updated
+            col += [
+                [T('', size=(25, 5), key='_STATS_')],
+                [
+                    ProgressBar(
+                        max_value=self.max_value,
+                        orientation='h',
+                        key='_PROG_',
+                        size=self.size,
+                        bar_color=self.bar_color,
+                    )
+                ],
+                [Cancel(button_color=self.button_color), Stretch()],
+            ]
             layout += [Column(col)]
         else:
-            col = [[ProgressBar(max_value=self.max_value, orientation='v', key='_PROG_', size=self.size, bar_color=self.bar_color)]]
-            col2 = [[T(''.join(map(lambda x: str(x)+'\n',args)),key='_OPTMSG_')]] ### convert all *args into one string that can be updated
-            col2 += [[T('', size=(25,5), key='_STATS_')],[Cancel(button_color=self.button_color), Stretch()]]
+            col = [
+                [
+                    ProgressBar(
+                        max_value=self.max_value,
+                        orientation='v',
+                        key='_PROG_',
+                        size=self.size,
+                        bar_color=self.bar_color,
+                    )
+                ]
+            ]
+            col2 = [
+                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
+            ]  ### convert all *args into one string that can be updated
+            col2 += [[T('', size=(25, 5), key='_STATS_')], [Cancel(button_color=self.button_color), Stretch()]]
             layout += [Column(col), Column(col2)]
         self.window = Window(self.title, grab_anywhere=self.grab_anywhere, border_depth=self.border_width)
         self.window.Layout([layout]).Finalize()
@@ -7523,15 +9528,20 @@ class QuickMeter(object):
         self.max_value = max_value
         self.window.Element('_PROG_').UpdateBar(self.current_value, self.max_value)
         self.window.Element('_STATS_').Update('\n'.join(self.ComputeProgressStats()))
-        self.window.Element('_OPTMSG_').Update(value=''.join(map(lambda x: str(x)+'\n',args))) ###  update the string with the args
+        self.window.Element('_OPTMSG_').Update(
+            value=''.join(map(lambda x: str(x) + '\n', args))
+        )  ###  update the string with the args
         event, values = self.window.Read(timeout=0)
-        if event in('Cancel', None) or current_value >= max_value:
+        if event in ('Cancel', None) or current_value >= max_value:
             self.window.Close()
-            del(QuickMeter.active_meters[self.key])
-            QuickMeter.exit_reasons[self.key] = METER_REASON_CANCELLED if event == 'Cancel' else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
+            del QuickMeter.active_meters[self.key]
+            QuickMeter.exit_reasons[self.key] = (
+                METER_REASON_CANCELLED
+                if event == 'Cancel'
+                else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
+            )
             return QuickMeter.exit_reasons[self.key]
         return METER_OK
-
 
     def ComputeProgressStats(self):
         utc = datetime.datetime.utcnow()
@@ -7558,12 +9568,24 @@ class QuickMeter(object):
             '',
             '{} Elapsed Time'.format(time_delta_short),
             '{} Time Remaining'.format(time_remaining_short),
-            '{} Estimated Total Time'.format(total_time_short)]
+            '{} Estimated Total Time'.format(total_time_short),
+        ]
         return self.stat_messages
 
 
-def OneLineProgressMeter(title, current_value, max_value, key='OK for 1 meter', *args, orientation='v', bar_color=(None, None),
-                         button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
+def OneLineProgressMeter(
+    title,
+    current_value,
+    max_value,
+    key='OK for 1 meter',
+    *args,
+    orientation='v',
+    bar_color=(None, None),
+    button_color=None,
+    size=DEFAULT_PROGRESS_BAR_SIZE,
+    border_width=None,
+    grab_anywhere=False,
+):
     """
     :param orientation: 'horizontal' or 'vertical' ('h' or 'v' work) (Default value = 'vertical' / 'v')
     :type orientation: (str)
@@ -7581,21 +9603,33 @@ def OneLineProgressMeter(title, current_value, max_value, key='OK for 1 meter', 
     :type no_titlebar: (bool)
     """
     if key not in QuickMeter.active_meters:
-        meter = QuickMeter(title, current_value, max_value, key, *args, orientation=orientation, bar_color=bar_color,
-                           button_color=button_color, size=size, border_width=border_width, grab_anywhere=grab_anywhere)
+        meter = QuickMeter(
+            title,
+            current_value,
+            max_value,
+            key,
+            *args,
+            orientation=orientation,
+            bar_color=bar_color,
+            button_color=button_color,
+            size=size,
+            border_width=border_width,
+            grab_anywhere=grab_anywhere,
+        )
         QuickMeter.active_meters[key] = meter
     else:
         meter = QuickMeter.active_meters[key]
 
     rc = meter.UpdateMeter(current_value, max_value, *args)
-    OneLineProgressMeter.exit_reasons = getattr(OneLineProgressMeter,'exit_reasons', QuickMeter.exit_reasons)
+    OneLineProgressMeter.exit_reasons = getattr(OneLineProgressMeter, 'exit_reasons', QuickMeter.exit_reasons)
     return rc == METER_OK
+
 
 def OneLineProgressMeterCancel(key='OK for 1 meter'):
     try:
         meter = QuickMeter.active_meters[key]
         meter.window.Close()
-        del(QuickMeter.active_meters[key])
+        del QuickMeter.active_meters[key]
         QuickMeter.exit_reasons[key] = METER_REASON_CANCELLED
     except:  # meter is already deleted
         return
@@ -7625,11 +9659,22 @@ def GetComplimentaryHex(color):
 # ========================  EasyPrint           =====#
 # ===================================================#
 
-class DebugWin():
+
+class DebugWin:
     debug_window = None
 
-    def __init__(self, size=(None, None), location=(None, None), font=None, no_titlebar=False, no_button=False,
-                 grab_anywhere=False, keep_on_top=False, title=None, do_not_reroute_stdout=False):
+    def __init__(
+        self,
+        size=(None, None),
+        location=(None, None),
+        font=None,
+        no_titlebar=False,
+        no_button=False,
+        grab_anywhere=False,
+        keep_on_top=False,
+        title=None,
+        do_not_reroute_stdout=False,
+    ):
         # Show a form that's a running counter
         self.size = size
         self.location = location
@@ -7641,17 +9686,23 @@ class DebugWin():
         self.do_not_reroute_stdout = do_not_reroute_stdout
 
         win_size = size if size != (None, None) else DEFAULT_DEBUG_WINDOW_SIZE
-        self.window = Window(title=title or 'Debug Window', no_titlebar=no_titlebar, auto_size_text=True, location=location,
-                             font=font or ('Courier New', 10), grab_anywhere=grab_anywhere, keep_on_top=keep_on_top)
-        self.output_element = MultilineOutput(size=win_size, key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
+        self.window = Window(
+            title=title or 'Debug Window',
+            no_titlebar=no_titlebar,
+            auto_size_text=True,
+            location=location,
+            font=font or ('Courier New', 10),
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+        )
+        self.output_element = (
+            MultilineOutput(size=win_size, key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
+        )
 
         if no_button:
             self.layout = [[self.output_element]]
         else:
-            self.layout = [
-                [self.output_element],
-                [DummyButton('Quit'), Stretch()]
-            ]
+            self.layout = [[self.output_element], [DummyButton('Quit'), Stretch()]]
         self.window.AddRows(self.layout)
         self.window.Read(timeout=0)  # Show a non-blocking form, returns immediately
         Window.active_popups[self.window] = 'debug window'
@@ -7662,11 +9713,29 @@ class DebugWin():
         endchar = end if end is not None else '\n'
 
         if self.window is None:  # if window was destroyed already, just print
-            self.__init__(size=self.size, location=self.location, font=self.font, no_titlebar=self.no_titlebar, no_button=self.no_button, grab_anywhere=self.grab_anywhere, keep_on_top=self.keep_on_top, do_not_reroute_stdout=self.do_not_reroute_stdout)
+            self.__init__(
+                size=self.size,
+                location=self.location,
+                font=self.font,
+                no_titlebar=self.no_titlebar,
+                no_button=self.no_button,
+                grab_anywhere=self.grab_anywhere,
+                keep_on_top=self.keep_on_top,
+                do_not_reroute_stdout=self.do_not_reroute_stdout,
+            )
         event, values = self.window.Read(timeout=0)
         if event == 'Quit' or event is None:
             self.Close()
-            self.__init__(size=self.size, location=self.location, font=self.font, no_titlebar=self.no_titlebar, no_button=self.no_button, grab_anywhere=self.grab_anywhere, keep_on_top=self.keep_on_top, do_not_reroute_stdout=self.do_not_reroute_stdout)
+            self.__init__(
+                size=self.size,
+                location=self.location,
+                font=self.font,
+                no_titlebar=self.no_titlebar,
+                no_button=self.no_button,
+                grab_anywhere=self.grab_anywhere,
+                keep_on_top=self.keep_on_top,
+                do_not_reroute_stdout=self.do_not_reroute_stdout,
+            )
         if self.do_not_reroute_stdout:
             end_str = str(end) if end is not None else '\n'
             sep_str = str(sep) if sep is not None else ' '
@@ -7682,7 +9751,6 @@ class DebugWin():
         else:
             print(*args, sep=sepchar, end=endchar)
 
-
     def Close(self):
         self.window.Close()
         self.window = None
@@ -7692,9 +9760,19 @@ def PrintClose():
     EasyPrintClose()
 
 
-def EasyPrint(*args, size=(None, None), end=None, sep=None, location=(None, None), font=None, no_titlebar=False,
-              no_button=False, grab_anywhere=False, keep_on_top=False, do_not_reroute_stdout=True):
-
+def EasyPrint(
+    *args,
+    size=(None, None),
+    end=None,
+    sep=None,
+    location=(None, None),
+    font=None,
+    no_titlebar=False,
+    no_button=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    do_not_reroute_stdout=True,
+):
     """
     :param args: The arguments to display
     :type args: List[Any]
@@ -7727,8 +9805,16 @@ def EasyPrint(*args, size=(None, None), end=None, sep=None, location=(None, None
     """
 
     if DebugWin.debug_window is None:
-        DebugWin.debug_window = DebugWin(size=size, location=location, font=font, no_titlebar=no_titlebar,
-                                    no_button=no_button, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, do_not_reroute_stdout=do_not_reroute_stdout)
+        DebugWin.debug_window = DebugWin(
+            size=size,
+            location=location,
+            font=font,
+            no_titlebar=no_titlebar,
+            no_button=no_button,
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+            do_not_reroute_stdout=do_not_reroute_stdout,
+        )
     DebugWin.debug_window.Print(*args, end=end, sep=sep)
 
 
@@ -7740,8 +9826,6 @@ def EasyPrintClose():
     if DebugWin.debug_window is not None:
         DebugWin.debug_window.Close()
         DebugWin.debug_window = None
-
-
 
 
 #                            d8b          888
@@ -7757,9 +9841,9 @@ def EasyPrintClose():
 #           888
 
 
-
 CPRINT_DESTINATION_WINDOW = None
 CPRINT_DESTINATION_MULTILINE_ELMENT_KEY = None
+
 
 def cprint_set_output_destination(window, multiline_key):
     """
@@ -7778,9 +9862,20 @@ def cprint_set_output_destination(window, multiline_key):
     CPRINT_DESTINATION_MULTILINE_ELMENT_KEY = multiline_key
 
 
-
 # def cprint(*args, **kwargs):
-def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=None, b=None, colors=None, c=None, window=None, key=None):
+def cprint(
+    *args,
+    end=None,
+    sep=' ',
+    text_color=None,
+    t=None,
+    background_color=None,
+    b=None,
+    colors=None,
+    c=None,
+    window=None,
+    key=None,
+):
     """
     Color print to a multiline element in a window of your choice.
     Must have EITHER called cprint_set_output_destination prior to making this call so that the
@@ -7839,9 +9934,11 @@ def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=N
     destination_window = window or CPRINT_DESTINATION_WINDOW
 
     if (destination_window is None and window is None) or (destination_key is None and key is None):
-        print('** Warning ** Attempting to perform a cprint without a valid window & key',
-              'Will instead print on Console',
-              'You can specify window and key in this cprint call, or set ahead of time using cprint_set_output_destination')
+        print(
+            '** Warning ** Attempting to perform a cprint without a valid window & key',
+            'Will instead print on Console',
+            'You can specify window and key in this cprint call, or set ahead of time using cprint_set_output_destination',
+        )
         print(*args)
         return
 
@@ -7858,18 +9955,17 @@ def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=N
     except Exception as e:
         print('* cprint warning * you messed up with color formatting', e)
 
-    mline = destination_window.find_element(destination_key, silent_on_error=True)      # type: Multiline
+    mline = destination_window.find_element(destination_key, silent_on_error=True)  # type: Multiline
     try:
         # mline = destination_window[destination_key]     # type: # Multiline
         if end is None:
             mline.print(*args, text_color=kw_text_color, background_color=kw_background_color, end='', sep=sep)
             mline.print('')
         else:
-            mline.print(*args,text_color=kw_text_color, background_color=kw_background_color, end=end, sep=sep)
+            mline.print(*args, text_color=kw_text_color, background_color=kw_background_color, end=end, sep=sep)
     except Exception as e:
         print('** cprint error trying to print to the multiline. Printing to console instead **', e)
         print(*args, end=end, sep=sep)
-
 
 
 # ------------------------------------------------------------------------------------------------ #
@@ -7877,7 +9973,9 @@ def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=N
 # ------------------------------------------------------------------------------------------------ #
 
 
-def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True):
+def _print_to_element(
+    multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True
+):
     """
     Print like Python normally prints except route the output to a multline element and also add colors if desired
 
@@ -7903,18 +10001,32 @@ def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=N
     num_args = len(args)
     for i, arg in enumerate(args):
         outstring += str(arg)
-        if i != num_args-1:
+        if i != num_args - 1:
             outstring += sep_str
     outstring += end_str
 
-    multiline_element.update(outstring, append=True, text_color_for_value=text_color, background_color_for_value=background_color, autoscroll=autoscroll)
-
+    multiline_element.update(
+        outstring,
+        append=True,
+        text_color_for_value=text_color,
+        background_color_for_value=background_color,
+        autoscroll=autoscroll,
+    )
 
 
 # ========================  Scrolled Text Box   =====#
 # ===================================================#
-def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None,
-                  size=(None, None), location=(None, None), title=None, non_blocking=False):
+def PopupScrolled(
+    *args,
+    button_color=None,
+    yes_no=False,
+    auto_close=False,
+    auto_close_duration=None,
+    size=(None, None),
+    location=(None, None),
+    title=None,
+    non_blocking=False,
+):
     """
     :param args: The arguments to display
     :type args: List[Any]
@@ -7947,11 +10059,18 @@ def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto
     :param font:  specifies the font family, size, etc
     :type font: Union[str, Tuple[str, int]]
     """
-    if not args: return
+    if not args:
+        return
     width, height = size
     width = width if width else MESSAGE_BOX_LINE_WIDTH
-    window = Window(title=title or args[0], auto_size_text=True, button_color=button_color, auto_close=auto_close,
-                  auto_close_duration=auto_close_duration, location=location)
+    window = Window(
+        title=title or args[0],
+        auto_size_text=True,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        location=location,
+    )
     max_line_total, max_line_width, total_lines, height_computed = 0, 0, 0, 0
     complete_output = ''
     for message in args:
@@ -7966,10 +10085,12 @@ def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto
         height_computed += lines_needed
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    height_computed = (
+        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    )
     if height:
         height_computed = height
-    computed_size = (max_line_width*10, height_computed*16)
+    computed_size = (max_line_width * 10, height_computed * 16)
     window.AddRow(MultilineOutput(complete_output, size=computed_size))
     pad = max_line_total - 15 if max_line_total > 15 else 1
     # show either an OK or Yes/No depending on paramater
@@ -7977,7 +10098,9 @@ def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto
     if yes_no:
         window.AddRow(Text('', size=(pad, 1), auto_size_text=False), button('Yes'), button('No'))
     else:
-        window.AddRow(Text('', size=(pad, 1), auto_size_text=False), button('OK', size=(5, 1), button_color=button_color))
+        window.AddRow(
+            Text('', size=(pad, 1), auto_size_text=False), button('OK', size=(5, 1), button_color=button_color)
+        )
 
     if non_blocking:
         button, values = window.Read(timeout=0)
@@ -8011,18 +10134,41 @@ def SetGlobalIcon(icon):
 # ============================== SetOptions =========#
 # Sets the icon to be used by default                #
 # ===================================================#
-def SetOptions(icon=None, button_color=None, element_size=(None, None), button_element_size=(None, None),
-               margins=(None, None),
-               element_padding=(None, None), auto_size_text=None, auto_size_buttons=None, font=None, border_width=None,
-               slider_border_width=None, slider_relief=None, slider_orientation=None,
-               autoclose_time=None, message_box_line_width=None,
-               progress_meter_border_depth=None, progress_meter_style=None,
-               progress_meter_relief=None, progress_meter_color=None, progress_meter_size=None,
-               text_justification=None, background_color=None, element_background_color=None,
-               text_element_background_color=None, input_elements_background_color=None, input_text_color=None,
-               scrollbar_color=None, text_color=None, element_text_color=None, debug_win_size=(None, None),
-               window_location=(None, None), error_button_color=(None,None),
-               tooltip_time=None):
+def SetOptions(
+    icon=None,
+    button_color=None,
+    element_size=(None, None),
+    button_element_size=(None, None),
+    margins=(None, None),
+    element_padding=(None, None),
+    auto_size_text=None,
+    auto_size_buttons=None,
+    font=None,
+    border_width=None,
+    slider_border_width=None,
+    slider_relief=None,
+    slider_orientation=None,
+    autoclose_time=None,
+    message_box_line_width=None,
+    progress_meter_border_depth=None,
+    progress_meter_style=None,
+    progress_meter_relief=None,
+    progress_meter_color=None,
+    progress_meter_size=None,
+    text_justification=None,
+    background_color=None,
+    element_background_color=None,
+    text_element_background_color=None,
+    input_elements_background_color=None,
+    input_text_color=None,
+    scrollbar_color=None,
+    text_color=None,
+    element_text_color=None,
+    debug_win_size=(None, None),
+    window_location=(None, None),
+    error_button_color=(None, None),
+    tooltip_time=None,
+):
     """
     :param icon: filename or base64 string to be used for the window's icon
     :type icon: Union[bytes, str]
@@ -8226,7 +10372,7 @@ def SetOptions(icon=None, button_color=None, element_size=(None, None), button_e
     if tooltip_time is not None:
         DEFAULT_TOOLTIP_TIME = tooltip_time
 
-    if error_button_color != (None,None):
+    if error_button_color != (None, None):
         print('error button')
         DEFAULT_ERROR_BUTTON_COLOR = error_button_color
 
@@ -8252,159 +10398,1962 @@ def SetOptions(icon=None, button_color=None, element_size=(None, None), button_e
 # of the elements.                                           #
 ##############################################################
 LOOK_AND_FEEL_TABLE = {
-'SystemDefault': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
-'SystemDefaultForReal': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': COLOR_SYSTEM_DEFAULT,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
-'SystemDefault1': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': COLOR_SYSTEM_DEFAULT,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
-'Material1': {'BACKGROUND': '#E3F2FD','TEXT': '#000000','INPUT': '#86A8FF','TEXT_INPUT': '#000000','SCROLL': '#86A8FF','BUTTON': ('#FFFFFF', '#5079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
-'Material2': {'BACKGROUND': '#FAFAFA','TEXT': '#000000','INPUT': '#004EA1','TEXT_INPUT': '#FFFFFF','SCROLL': '#5EA7FF','BUTTON': ('#FFFFFF', '#0079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
-'Reddit': {'BACKGROUND': '#ffffff','TEXT': '#1a1a1b','INPUT': '#dae0e6','TEXT_INPUT': '#222222','SCROLL': '#a5a4a4','BUTTON': ('#FFFFFF', '#0079d3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#ff5414','ACCENT2': '#33a8ff','ACCENT3': '#dbf0ff',},
-'Topanga': {'BACKGROUND': '#282923','TEXT': '#E7DB74','INPUT': '#393a32','TEXT_INPUT': '#E7C855','SCROLL': '#E7C855','BUTTON': ('#E7C855', '#284B5A'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#c15226','ACCENT2': '#7a4d5f','ACCENT3': '#889743',},
-'GreenTan': {'BACKGROUND': '#9FB8AD','TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': '#F7F3EC','TEXT_INPUT': '#000000','SCROLL': '#F7F3EC','BUTTON': ('#FFFFFF', '#475841'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Dark': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightGreen': {'BACKGROUND': '#B7CECE','TEXT': '#000000','INPUT': '#FDFFF7','TEXT_INPUT': '#000000','SCROLL': '#FDFFF7','BUTTON': ('#FFFFFF', '#658268'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'ACCENT1': '#76506d','ACCENT2': '#5148f1','ACCENT3': '#0a1c84','PROGRESS_DEPTH': 0,},
-'Dark2': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#FFFFFF','TEXT_INPUT': '#000000','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Black': {'BACKGROUND': '#000000','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#000000', '#FFFFFF'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Tan': {'BACKGROUND': '#fdf6e3','TEXT': '#268bd1','INPUT': '#eee8d5','TEXT_INPUT': '#6c71c3','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063542'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'TanBlue': {'BACKGROUND': '#e5dece','TEXT': '#063289','INPUT': '#f9f8f4','TEXT_INPUT': '#242834','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkTanBlue': {'BACKGROUND': '#242834','TEXT': '#dfe6f8','INPUT': '#97755c','TEXT_INPUT': '#FFFFFF','SCROLL': '#a9afbb','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkAmber': {'BACKGROUND': '#2c2825','TEXT': '#fdcb52','INPUT': '#705e52','TEXT_INPUT': '#fdcb52','SCROLL': '#705e52','BUTTON': ('#000000', '#fdcb52'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBlue': {'BACKGROUND': '#1a2835','TEXT': '#d1ecff','INPUT': '#335267','TEXT_INPUT': '#acc2d0','SCROLL': '#1b6497','BUTTON': ('#000000', '#fafaf8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Reds': {'BACKGROUND': '#280001','TEXT': '#FFFFFF','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#763e00','BUTTON': ('#000000', '#daad28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Green': {'BACKGROUND': '#82a459','TEXT': '#000000','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#e3ecf3','BUTTON': ('#FFFFFF', '#517239'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'BluePurple': {'BACKGROUND': '#A5CADD','TEXT': '#6E266E','INPUT': '#E0F5FF','TEXT_INPUT': '#000000','SCROLL': '#E0F5FF','BUTTON': ('#FFFFFF', '#303952'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Purple': {'BACKGROUND': '#B0AAC2','TEXT': '#000000','INPUT': '#F2EFE8','SCROLL': '#F2EFE8','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#C2D4D8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'BlueMono': {'BACKGROUND': '#AAB6D3','TEXT': '#000000','INPUT': '#F1F4FC','SCROLL': '#F1F4FC','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#7186C7'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'GreenMono': {'BACKGROUND': '#A8C1B4','TEXT': '#000000','INPUT': '#DDE0DE','SCROLL': '#E3E3E3','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#6D9F85'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'BrownBlue': {'BACKGROUND': '#64778d','TEXT': '#FFFFFF','INPUT': '#f0f3f7','SCROLL': '#A6B2BE','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#283b5b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'BrightColors': {'BACKGROUND': '#b4ffb4','TEXT': '#000000','INPUT': '#ffff64','SCROLL': '#ffb482','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#ffa0dc'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'NeutralBlue': {'BACKGROUND': '#92aa9d','TEXT': '#000000','INPUT': '#fcfff6','SCROLL': '#fcfff6','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#d0dbbd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Kayak': {'BACKGROUND': '#a7ad7f','TEXT': '#000000','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#5d907d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'SandyBeach': {'BACKGROUND': '#efeccb','TEXT': '#012f2f','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#012f2f','BUTTON': ('#FFFFFF', '#046380'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'TealMono': {'BACKGROUND': '#a8cfdd','TEXT': '#000000','INPUT': '#dfedf2','SCROLL': '#dfedf2','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#183440'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'Default': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
-'Default1': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': COLOR_SYSTEM_DEFAULT,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
-'DefaultNoMoreNagging': {'BACKGROUND': COLOR_SYSTEM_DEFAULT,'TEXT': COLOR_SYSTEM_DEFAULT,'INPUT': COLOR_SYSTEM_DEFAULT,'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,'SCROLL': COLOR_SYSTEM_DEFAULT,'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,'PROGRESS': COLOR_SYSTEM_DEFAULT,'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
-'LightBlue': {'BACKGROUND': '#E3F2FD','TEXT': '#000000','INPUT': '#86A8FF','TEXT_INPUT': '#000000','SCROLL': '#86A8FF','BUTTON': ('#FFFFFF', '#5079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
-'LightGrey': {'BACKGROUND': '#FAFAFA','TEXT': '#000000','INPUT': '#004EA1','TEXT_INPUT': '#FFFFFF','SCROLL': '#5EA7FF','BUTTON': ('#FFFFFF', '#0079D3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 0,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#FF0266','ACCENT2': '#FF5C93','ACCENT3': '#C5003C',},
-'LightGrey1': {'BACKGROUND': '#ffffff','TEXT': '#1a1a1b','INPUT': '#dae0e6','TEXT_INPUT': '#222222','SCROLL': '#a5a4a4','BUTTON': ('#FFFFFF', '#0079d3'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#ff5414','ACCENT2': '#33a8ff','ACCENT3': '#dbf0ff',},
-'DarkBrown': {'BACKGROUND': '#282923','TEXT': '#E7DB74','INPUT': '#393a32','TEXT_INPUT': '#E7C855','SCROLL': '#E7C855','BUTTON': ('#E7C855', '#284B5A'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'ACCENT1': '#c15226','ACCENT2': '#7a4d5f','ACCENT3': '#889743',},
-'LightGreen1': {'BACKGROUND': '#9FB8AD','TEXT': '#000000','INPUT': '#F7F3EC','TEXT_INPUT': '#000000','SCROLL': '#F7F3EC','BUTTON': ('#FFFFFF', '#475841'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightGreen2': {'BACKGROUND': '#B7CECE','TEXT': '#000000','INPUT': '#FDFFF7','TEXT_INPUT': '#000000','SCROLL': '#FDFFF7','BUTTON': ('#FFFFFF', '#658268'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'ACCENT1': '#76506d','ACCENT2': '#5148f1','ACCENT3': '#0a1c84','PROGRESS_DEPTH': 0,},
-'DarkGrey1': {'BACKGROUND': '#404040','TEXT': '#FFFFFF','INPUT': '#FFFFFF','TEXT_INPUT': '#000000','SCROLL': '#707070','BUTTON': ('#FFFFFF', '#004F00'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBlack': {'BACKGROUND': '#000000','TEXT': '#FFFFFF','INPUT': '#4D4D4D','TEXT_INPUT': '#FFFFFF','SCROLL': '#707070','BUTTON': ('#000000', '#FFFFFF'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBrown': {'BACKGROUND': '#fdf6e3','TEXT': '#268bd1','INPUT': '#eee8d5','TEXT_INPUT': '#6c71c3','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063542'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBrown1': {'BACKGROUND': '#e5dece','TEXT': '#063289','INPUT': '#f9f8f4','TEXT_INPUT': '#242834','SCROLL': '#eee8d5','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBlue1': {'BACKGROUND': '#242834','TEXT': '#dfe6f8','INPUT': '#97755c','TEXT_INPUT': '#FFFFFF','SCROLL': '#a9afbb','BUTTON': ('#FFFFFF', '#063289'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBrown1': {'BACKGROUND': '#2c2825','TEXT': '#fdcb52','INPUT': '#705e52','TEXT_INPUT': '#fdcb52','SCROLL': '#705e52','BUTTON': ('#000000', '#fdcb52'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBlue2': {'BACKGROUND': '#1a2835','TEXT': '#d1ecff','INPUT': '#335267','TEXT_INPUT': '#acc2d0','SCROLL': '#1b6497','BUTTON': ('#000000', '#fafaf8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBrown2': {'BACKGROUND': '#280001','TEXT': '#FFFFFF','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#763e00','BUTTON': ('#000000', '#daad28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGreen': {'BACKGROUND': '#82a459','TEXT': '#000000','INPUT': '#d8d584','TEXT_INPUT': '#000000','SCROLL': '#e3ecf3','BUTTON': ('#FFFFFF', '#517239'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBlue1': {'BACKGROUND': '#A5CADD','TEXT': '#6E266E','INPUT': '#E0F5FF','TEXT_INPUT': '#000000','SCROLL': '#E0F5FF','BUTTON': ('#FFFFFF', '#303952'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightPurple': {'BACKGROUND': '#B0AAC2','TEXT': '#000000','INPUT': '#F2EFE8','SCROLL': '#F2EFE8','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#C2D4D8'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBlue2': {'BACKGROUND': '#AAB6D3','TEXT': '#000000','INPUT': '#F1F4FC','SCROLL': '#F1F4FC','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#7186C7'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightGreen3': {'BACKGROUND': '#A8C1B4','TEXT': '#000000','INPUT': '#DDE0DE','SCROLL': '#E3E3E3','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#6D9F85'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBlue3': {'BACKGROUND': '#64778d','TEXT': '#FFFFFF','INPUT': '#f0f3f7','SCROLL': '#A6B2BE','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#283b5b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightGreen4': {'BACKGROUND': '#b4ffb4','TEXT': '#000000','INPUT': '#ffff64','SCROLL': '#ffb482','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#ffa0dc'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightGreen5': {'BACKGROUND': '#92aa9d','TEXT': '#000000','INPUT': '#fcfff6','SCROLL': '#fcfff6','TEXT_INPUT': '#000000','BUTTON': ('#000000', '#d0dbbd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBrown2': {'BACKGROUND': '#a7ad7f','TEXT': '#000000','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#5d907d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBrown3': {'BACKGROUND': '#efeccb','TEXT': '#012f2f','INPUT': '#e6d3a8','SCROLL': '#e6d3a8','TEXT_INPUT': '#012f2f','BUTTON': ('#FFFFFF', '#046380'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBlue3': {'BACKGROUND': '#a8cfdd','TEXT': '#000000','INPUT': '#dfedf2','SCROLL': '#dfedf2','TEXT_INPUT': '#000000','BUTTON': ('#FFFFFF', '#183440'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'LightBrown4': {'BACKGROUND': '#d7c79e','TEXT': '#a35638','INPUT': '#9dab86','TEXT_INPUT': '#000000','SCROLL': '#a35638','BUTTON': ('#FFFFFF', '#a35638'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'],},
-'DarkTeal': {'BACKGROUND': '#003f5c','TEXT': '#fb5b5a','INPUT': '#bc4873','TEXT_INPUT': '#FFFFFF','SCROLL': '#bc4873','BUTTON': ('#FFFFFF', '#fb5b5a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],},
-'DarkPurple': {'BACKGROUND': '#472b62','TEXT': '#fb5b5a','INPUT': '#bc4873','TEXT_INPUT': '#FFFFFF','SCROLL': '#bc4873','BUTTON': ('#FFFFFF', '#472b62'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],},
-'LightGreen6': {'BACKGROUND': '#eafbea','TEXT': '#1f6650','INPUT': '#6f9a8d','TEXT_INPUT': '#FFFFFF','SCROLL': '#1f6650','BUTTON': ('#FFFFFF', '#1f6650'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'],},
-'DarkGrey2': {'BACKGROUND': '#2b2b28','TEXT': '#f8f8f8','INPUT': '#f1d6ab','TEXT_INPUT': '#000000','SCROLL': '#f1d6ab','BUTTON': ('#2b2b28', '#e3b04b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'],},
-'LightBrown6': {'BACKGROUND': '#f9b282','TEXT': '#8f4426','INPUT': '#de6b35','TEXT_INPUT': '#FFFFFF','SCROLL': '#8f4426','BUTTON': ('#FFFFFF', '#8f4426'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'],},
-'DarkTeal1': {'BACKGROUND': '#396362','TEXT': '#ffe7d1','INPUT': '#f6c89f','TEXT_INPUT': '#000000','SCROLL': '#f6c89f','BUTTON': ('#ffe7d1', '#4b8e8d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],},
-'LightBrown7': {'BACKGROUND': '#f6c89f','TEXT': '#396362','INPUT': '#4b8e8d','TEXT_INPUT': '#FFFFFF','SCROLL': '#396362','BUTTON': ('#FFFFFF', '#396362'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],},
-'DarkPurple1': {'BACKGROUND': '#0c093c','TEXT': '#fad6d6','INPUT': '#eea5f6','TEXT_INPUT': '#000000','SCROLL': '#eea5f6','BUTTON': ('#FFFFFF', '#df42d1'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'],},
-'DarkGrey3': {'BACKGROUND': '#211717','TEXT': '#dfddc7','INPUT': '#f58b54','TEXT_INPUT': '#000000','SCROLL': '#f58b54','BUTTON': ('#dfddc7', '#a34a28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],},
-'LightBrown8': {'BACKGROUND': '#dfddc7','TEXT': '#211717','INPUT': '#a34a28','TEXT_INPUT': '#dfddc7','SCROLL': '#211717','BUTTON': ('#dfddc7', '#a34a28'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],},
-'DarkBlue4': {'BACKGROUND': '#494ca2','TEXT': '#e3e7f1','INPUT': '#c6cbef','TEXT_INPUT': '#000000','SCROLL': '#c6cbef','BUTTON': ('#FFFFFF', '#8186d5'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'],},
-'LightBlue4': {'BACKGROUND': '#5c94bd','TEXT': '#470938','INPUT': '#1a3e59','TEXT_INPUT': '#FFFFFF','SCROLL': '#470938','BUTTON': ('#FFFFFF', '#470938'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'],},
-'DarkTeal2': {'BACKGROUND': '#394a6d','TEXT': '#c0ffb3','INPUT': '#52de97','TEXT_INPUT': '#000000','SCROLL': '#52de97','BUTTON': ('#c0ffb3', '#394a6d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],},
-'DarkTeal3': {'BACKGROUND': '#3c9d9b','TEXT': '#c0ffb3','INPUT': '#52de97','TEXT_INPUT': '#000000','SCROLL': '#52de97','BUTTON': ('#c0ffb3', '#394a6d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],},
-'DarkPurple5': {'BACKGROUND': '#730068','TEXT': '#f6f078','INPUT': '#01d28e','TEXT_INPUT': '#000000','SCROLL': '#01d28e','BUTTON': ('#f6f078', '#730068'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'],},
-'DarkPurple2': {'BACKGROUND': '#202060','TEXT': '#b030b0','INPUT': '#602080','TEXT_INPUT': '#FFFFFF','SCROLL': '#602080','BUTTON': ('#FFFFFF', '#202040'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'],},
-'DarkBlue5': {'BACKGROUND': '#000272','TEXT': '#ff6363','INPUT': '#a32f80','TEXT_INPUT': '#FFFFFF','SCROLL': '#a32f80','BUTTON': ('#FFFFFF', '#341677'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'],},
-'LightGrey2': {'BACKGROUND': '#f6f6f6','TEXT': '#420000','INPUT': '#d4d7dd','TEXT_INPUT': '#420000','SCROLL': '#420000','BUTTON': ('#420000', '#d4d7dd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],},
-'LightGrey3': {'BACKGROUND': '#eae9e9','TEXT': '#420000','INPUT': '#d4d7dd','TEXT_INPUT': '#420000','SCROLL': '#420000','BUTTON': ('#420000', '#d4d7dd'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],},
-'DarkBlue6': {'BACKGROUND': '#01024e','TEXT': '#ff6464','INPUT': '#8b4367','TEXT_INPUT': '#FFFFFF','SCROLL': '#8b4367','BUTTON': ('#FFFFFF', '#543864'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'],},
-'DarkBlue7': {'BACKGROUND': '#241663','TEXT': '#eae7af','INPUT': '#a72693','TEXT_INPUT': '#eae7af','SCROLL': '#a72693','BUTTON': ('#eae7af', '#160f30'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'],},
-'LightBrown9': {'BACKGROUND': '#f6d365','TEXT': '#3a1f5d','INPUT': '#c83660','TEXT_INPUT': '#f6d365','SCROLL': '#3a1f5d','BUTTON': ('#f6d365', '#c83660'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'],},
-'DarkPurple3': {'BACKGROUND': '#6e2142','TEXT': '#ffd692','INPUT': '#e16363','TEXT_INPUT': '#ffd692','SCROLL': '#e16363','BUTTON': ('#ffd692', '#943855'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],},
-'LightBrown10': {'BACKGROUND': '#ffd692','TEXT': '#6e2142','INPUT': '#943855','TEXT_INPUT': '#FFFFFF','SCROLL': '#6e2142','BUTTON': ('#FFFFFF', '#6e2142'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],},
-'DarkPurple4': {'BACKGROUND': '#200f21','TEXT': '#f638dc','INPUT': '#5a3d5c','TEXT_INPUT': '#FFFFFF','SCROLL': '#5a3d5c','BUTTON': ('#FFFFFF', '#382039'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'],},
-'LightBlue5': {'BACKGROUND': '#b2fcff','TEXT': '#3e64ff','INPUT': '#5edfff','TEXT_INPUT': '#000000','SCROLL': '#3e64ff','BUTTON': ('#FFFFFF', '#3e64ff'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'],},
-'DarkTeal4': {'BACKGROUND': '#464159','TEXT': '#c7f0db','INPUT': '#8bbabb','TEXT_INPUT': '#000000','SCROLL': '#8bbabb','BUTTON': ('#FFFFFF', '#6c7b95'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],},
-'LightTeal': {'BACKGROUND': '#c7f0db','TEXT': '#464159','INPUT': '#6c7b95','TEXT_INPUT': '#FFFFFF','SCROLL': '#464159','BUTTON': ('#FFFFFF', '#464159'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],},
-'DarkTeal5': {'BACKGROUND': '#8bbabb','TEXT': '#464159','INPUT': '#6c7b95','TEXT_INPUT': '#FFFFFF','SCROLL': '#464159','BUTTON': ('#c7f0db', '#6c7b95'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],},
-'LightGrey4': {'BACKGROUND': '#faf5ef','TEXT': '#672f2f','INPUT': '#99b19c','TEXT_INPUT': '#672f2f','SCROLL': '#672f2f','BUTTON': ('#672f2f', '#99b19c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],},
-'LightGreen7': {'BACKGROUND': '#99b19c','TEXT': '#faf5ef','INPUT': '#d7d1c9','TEXT_INPUT': '#000000','SCROLL': '#d7d1c9','BUTTON': ('#FFFFFF', '#99b19c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],},
-'LightGrey5': {'BACKGROUND': '#d7d1c9','TEXT': '#672f2f','INPUT': '#99b19c','TEXT_INPUT': '#672f2f','SCROLL': '#672f2f','BUTTON': ('#FFFFFF', '#672f2f'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],},
-'DarkBrown3': {'BACKGROUND': '#a0855b','TEXT': '#f9f6f2','INPUT': '#f1d6ab','TEXT_INPUT': '#000000','SCROLL': '#f1d6ab','BUTTON': ('#FFFFFF', '#38470b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],},
-'LightBrown11': {'BACKGROUND': '#f1d6ab','TEXT': '#38470b','INPUT': '#a0855b','TEXT_INPUT': '#FFFFFF','SCROLL': '#38470b','BUTTON': ('#f9f6f2', '#a0855b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],},
-'DarkRed': {'BACKGROUND': '#83142c','TEXT': '#f9d276','INPUT': '#ad1d45','TEXT_INPUT': '#FFFFFF','SCROLL': '#ad1d45','BUTTON': ('#f9d276', '#ad1d45'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'],},
-'DarkTeal6': {'BACKGROUND': '#204969','TEXT': '#fff7f7','INPUT': '#dadada','TEXT_INPUT': '#000000','SCROLL': '#dadada','BUTTON': ('#000000', '#fff7f7'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'],},
-'DarkBrown4': {'BACKGROUND': '#252525','TEXT': '#ff0000','INPUT': '#af0404','TEXT_INPUT': '#FFFFFF','SCROLL': '#af0404','BUTTON': ('#FFFFFF', '#252525'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'],},
-'LightYellow': {'BACKGROUND': '#f4ff61','TEXT': '#27aa80','INPUT': '#32ff6a','TEXT_INPUT': '#000000','SCROLL': '#27aa80','BUTTON': ('#f4ff61', '#27aa80'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'],},
-'DarkGreen1': {'BACKGROUND': '#2b580c','TEXT': '#fdef96','INPUT': '#f7b71d','TEXT_INPUT': '#000000','SCROLL': '#f7b71d','BUTTON': ('#fdef96', '#2b580c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'],},
-'LightGreen8': {'BACKGROUND': '#c8dad3','TEXT': '#63707e','INPUT': '#93b5b3','TEXT_INPUT': '#000000','SCROLL': '#63707e','BUTTON': ('#FFFFFF', '#63707e'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'],},
-'DarkTeal7': {'BACKGROUND': '#248ea9','TEXT': '#fafdcb','INPUT': '#aee7e8','TEXT_INPUT': '#000000','SCROLL': '#aee7e8','BUTTON': ('#000000', '#fafdcb'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'],},
-'DarkBlue8': {'BACKGROUND': '#454d66','TEXT': '#d9d872','INPUT': '#58b368','TEXT_INPUT': '#000000','SCROLL': '#58b368','BUTTON': ('#000000', '#009975'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'],},
-'DarkBlue9': {'BACKGROUND': '#263859','TEXT': '#ff6768','INPUT': '#6b778d','TEXT_INPUT': '#FFFFFF','SCROLL': '#6b778d','BUTTON': ('#ff6768', '#263859'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'],},
-'DarkBlue10': {'BACKGROUND': '#0028ff','TEXT': '#f1f4df','INPUT': '#10eaf0','TEXT_INPUT': '#000000','SCROLL': '#10eaf0','BUTTON': ('#f1f4df', '#24009c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'],},
-'DarkBlue11': {'BACKGROUND': '#6384b3','TEXT': '#e6f0b6','INPUT': '#b8e9c0','TEXT_INPUT': '#000000','SCROLL': '#b8e9c0','BUTTON': ('#e6f0b6', '#684949'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'],},
-'DarkTeal8': {'BACKGROUND': '#71a0a5','TEXT': '#212121','INPUT': '#665c84','TEXT_INPUT': '#FFFFFF','SCROLL': '#212121','BUTTON': ('#fab95b', '#665c84'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'],},
-'DarkRed1': {'BACKGROUND': '#c10000','TEXT': '#eeeeee','INPUT': '#dedede','TEXT_INPUT': '#000000','SCROLL': '#dedede','BUTTON': ('#c10000', '#eeeeee'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'],},
-'LightBrown5': {'BACKGROUND': '#fff591','TEXT': '#e41749','INPUT': '#f5587b','TEXT_INPUT': '#000000','SCROLL': '#e41749','BUTTON': ('#fff591', '#e41749'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'],},
-'LightGreen9': {'BACKGROUND': '#f1edb3','TEXT': '#3b503d','INPUT': '#4a746e','TEXT_INPUT': '#f1edb3','SCROLL': '#3b503d','BUTTON': ('#f1edb3', '#3b503d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],},
-'DarkGreen2': {'BACKGROUND': '#3b503d','TEXT': '#f1edb3','INPUT': '#c8cf94','TEXT_INPUT': '#000000','SCROLL': '#c8cf94','BUTTON': ('#f1edb3', '#3b503d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],},
-'LightGray1': {'BACKGROUND': '#f2f2f2','TEXT': '#222831','INPUT': '#393e46','TEXT_INPUT': '#FFFFFF','SCROLL': '#222831','BUTTON': ('#f2f2f2', '#222831'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn'],},
-'DarkGrey4': {'BACKGROUND': '#52524e','TEXT': '#e9e9e5','INPUT': '#d4d6c8','TEXT_INPUT': '#000000','SCROLL': '#d4d6c8','BUTTON': ('#FFFFFF', '#9a9b94'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],'DESCRIPTION': ['Grey', 'Pastel', 'Winter'],},
-'DarkBlue12': {'BACKGROUND': '#324e7b','TEXT': '#f8f8f8','INPUT': '#86a6df','TEXT_INPUT': '#000000','SCROLL': '#86a6df','BUTTON': ('#FFFFFF', '#5068a9'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'],},
-'DarkPurple6': {'BACKGROUND': '#070739','TEXT': '#e1e099','INPUT': '#c327ab','TEXT_INPUT': '#e1e099','SCROLL': '#c327ab','BUTTON': ('#e1e099', '#521477'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark'],},
-'DarkPurple7': {'BACKGROUND': '#191930','TEXT': '#B1B7C5','INPUT': '#232B5C','TEXT_INPUT': '#D0E3E7','SCROLL': '#B1B7C5','BUTTON': ('#272D38', '#B1B7C5'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBlue13': {'BACKGROUND': '#203562','TEXT': '#e3e8f8','INPUT': '#c0c5cd','TEXT_INPUT': '#000000','SCROLL': '#c0c5cd','BUTTON': ('#FFFFFF', '#3e588f'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'],},
-'DarkBrown5': {'BACKGROUND': '#3c1b1f','TEXT': '#f6e1b5','INPUT': '#e2bf81','TEXT_INPUT': '#000000','SCROLL': '#e2bf81','BUTTON': ('#3c1b1f', '#f6e1b5'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'],},
-'DarkGreen3': {'BACKGROUND': '#062121','TEXT': '#eeeeee','INPUT': '#e4dcad','TEXT_INPUT': '#000000','SCROLL': '#e4dcad','BUTTON': ('#eeeeee', '#181810'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],},
-'DarkBlack1': {'BACKGROUND': '#181810','TEXT': '#eeeeee','INPUT': '#e4dcad','TEXT_INPUT': '#000000','SCROLL': '#e4dcad','BUTTON': ('#FFFFFF', '#062121'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],},
-'DarkGrey5': {'BACKGROUND': '#343434','TEXT': '#f3f3f3','INPUT': '#e9dcbe','TEXT_INPUT': '#000000','SCROLL': '#e9dcbe','BUTTON': ('#FFFFFF', '#8e8b82'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],'DESCRIPTION': ['Grey', 'Brown'],},
-'LightBrown12': {'BACKGROUND': '#8e8b82','TEXT': '#f3f3f3','INPUT': '#e9dcbe','TEXT_INPUT': '#000000','SCROLL': '#e9dcbe','BUTTON': ('#f3f3f3', '#8e8b82'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],'DESCRIPTION': ['Grey', 'Brown'],},
-'DarkTeal9': {'BACKGROUND': '#13445a','TEXT': '#fef4e8','INPUT': '#446878','TEXT_INPUT': '#FFFFFF','SCROLL': '#446878','BUTTON': ('#fef4e8', '#446878'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'],},
-'DarkBlue14': {'BACKGROUND': '#21273d','TEXT': '#f1f6f8','INPUT': '#b9d4f1','TEXT_INPUT': '#000000','SCROLL': '#b9d4f1','BUTTON': ('#FFFFFF', '#6a759b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],},
-'LightBlue6': {'BACKGROUND': '#f1f6f8','TEXT': '#21273d','INPUT': '#6a759b','TEXT_INPUT': '#FFFFFF','SCROLL': '#21273d','BUTTON': ('#f1f6f8', '#6a759b'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],},
-'DarkGreen4': {'BACKGROUND': '#044343','TEXT': '#e4e4e4','INPUT': '#045757','TEXT_INPUT': '#e4e4e4','SCROLL': '#045757','BUTTON': ('#e4e4e4', '#045757'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark'],},
-'DarkGreen5': {'BACKGROUND': '#1b4b36','TEXT': '#e0e7f1','INPUT': '#aebd77','TEXT_INPUT': '#000000','SCROLL': '#aebd77','BUTTON': ('#FFFFFF', '#538f6a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'],'DESCRIPTION': ['Green', 'Grey'],},
-'DarkTeal10': {'BACKGROUND': '#0d3446','TEXT': '#d8dfe2','INPUT': '#71adb5','TEXT_INPUT': '#000000','SCROLL': '#71adb5','BUTTON': ('#FFFFFF', '#176d81'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'],},
-'DarkGrey6': {'BACKGROUND': '#3e3e3e','TEXT': '#ededed','INPUT': '#68868c','TEXT_INPUT': '#ededed','SCROLL': '#68868c','BUTTON': ('#FFFFFF', '#405559'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],},
-'DarkTeal11': {'BACKGROUND': '#405559','TEXT': '#ededed','INPUT': '#68868c','TEXT_INPUT': '#ededed','SCROLL': '#68868c','BUTTON': ('#ededed', '#68868c'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],},
-'LightBlue7': {'BACKGROUND': '#9ed0e0','TEXT': '#19483f','INPUT': '#5c868e','TEXT_INPUT': '#FFFFFF','SCROLL': '#19483f','BUTTON': ('#FFFFFF', '#19483f'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'],},
-'LightGreen10': {'BACKGROUND': '#d8ebb5','TEXT': '#205d67','INPUT': '#639a67','TEXT_INPUT': '#FFFFFF','SCROLL': '#205d67','BUTTON': ('#d8ebb5', '#205d67'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'],},
-'DarkBlue15': {'BACKGROUND': '#151680','TEXT': '#f1fea4','INPUT': '#375fc0','TEXT_INPUT': '#f1fea4','SCROLL': '#375fc0','BUTTON': ('#f1fea4', '#1c44ac'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],},
-'DarkBlue16': {'BACKGROUND': '#1c44ac','TEXT': '#f1fea4','INPUT': '#375fc0','TEXT_INPUT': '#f1fea4','SCROLL': '#375fc0','BUTTON': ('#f1fea4', '#151680'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],},
-'DarkTeal12': {'BACKGROUND': '#004a7c','TEXT': '#fafafa','INPUT': '#e8f1f5','TEXT_INPUT': '#000000','SCROLL': '#e8f1f5','BUTTON': ('#fafafa', '#005691'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'],},
-'LightBrown13': {'BACKGROUND': '#ebf5ee','TEXT': '#921224','INPUT': '#bdc6b8','TEXT_INPUT': '#921224','SCROLL': '#921224','BUTTON': ('#FFFFFF', '#921224'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'],},
-'DarkBlue17': {'BACKGROUND': '#21294c','TEXT': '#f9f2d7','INPUT': '#f2dea8','TEXT_INPUT': '#000000','SCROLL': '#f2dea8','BUTTON': ('#f9f2d7', '#141829'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],},
-'DarkBrown6': {'BACKGROUND': '#785e4d','TEXT': '#f2eee3','INPUT': '#baaf92','TEXT_INPUT': '#000000','SCROLL': '#baaf92','BUTTON': ('#FFFFFF', '#785e4d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'],},
-'DarkGreen6': {'BACKGROUND': '#5c715e','TEXT': '#f2f9f1','INPUT': '#ddeedf','TEXT_INPUT': '#000000','SCROLL': '#ddeedf','BUTTON': ('#f2f9f1', '#5c715e'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],'DESCRIPTION': ['Grey', 'Green', 'Vintage'],},
-'DarkGreen7': {'BACKGROUND': '#0C231E','TEXT': '#efbe1c','INPUT': '#153C33','TEXT_INPUT': '#efbe1c','SCROLL': '#153C33','BUTTON': ('#efbe1c', '#153C33'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey7': {'BACKGROUND': '#4b586e','TEXT': '#dddddd','INPUT': '#574e6d','TEXT_INPUT': '#dddddd','SCROLL': '#574e6d','BUTTON': ('#dddddd', '#43405d'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],'DESCRIPTION': ['Grey', 'Winter', 'Cold'],},
-'DarkRed2': {'BACKGROUND': '#ab1212','TEXT': '#f6e4b5','INPUT': '#cd3131','TEXT_INPUT': '#f6e4b5','SCROLL': '#cd3131','BUTTON': ('#f6e4b5', '#ab1212'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'],},
-'LightGrey6': {'BACKGROUND': '#e3e3e3','TEXT': '#233142','INPUT': '#455d7a','TEXT_INPUT': '#e3e3e3','SCROLL': '#233142','BUTTON': ('#e3e3e3', '#455d7a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey'],},
-'HotDogStand': {'BACKGROUND': 'red','TEXT': 'yellow','INPUT': 'yellow','TEXT_INPUT': '#000000','SCROLL': 'yellow','BUTTON': ('red', 'yellow'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey8': {'BACKGROUND': '#19232D','TEXT': '#ffffff','INPUT': '#32414B','TEXT_INPUT': '#ffffff','SCROLL': '#505F69','BUTTON': ('#ffffff', '#32414B'),'PROGRESS': ('#505F69', '#32414B'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey9': {'BACKGROUND': '#36393F','TEXT': '#DCDDDE','INPUT': '#40444B','TEXT_INPUT': '#ffffff','SCROLL': '#202225','BUTTON': ('#202225', '#B9BBBE'),'PROGRESS': ('#202225', '#40444B'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey10': {'BACKGROUND': '#1c1e23','TEXT': '#cccdcf','INPUT': '#272a31','TEXT_INPUT': '#8b9fde','SCROLL': '#313641','BUTTON': ('#f5f5f6', '#2e3d5a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey11': {'BACKGROUND': '#1c1e23','TEXT': '#cccdcf','INPUT': '#313641','TEXT_INPUT': '#cccdcf','SCROLL': '#313641','BUTTON': ('#f5f5f6', '#313641'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey12': {'BACKGROUND': '#1c1e23','TEXT': '#8b9fde','INPUT': '#313641','TEXT_INPUT': '#8b9fde','SCROLL': '#313641','BUTTON': ('#cccdcf', '#2e3d5a'),'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey13': {'BACKGROUND': '#1c1e23','TEXT': '#cccdcf','INPUT': '#272a31','TEXT_INPUT': '#cccdcf','SCROLL': '#313641','BUTTON': ('#8b9fde', '#313641'),'PROGRESS': ('#cccdcf', '#272a31'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkGrey14': {'BACKGROUND': '#24292e','TEXT': '#fafbfc','INPUT': '#1d2125','TEXT_INPUT': '#fafbfc','SCROLL': '#1d2125','BUTTON': ('#fafbfc', '#155398'),'PROGRESS': ('#155398', '#1d2125'),'BORDER': 1,'SLIDER_DEPTH': 0,'PROGRESS_DEPTH': 0,},
-'DarkBrown7': {'BACKGROUND': '#2c2417','TEXT': '#baa379','INPUT': '#baa379','TEXT_INPUT': '#000000','SCROLL': '#392e1c','BUTTON': ('#000000', '#baa379'),'PROGRESS': ('#baa379', '#453923'),'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
-'Python': {'BACKGROUND': '#3d7aab','TEXT': '#ffde56','INPUT': '#295273','TEXT_INPUT': '#ffde56','SCROLL': '#295273','BUTTON': ('#ffde56', '#295273'),'PROGRESS': ('#ffde56', '#295273'),'BORDER': 1,'SLIDER_DEPTH': 1,'PROGRESS_DEPTH': 0,},
+    'SystemDefault': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefaultForReal': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefault1': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Material1': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Material2': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Reddit': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('#FFFFFF', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'Topanga': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'GreenTan': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('#FFFFFF', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': '#000000',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('#FFFFFF', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark2': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#FFFFFF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Black': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#000000', '#FFFFFF'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Tan': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TanBlue': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkTanBlue': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkAmber': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('#000000', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('#000000', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Reds': {
+        'BACKGROUND': '#280001',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#763e00',
+        'BUTTON': ('#000000', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Green': {
+        'BACKGROUND': '#82a459',
+        'TEXT': '#000000',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('#FFFFFF', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BluePurple': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('#FFFFFF', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Purple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': '#000000',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BlueMono': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': '#000000',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'GreenMono': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': '#000000',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrownBlue': {
+        'BACKGROUND': '#64778d',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrightColors': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': '#000000',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'NeutralBlue': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': '#000000',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Kayak': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': '#000000',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SandyBeach': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('#FFFFFF', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TealMono': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': '#000000',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Default': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Default1': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DefaultNoMoreNagging': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey1': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('#FFFFFF', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'DarkBrown': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'LightGreen1': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': '#000000',
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('#FFFFFF', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen2': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': '#000000',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('#FFFFFF', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey1': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#FFFFFF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlack': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#000000', '#FFFFFF'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown1': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue1': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown1': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('#000000', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue2': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('#000000', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown2': {
+        'BACKGROUND': '#280001',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#763e00',
+        'BUTTON': ('#000000', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGreen': {
+        'BACKGROUND': '#82a459',
+        'TEXT': '#000000',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('#FFFFFF', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue1': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('#FFFFFF', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightPurple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': '#000000',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue2': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': '#000000',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen3': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': '#000000',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue3': {
+        'BACKGROUND': '#64778d',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen4': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': '#000000',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen5': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': '#000000',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown2': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': '#000000',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown3': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('#FFFFFF', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue3': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': '#000000',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown4': {
+        'BACKGROUND': '#d7c79e',
+        'TEXT': '#a35638',
+        'INPUT': '#9dab86',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#a35638',
+        'BUTTON': ('#FFFFFF', '#a35638'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'],
+    },
+    'DarkTeal': {
+        'BACKGROUND': '#003f5c',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('#FFFFFF', '#fb5b5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'DarkPurple': {
+        'BACKGROUND': '#472b62',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('#FFFFFF', '#472b62'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'LightGreen6': {
+        'BACKGROUND': '#eafbea',
+        'TEXT': '#1f6650',
+        'INPUT': '#6f9a8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#1f6650',
+        'BUTTON': ('#FFFFFF', '#1f6650'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'],
+    },
+    'DarkGrey2': {
+        'BACKGROUND': '#2b2b28',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('#2b2b28', '#e3b04b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'],
+    },
+    'LightBrown6': {
+        'BACKGROUND': '#f9b282',
+        'TEXT': '#8f4426',
+        'INPUT': '#de6b35',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8f4426',
+        'BUTTON': ('#FFFFFF', '#8f4426'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'],
+    },
+    'DarkTeal1': {
+        'BACKGROUND': '#396362',
+        'TEXT': '#ffe7d1',
+        'INPUT': '#f6c89f',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f6c89f',
+        'BUTTON': ('#ffe7d1', '#4b8e8d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'LightBrown7': {
+        'BACKGROUND': '#f6c89f',
+        'TEXT': '#396362',
+        'INPUT': '#4b8e8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#396362',
+        'BUTTON': ('#FFFFFF', '#396362'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'DarkPurple1': {
+        'BACKGROUND': '#0c093c',
+        'TEXT': '#fad6d6',
+        'INPUT': '#eea5f6',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#eea5f6',
+        'BUTTON': ('#FFFFFF', '#df42d1'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'],
+    },
+    'DarkGrey3': {
+        'BACKGROUND': '#211717',
+        'TEXT': '#dfddc7',
+        'INPUT': '#f58b54',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f58b54',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'LightBrown8': {
+        'BACKGROUND': '#dfddc7',
+        'TEXT': '#211717',
+        'INPUT': '#a34a28',
+        'TEXT_INPUT': '#dfddc7',
+        'SCROLL': '#211717',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'DarkBlue4': {
+        'BACKGROUND': '#494ca2',
+        'TEXT': '#e3e7f1',
+        'INPUT': '#c6cbef',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c6cbef',
+        'BUTTON': ('#FFFFFF', '#8186d5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'],
+    },
+    'LightBlue4': {
+        'BACKGROUND': '#5c94bd',
+        'TEXT': '#470938',
+        'INPUT': '#1a3e59',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#470938',
+        'BUTTON': ('#FFFFFF', '#470938'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'],
+    },
+    'DarkTeal2': {
+        'BACKGROUND': '#394a6d',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkTeal3': {
+        'BACKGROUND': '#3c9d9b',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkPurple5': {
+        'BACKGROUND': '#730068',
+        'TEXT': '#f6f078',
+        'INPUT': '#01d28e',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#01d28e',
+        'BUTTON': ('#f6f078', '#730068'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'],
+    },
+    'DarkPurple2': {
+        'BACKGROUND': '#202060',
+        'TEXT': '#b030b0',
+        'INPUT': '#602080',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#602080',
+        'BUTTON': ('#FFFFFF', '#202040'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'],
+    },
+    'DarkBlue5': {
+        'BACKGROUND': '#000272',
+        'TEXT': '#ff6363',
+        'INPUT': '#a32f80',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a32f80',
+        'BUTTON': ('#FFFFFF', '#341677'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'],
+    },
+    'LightGrey2': {
+        'BACKGROUND': '#f6f6f6',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'LightGrey3': {
+        'BACKGROUND': '#eae9e9',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'DarkBlue6': {
+        'BACKGROUND': '#01024e',
+        'TEXT': '#ff6464',
+        'INPUT': '#8b4367',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8b4367',
+        'BUTTON': ('#FFFFFF', '#543864'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'],
+    },
+    'DarkBlue7': {
+        'BACKGROUND': '#241663',
+        'TEXT': '#eae7af',
+        'INPUT': '#a72693',
+        'TEXT_INPUT': '#eae7af',
+        'SCROLL': '#a72693',
+        'BUTTON': ('#eae7af', '#160f30'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'],
+    },
+    'LightBrown9': {
+        'BACKGROUND': '#f6d365',
+        'TEXT': '#3a1f5d',
+        'INPUT': '#c83660',
+        'TEXT_INPUT': '#f6d365',
+        'SCROLL': '#3a1f5d',
+        'BUTTON': ('#f6d365', '#c83660'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'],
+    },
+    'DarkPurple3': {
+        'BACKGROUND': '#6e2142',
+        'TEXT': '#ffd692',
+        'INPUT': '#e16363',
+        'TEXT_INPUT': '#ffd692',
+        'SCROLL': '#e16363',
+        'BUTTON': ('#ffd692', '#943855'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'LightBrown10': {
+        'BACKGROUND': '#ffd692',
+        'TEXT': '#6e2142',
+        'INPUT': '#943855',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6e2142',
+        'BUTTON': ('#FFFFFF', '#6e2142'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'DarkPurple4': {
+        'BACKGROUND': '#200f21',
+        'TEXT': '#f638dc',
+        'INPUT': '#5a3d5c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5a3d5c',
+        'BUTTON': ('#FFFFFF', '#382039'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'],
+    },
+    'LightBlue5': {
+        'BACKGROUND': '#b2fcff',
+        'TEXT': '#3e64ff',
+        'INPUT': '#5edfff',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#3e64ff',
+        'BUTTON': ('#FFFFFF', '#3e64ff'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'],
+    },
+    'DarkTeal4': {
+        'BACKGROUND': '#464159',
+        'TEXT': '#c7f0db',
+        'INPUT': '#8bbabb',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#8bbabb',
+        'BUTTON': ('#FFFFFF', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightTeal': {
+        'BACKGROUND': '#c7f0db',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('#FFFFFF', '#464159'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'DarkTeal5': {
+        'BACKGROUND': '#8bbabb',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('#c7f0db', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightGrey4': {
+        'BACKGROUND': '#faf5ef',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('#672f2f', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGreen7': {
+        'BACKGROUND': '#99b19c',
+        'TEXT': '#faf5ef',
+        'INPUT': '#d7d1c9',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d7d1c9',
+        'BUTTON': ('#FFFFFF', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGrey5': {
+        'BACKGROUND': '#d7d1c9',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('#FFFFFF', '#672f2f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'DarkBrown3': {
+        'BACKGROUND': '#a0855b',
+        'TEXT': '#f9f6f2',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('#FFFFFF', '#38470b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'LightBrown11': {
+        'BACKGROUND': '#f1d6ab',
+        'TEXT': '#38470b',
+        'INPUT': '#a0855b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#38470b',
+        'BUTTON': ('#f9f6f2', '#a0855b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'DarkRed': {
+        'BACKGROUND': '#83142c',
+        'TEXT': '#f9d276',
+        'INPUT': '#ad1d45',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#ad1d45',
+        'BUTTON': ('#f9d276', '#ad1d45'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'],
+    },
+    'DarkTeal6': {
+        'BACKGROUND': '#204969',
+        'TEXT': '#fff7f7',
+        'INPUT': '#dadada',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dadada',
+        'BUTTON': ('#000000', '#fff7f7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'],
+    },
+    'DarkBrown4': {
+        'BACKGROUND': '#252525',
+        'TEXT': '#ff0000',
+        'INPUT': '#af0404',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#af0404',
+        'BUTTON': ('#FFFFFF', '#252525'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'],
+    },
+    'LightYellow': {
+        'BACKGROUND': '#f4ff61',
+        'TEXT': '#27aa80',
+        'INPUT': '#32ff6a',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#27aa80',
+        'BUTTON': ('#f4ff61', '#27aa80'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'],
+    },
+    'DarkGreen1': {
+        'BACKGROUND': '#2b580c',
+        'TEXT': '#fdef96',
+        'INPUT': '#f7b71d',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f7b71d',
+        'BUTTON': ('#fdef96', '#2b580c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'],
+    },
+    'LightGreen8': {
+        'BACKGROUND': '#c8dad3',
+        'TEXT': '#63707e',
+        'INPUT': '#93b5b3',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#63707e',
+        'BUTTON': ('#FFFFFF', '#63707e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'],
+    },
+    'DarkTeal7': {
+        'BACKGROUND': '#248ea9',
+        'TEXT': '#fafdcb',
+        'INPUT': '#aee7e8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aee7e8',
+        'BUTTON': ('#000000', '#fafdcb'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'],
+    },
+    'DarkBlue8': {
+        'BACKGROUND': '#454d66',
+        'TEXT': '#d9d872',
+        'INPUT': '#58b368',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#58b368',
+        'BUTTON': ('#000000', '#009975'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'],
+    },
+    'DarkBlue9': {
+        'BACKGROUND': '#263859',
+        'TEXT': '#ff6768',
+        'INPUT': '#6b778d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6b778d',
+        'BUTTON': ('#ff6768', '#263859'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'],
+    },
+    'DarkBlue10': {
+        'BACKGROUND': '#0028ff',
+        'TEXT': '#f1f4df',
+        'INPUT': '#10eaf0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#10eaf0',
+        'BUTTON': ('#f1f4df', '#24009c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'],
+    },
+    'DarkBlue11': {
+        'BACKGROUND': '#6384b3',
+        'TEXT': '#e6f0b6',
+        'INPUT': '#b8e9c0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b8e9c0',
+        'BUTTON': ('#e6f0b6', '#684949'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'],
+    },
+    'DarkTeal8': {
+        'BACKGROUND': '#71a0a5',
+        'TEXT': '#212121',
+        'INPUT': '#665c84',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#212121',
+        'BUTTON': ('#fab95b', '#665c84'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'],
+    },
+    'DarkRed1': {
+        'BACKGROUND': '#c10000',
+        'TEXT': '#eeeeee',
+        'INPUT': '#dedede',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dedede',
+        'BUTTON': ('#c10000', '#eeeeee'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'],
+    },
+    'LightBrown5': {
+        'BACKGROUND': '#fff591',
+        'TEXT': '#e41749',
+        'INPUT': '#f5587b',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e41749',
+        'BUTTON': ('#fff591', '#e41749'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'],
+    },
+    'LightGreen9': {
+        'BACKGROUND': '#f1edb3',
+        'TEXT': '#3b503d',
+        'INPUT': '#4a746e',
+        'TEXT_INPUT': '#f1edb3',
+        'SCROLL': '#3b503d',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'DarkGreen2': {
+        'BACKGROUND': '#3b503d',
+        'TEXT': '#f1edb3',
+        'INPUT': '#c8cf94',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c8cf94',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'LightGray1': {
+        'BACKGROUND': '#f2f2f2',
+        'TEXT': '#222831',
+        'INPUT': '#393e46',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#222831',
+        'BUTTON': ('#f2f2f2', '#222831'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],
+        'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn'],
+    },
+    'DarkGrey4': {
+        'BACKGROUND': '#52524e',
+        'TEXT': '#e9e9e5',
+        'INPUT': '#d4d6c8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d4d6c8',
+        'BUTTON': ('#FFFFFF', '#9a9b94'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],
+        'DESCRIPTION': ['Grey', 'Pastel', 'Winter'],
+    },
+    'DarkBlue12': {
+        'BACKGROUND': '#324e7b',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#86a6df',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86a6df',
+        'BUTTON': ('#FFFFFF', '#5068a9'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkPurple6': {
+        'BACKGROUND': '#070739',
+        'TEXT': '#e1e099',
+        'INPUT': '#c327ab',
+        'TEXT_INPUT': '#e1e099',
+        'SCROLL': '#c327ab',
+        'BUTTON': ('#e1e099', '#521477'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],
+        'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark'],
+    },
+    'DarkPurple7': {
+        'BACKGROUND': '#191930',
+        'TEXT': '#B1B7C5',
+        'INPUT': '#232B5C',
+        'TEXT_INPUT': '#D0E3E7',
+        'SCROLL': '#B1B7C5',
+        'BUTTON': ('#272D38', '#B1B7C5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue13': {
+        'BACKGROUND': '#203562',
+        'TEXT': '#e3e8f8',
+        'INPUT': '#c0c5cd',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c0c5cd',
+        'BUTTON': ('#FFFFFF', '#3e588f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'],
+    },
+    'DarkBrown5': {
+        'BACKGROUND': '#3c1b1f',
+        'TEXT': '#f6e1b5',
+        'INPUT': '#e2bf81',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e2bf81',
+        'BUTTON': ('#3c1b1f', '#f6e1b5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],
+        'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'],
+    },
+    'DarkGreen3': {
+        'BACKGROUND': '#062121',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('#eeeeee', '#181810'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
+    },
+    'DarkBlack1': {
+        'BACKGROUND': '#181810',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('#FFFFFF', '#062121'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
+    },
+    'DarkGrey5': {
+        'BACKGROUND': '#343434',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#FFFFFF', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'LightBrown12': {
+        'BACKGROUND': '#8e8b82',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#f3f3f3', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'DarkTeal9': {
+        'BACKGROUND': '#13445a',
+        'TEXT': '#fef4e8',
+        'INPUT': '#446878',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#446878',
+        'BUTTON': ('#fef4e8', '#446878'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],
+        'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'],
+    },
+    'DarkBlue14': {
+        'BACKGROUND': '#21273d',
+        'TEXT': '#f1f6f8',
+        'INPUT': '#b9d4f1',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b9d4f1',
+        'BUTTON': ('#FFFFFF', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
+    },
+    'LightBlue6': {
+        'BACKGROUND': '#f1f6f8',
+        'TEXT': '#21273d',
+        'INPUT': '#6a759b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#21273d',
+        'BUTTON': ('#f1f6f8', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkGreen4': {
+        'BACKGROUND': '#044343',
+        'TEXT': '#e4e4e4',
+        'INPUT': '#045757',
+        'TEXT_INPUT': '#e4e4e4',
+        'SCROLL': '#045757',
+        'BUTTON': ('#e4e4e4', '#045757'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],
+        'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark'],
+    },
+    'DarkGreen5': {
+        'BACKGROUND': '#1b4b36',
+        'TEXT': '#e0e7f1',
+        'INPUT': '#aebd77',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aebd77',
+        'BUTTON': ('#FFFFFF', '#538f6a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'],
+        'DESCRIPTION': ['Green', 'Grey'],
+    },
+    'DarkTeal10': {
+        'BACKGROUND': '#0d3446',
+        'TEXT': '#d8dfe2',
+        'INPUT': '#71adb5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#71adb5',
+        'BUTTON': ('#FFFFFF', '#176d81'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'],
+    },
+    'DarkGrey6': {
+        'BACKGROUND': '#3e3e3e',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#FFFFFF', '#405559'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'DarkTeal11': {
+        'BACKGROUND': '#405559',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#ededed', '#68868c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'LightBlue7': {
+        'BACKGROUND': '#9ed0e0',
+        'TEXT': '#19483f',
+        'INPUT': '#5c868e',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#19483f',
+        'BUTTON': ('#FFFFFF', '#19483f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],
+        'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'],
+    },
+    'LightGreen10': {
+        'BACKGROUND': '#d8ebb5',
+        'TEXT': '#205d67',
+        'INPUT': '#639a67',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#205d67',
+        'BUTTON': ('#d8ebb5', '#205d67'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],
+        'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'],
+    },
+    'DarkBlue15': {
+        'BACKGROUND': '#151680',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#1c44ac'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkBlue16': {
+        'BACKGROUND': '#1c44ac',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#151680'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkTeal12': {
+        'BACKGROUND': '#004a7c',
+        'TEXT': '#fafafa',
+        'INPUT': '#e8f1f5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e8f1f5',
+        'BUTTON': ('#fafafa', '#005691'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],
+        'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'],
+    },
+    'LightBrown13': {
+        'BACKGROUND': '#ebf5ee',
+        'TEXT': '#921224',
+        'INPUT': '#bdc6b8',
+        'TEXT_INPUT': '#921224',
+        'SCROLL': '#921224',
+        'BUTTON': ('#FFFFFF', '#921224'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],
+        'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'],
+    },
+    'DarkBlue17': {
+        'BACKGROUND': '#21294c',
+        'TEXT': '#f9f2d7',
+        'INPUT': '#f2dea8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f2dea8',
+        'BUTTON': ('#f9f2d7', '#141829'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
+        'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],
+    },
+    'DarkBrown6': {
+        'BACKGROUND': '#785e4d',
+        'TEXT': '#f2eee3',
+        'INPUT': '#baaf92',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#baaf92',
+        'BUTTON': ('#FFFFFF', '#785e4d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],
+        'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'],
+    },
+    'DarkGreen6': {
+        'BACKGROUND': '#5c715e',
+        'TEXT': '#f2f9f1',
+        'INPUT': '#ddeedf',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#ddeedf',
+        'BUTTON': ('#f2f9f1', '#5c715e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],
+        'DESCRIPTION': ['Grey', 'Green', 'Vintage'],
+    },
+    'DarkGreen7': {
+        'BACKGROUND': '#0C231E',
+        'TEXT': '#efbe1c',
+        'INPUT': '#153C33',
+        'TEXT_INPUT': '#efbe1c',
+        'SCROLL': '#153C33',
+        'BUTTON': ('#efbe1c', '#153C33'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey7': {
+        'BACKGROUND': '#4b586e',
+        'TEXT': '#dddddd',
+        'INPUT': '#574e6d',
+        'TEXT_INPUT': '#dddddd',
+        'SCROLL': '#574e6d',
+        'BUTTON': ('#dddddd', '#43405d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],
+        'DESCRIPTION': ['Grey', 'Winter', 'Cold'],
+    },
+    'DarkRed2': {
+        'BACKGROUND': '#ab1212',
+        'TEXT': '#f6e4b5',
+        'INPUT': '#cd3131',
+        'TEXT_INPUT': '#f6e4b5',
+        'SCROLL': '#cd3131',
+        'BUTTON': ('#f6e4b5', '#ab1212'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],
+        'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'],
+    },
+    'LightGrey6': {
+        'BACKGROUND': '#e3e3e3',
+        'TEXT': '#233142',
+        'INPUT': '#455d7a',
+        'TEXT_INPUT': '#e3e3e3',
+        'SCROLL': '#233142',
+        'BUTTON': ('#e3e3e3', '#455d7a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],
+        'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey'],
+    },
+    'HotDogStand': {
+        'BACKGROUND': 'red',
+        'TEXT': 'yellow',
+        'INPUT': 'yellow',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': 'yellow',
+        'BUTTON': ('red', 'yellow'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey8': {
+        'BACKGROUND': '#19232D',
+        'TEXT': '#ffffff',
+        'INPUT': '#32414B',
+        'TEXT_INPUT': '#ffffff',
+        'SCROLL': '#505F69',
+        'BUTTON': ('#ffffff', '#32414B'),
+        'PROGRESS': ('#505F69', '#32414B'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey9': {
+        'BACKGROUND': '#36393F',
+        'TEXT': '#DCDDDE',
+        'INPUT': '#40444B',
+        'TEXT_INPUT': '#ffffff',
+        'SCROLL': '#202225',
+        'BUTTON': ('#202225', '#B9BBBE'),
+        'PROGRESS': ('#202225', '#40444B'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey10': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#cccdcf',
+        'INPUT': '#272a31',
+        'TEXT_INPUT': '#8b9fde',
+        'SCROLL': '#313641',
+        'BUTTON': ('#f5f5f6', '#2e3d5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey11': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#cccdcf',
+        'INPUT': '#313641',
+        'TEXT_INPUT': '#cccdcf',
+        'SCROLL': '#313641',
+        'BUTTON': ('#f5f5f6', '#313641'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey12': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#8b9fde',
+        'INPUT': '#313641',
+        'TEXT_INPUT': '#8b9fde',
+        'SCROLL': '#313641',
+        'BUTTON': ('#cccdcf', '#2e3d5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COMPUTE,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey13': {
+        'BACKGROUND': '#1c1e23',
+        'TEXT': '#cccdcf',
+        'INPUT': '#272a31',
+        'TEXT_INPUT': '#cccdcf',
+        'SCROLL': '#313641',
+        'BUTTON': ('#8b9fde', '#313641'),
+        'PROGRESS': ('#cccdcf', '#272a31'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey14': {
+        'BACKGROUND': '#24292e',
+        'TEXT': '#fafbfc',
+        'INPUT': '#1d2125',
+        'TEXT_INPUT': '#fafbfc',
+        'SCROLL': '#1d2125',
+        'BUTTON': ('#fafbfc', '#155398'),
+        'PROGRESS': ('#155398', '#1d2125'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown7': {
+        'BACKGROUND': '#2c2417',
+        'TEXT': '#baa379',
+        'INPUT': '#baa379',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#392e1c',
+        'BUTTON': ('#000000', '#baa379'),
+        'PROGRESS': ('#baa379', '#453923'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Python': {
+        'BACKGROUND': '#3d7aab',
+        'TEXT': '#ffde56',
+        'INPUT': '#295273',
+        'TEXT_INPUT': '#ffde56',
+        'SCROLL': '#295273',
+        'BUTTON': ('#ffde56', '#295273'),
+        'PROGRESS': ('#ffde56', '#295273'),
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
 }
-
 
 
 def ListOfLookAndFeelValues():
@@ -8462,7 +12411,6 @@ def theme_text_color(color=None):
     return DEFAULT_TEXT_COLOR
 
 
-
 def theme_input_background_color(color=None):
     """
     Sets/Returns the input element background color currently in use
@@ -8483,7 +12431,6 @@ def theme_input_text_color(color=None):
     if color is not None:
         set_options(input_text_color=color)
     return DEFAULT_INPUT_TEXT_COLOR
-
 
 
 def theme_button_color(color=None):
@@ -8553,7 +12500,6 @@ def theme_progress_bar_border_width(border_width=None):
     return DEFAULT_PROGRESS_BAR_BORDER_WIDTH
 
 
-
 def theme_element_text_color(color=None):
     """
     Sets/Returns the text color used by elements that have text as part of their display (Tables, Trees and Sliders)
@@ -8574,7 +12520,6 @@ def theme_list():
     return list_of_look_and_feel_values()
 
 
-
 def theme_add_new(new_theme_name, new_theme_dict):
     """
     Add a new theme to the dictionary of themes
@@ -8589,8 +12534,6 @@ def theme_add_new(new_theme_name, new_theme_dict):
         LOOK_AND_FEEL_TABLE[new_theme_name] = new_theme_dict
     except Exception as e:
         print('Exception during adding new theme {}'.format(e))
-
-
 
 
 def theme_previewer(columns=12):
@@ -8656,31 +12599,32 @@ def ChangeLookAndFeel(index, force=False):
 
         # Color the progress bar using button background and input colors...unless they're the same
         if colors['PROGRESS'] != COLOR_SYSTEM_DEFAULT:
-                if colors['BUTTON'][1] != colors['INPUT'] and colors['BUTTON'][1] != colors['BACKGROUND']:
-                    colors['PROGRESS'] = colors['BUTTON'][1], colors['INPUT']
-                else:  # if the same, then use text input on top of input color
-                    colors['PROGRESS'] = (colors['TEXT_INPUT'], colors['INPUT'])
+            if colors['BUTTON'][1] != colors['INPUT'] and colors['BUTTON'][1] != colors['BACKGROUND']:
+                colors['PROGRESS'] = colors['BUTTON'][1], colors['INPUT']
+            else:  # if the same, then use text input on top of input color
+                colors['PROGRESS'] = (colors['TEXT_INPUT'], colors['INPUT'])
         else:
             colors['PROGRESS'] = DEFAULT_PROGRESS_BAR_COLOR_OFFICIAL
         # call to change all the colors
-        SetOptions(background_color=colors['BACKGROUND'],
-                   text_element_background_color=colors['BACKGROUND'],
-                   element_background_color=colors['BACKGROUND'],
-                   text_color=colors['TEXT'],
-                   input_elements_background_color=colors['INPUT'],
-                   # button_color=colors['BUTTON'] if not sys.platform.startswith('darwin') else None,
-                   button_color=colors['BUTTON'],
-                   progress_meter_color=colors['PROGRESS'],
-                   border_width=colors['BORDER'],
-                   slider_border_width=colors['SLIDER_DEPTH'],
-                   progress_meter_border_depth=colors['PROGRESS_DEPTH'],
-                   scrollbar_color=(colors['SCROLL']),
-                   element_text_color=colors['TEXT'],
-                   input_text_color=colors['TEXT_INPUT'])
+        SetOptions(
+            background_color=colors['BACKGROUND'],
+            text_element_background_color=colors['BACKGROUND'],
+            element_background_color=colors['BACKGROUND'],
+            text_color=colors['TEXT'],
+            input_elements_background_color=colors['INPUT'],
+            # button_color=colors['BUTTON'] if not sys.platform.startswith('darwin') else None,
+            button_color=colors['BUTTON'],
+            progress_meter_color=colors['PROGRESS'],
+            border_width=colors['BORDER'],
+            slider_border_width=colors['SLIDER_DEPTH'],
+            progress_meter_border_depth=colors['PROGRESS_DEPTH'],
+            scrollbar_color=(colors['SCROLL']),
+            element_text_color=colors['TEXT'],
+            input_text_color=colors['TEXT_INPUT'],
+        )
     except:  # most likely an index out of range
         print('** Warning - Theme value not valid. Change your theme call. **')
         print('valid values are', list_of_look_and_feel_values())
-
 
 
 def preview_all_look_and_feel_themes(columns=12):
@@ -8691,15 +12635,23 @@ def preview_all_look_and_feel_themes(columns=12):
     """
 
     # Show a "splash" type message so the user doesn't give up waiting
-    popup_quick_message('Hang on for a moment, this will take a bit to create....', background_color='red', text_color='white', auto_close=True, non_blocking=True)
+    popup_quick_message(
+        'Hang on for a moment, this will take a bit to create....',
+        background_color='red',
+        text_color='white',
+        auto_close=True,
+        non_blocking=True,
+    )
 
     web = False
 
     win_bg = 'black'
 
     def sample_layout():
-        return [[Text('Text element'), InputText('Input data here', size=(10, 1))],
-                [Button('Ok'), Button('Cancel'), Slider((1, 10), orientation='h', size=(5, 15))]]
+        return [
+            [Text('Text element'), InputText('Input data here', size=(10, 1))],
+            [Button('Ok'), Button('Cancel'), Slider((1, 10), orientation='h', size=(5, 15))],
+        ]
 
     layout = [[Text('Here is a complete list of themes', font='Default 18', background_color=win_bg)]]
 
@@ -8740,8 +12692,11 @@ def ObjToStringSingleObj(obj):
     """
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    )
 
 
 def ObjToString(obj, extra='    '):
@@ -8756,11 +12711,25 @@ def ObjToString(obj, extra='    '):
     """
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (extra + (str(item) + ' = ' +
-                  (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(
-                      obj.__dict__[item])))
-         for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join(
+            (
+                extra
+                + (
+                    str(item)
+                    + ' = '
+                    + (
+                        ObjToString(obj.__dict__[item], extra + '    ')
+                        if hasattr(obj.__dict__[item], '__dict__')
+                        else str(obj.__dict__[item])
+                    )
+                )
+                for item in sorted(obj.__dict__)
+            )
+        )
+    )
 
 
 # ------------------------------------------------------------------------------------------------------------------ #
@@ -8770,9 +12739,28 @@ def ObjToString(obj, extra='    '):
 
 # ----------------------------------- The mighty Popup! ------------------------------------------------------------ #
 
-def Popup(*args, title=None, button_color=None, background_color=None, text_color=None, button_type=POPUP_BUTTONS_OK,
-          auto_close=False, auto_close_duration=None, custom_text=(None, None), non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None,
-          font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None), any_key_closes=False, image=None):
+
+def Popup(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    button_type=POPUP_BUTTONS_OK,
+    auto_close=False,
+    auto_close_duration=None,
+    custom_text=(None, None),
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    any_key_closes=False,
+    image=None,
+):
     """
     Popup - Display a popup box with as many parms as you wish to include
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -8828,10 +12816,21 @@ def Popup(*args, title=None, button_color=None, background_color=None, text_colo
 
     _title = title if title is not None else args_to_print[0]
     _title = str(_title)
-    window = Window(_title, auto_size_text=True, background_color=background_color, button_color=button_color,
-                    auto_close=auto_close, auto_close_duration=auto_close_duration, icon=icon, font=font,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location,
-                    return_keyboard_events=any_key_closes)
+    window = Window(
+        _title,
+        auto_size_text=True,
+        background_color=background_color,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        icon=icon,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        return_keyboard_events=any_key_closes,
+    )
     max_line_total, total_lines = 0, 0
     layout = [[]]
     if image is not None:
@@ -8844,10 +12843,10 @@ def Popup(*args, title=None, button_color=None, background_color=None, text_colo
         # fancy code to check if string and convert if not is not need. Just always convert to string :-)
         # if not isinstance(message, str): message = str(message)
         message = str(message)
-        if message.count('\n'):         # if there are line breaks, then wrap each segment separately
+        if message.count('\n'):  # if there are line breaks, then wrap each segment separately
             # message_wrapped = message         # used to just do this, but now breaking into smaller pieces
             message_wrapped = ''
-            msg_list = message.split('\n')      # break into segments that will each be wrapped
+            msg_list = message.split('\n')  # break into segments that will each be wrapped
             message_wrapped = '\n'.join([textwrap.fill(msg, local_line_width) for msg in msg_list])
         else:
             message_wrapped = textwrap.fill(message, local_line_width)
@@ -8858,7 +12857,8 @@ def Popup(*args, title=None, button_color=None, background_color=None, text_colo
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
         window.AddRow(
-            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color))
+            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)
+        )
         total_lines += height
 
     # if total_lines < 3:
@@ -8875,21 +12875,45 @@ def Popup(*args, title=None, button_color=None, background_color=None, text_colo
         elif custom_text[1] is None:
             layout.append([PopupButton(custom_text[0], button_color=button_color, focus=True, bind_return_key=True)])
         else:
-            layout.append([PopupButton(custom_text[0], button_color=button_color, focus=True, bind_return_key=True),
-                          PopupButton(custom_text[1], button_color=button_color),Stretch()])
+            layout.append(
+                [
+                    PopupButton(custom_text[0], button_color=button_color, focus=True, bind_return_key=True),
+                    PopupButton(custom_text[1], button_color=button_color),
+                    Stretch(),
+                ]
+            )
     elif button_type is POPUP_BUTTONS_YES_NO:
-        layout.append([PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True, size=(60, 20)), PopupButton('No', button_color=button_color, size=(60, 20))])
+        layout.append(
+            [
+                PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True, size=(60, 20)),
+                PopupButton('No', button_color=button_color, size=(60, 20)),
+            ]
+        )
     elif button_type is POPUP_BUTTONS_CANCELLED:
-        layout.append([PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True), Stretch()])
+        layout.append(
+            [PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True), Stretch()]
+        )
     elif button_type is POPUP_BUTTONS_ERROR:
-        layout.append([PopupButton('Error', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True), Stretch()])
+        layout.append(
+            [
+                PopupButton('Error', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True),
+                Stretch(),
+            ]
+        )
     elif button_type is POPUP_BUTTONS_OK_CANCEL:
-        layout.append([PopupButton('OK', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True),
-                      PopupButton('Cancel', size=(60, 20), button_color=button_color), Stretch()])
+        layout.append(
+            [
+                PopupButton('OK', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True),
+                PopupButton('Cancel', size=(60, 20), button_color=button_color),
+                Stretch(),
+            ]
+        )
     elif button_type is POPUP_BUTTONS_NO_BUTTONS:
         pass
     else:
-        layout.append([PopupButton('OK', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True), Stretch()])
+        layout.append(
+            [PopupButton('OK', size=(60, 20), button_color=button_color, focus=True, bind_return_key=True), Stretch()]
+        )
 
     window.Layout(layout)
     if non_blocking:
@@ -8912,9 +12936,24 @@ def MsgBox(*args):
 
 
 # --------------------------- PopupNoButtons ---------------------------
-def PopupNoButtons(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-                   auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                   no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+def PopupNoButtons(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
     Show a Popup but without any buttons
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -8948,18 +12987,47 @@ def PopupNoButtons(*args, title=None, button_color=None, background_color=None, 
     :param location: Location of upper left corner of the window
     :type location: Tuple[int, int]
     """
-    Popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=POPUP_BUTTONS_NO_BUTTONS,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=POPUP_BUTTONS_NO_BUTTONS,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 # --------------------------- PopupNonBlocking ---------------------------
-def PopupNonBlocking(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                     auto_close=False, auto_close_duration=None, non_blocking=True, icon=DEFAULT_WINDOW_ICON,
-                     line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                     location=(None, None), image=None):
+def PopupNonBlocking(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
         Show Popup box and immediately return (does not block)
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -8996,20 +13064,50 @@ def PopupNonBlocking(*args, title=None, button_type=POPUP_BUTTONS_OK, button_col
     :param location: Location of upper left corner of the window
     :type location: Tuple[int, int]
     """
-    Popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 PopupNoWait = PopupNonBlocking
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup  ---------------------------
-def PopupQuick(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-               auto_close=True, auto_close_duration=2, non_blocking=True, icon=DEFAULT_WINDOW_ICON, line_width=None,
-               font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+def PopupQuick(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=2,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
         Show Popup box that doesn't block and closes itself
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9047,19 +13145,47 @@ def PopupQuick(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=Non
     :param image:  Image to include at the top of the popup window
     :type image: (str) or (bytes)
     """
-    Popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup with no titlebar and no buttons ---------------------------
-def PopupQuickMessage(*args, title=None, button_type=POPUP_BUTTONS_NO_BUTTONS, button_color=None, background_color=None,
-                      text_color=None,
-                      auto_close=True, auto_close_duration=3, non_blocking=True, icon=DEFAULT_WINDOW_ICON,
-                      line_width=None,
-                      font=None, no_titlebar=True, grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+def PopupQuickMessage(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_NO_BUTTONS,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=3,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=True,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
         Show Popup box that doesn't block and closes itself
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9097,17 +13223,46 @@ def PopupQuickMessage(*args, title=None, button_type=POPUP_BUTTONS_NO_BUTTONS, b
     :param image:  Image to include at the top of the popup window
     :type image: (str) or (bytes)
     """
-    Popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 # --------------------------- PopupNoTitlebar ---------------------------
-def PopupNoTitlebar(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                    auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON,
-                    line_width=None, font=None, grab_anywhere=True, keep_on_top=False, location=(None, None), image=None):
+def PopupNoTitlebar(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    grab_anywhere=True,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
         Display a Popup without a titlebar.   Enables grab anywhere so you can move it
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9143,11 +13298,25 @@ def PopupNoTitlebar(*args, title=None, button_type=POPUP_BUTTONS_OK, button_colo
     :param image:  Image to include at the top of the popup window
     :type image: (str) or (bytes)
     """
-    Popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=True, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=True,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 PopupNoFrame = PopupNoTitlebar
@@ -9156,10 +13325,25 @@ PopupAnnoying = PopupNoTitlebar
 
 
 # --------------------------- PopupAutoClose ---------------------------
-def PopupAutoClose(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                   auto_close=True, auto_close_duration=DEFAULT_AUTOCLOSE_TIME, non_blocking=False, icon=DEFAULT_WINDOW_ICON,
-                   line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                   location=(None, None), image=None):
+def PopupAutoClose(
+    *args,
+    title=None,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=DEFAULT_AUTOCLOSE_TIME,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
         Popup that closes itself after some time period
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9197,20 +13381,49 @@ def PopupAutoClose(*args, title=None, button_type=POPUP_BUTTONS_OK, button_color
     :param image:  Image to include at the top of the popup window
     :type image: (str) or (bytes)
     """
-    Popup(*args, title=title, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 PopupTimed = PopupAutoClose
 
 
 # --------------------------- PopupError ---------------------------
-def PopupError(*args, title=None, button_color=(None, None), background_color=None, text_color=None, auto_close=False,
-               auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-               no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+def PopupError(
+    *args,
+    title=None,
+    button_color=(None, None),
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
         Popup with colored button and 'Error' as button text
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9247,16 +13460,46 @@ def PopupError(*args, title=None, button_color=(None, None), background_color=No
     :type image: (str) or (bytes)
     """
     tbutton_color = DEFAULT_ERROR_BUTTON_COLOR if button_color == (None, None) else button_color
-    Popup(*args, title=title, button_type=POPUP_BUTTONS_ERROR, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=tbutton_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_ERROR,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=tbutton_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 # --------------------------- PopupCancel ---------------------------
-def PopupCancel(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-                auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+def PopupCancel(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
         Display Popup with "cancelled" button text
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9292,16 +13535,45 @@ def PopupCancel(*args, title=None, button_color=None, background_color=None, tex
     :param image:  Image to include at the top of the popup window
     :type image: (str) or (bytes)
     """
-    Popup(*args, title=title, button_type=POPUP_BUTTONS_CANCELLED, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_CANCELLED,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 # --------------------------- PopupOK ---------------------------
-def PopupOK(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-            auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-            no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupOK(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display Popup with OK button only
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9335,16 +13607,46 @@ def PopupOK(*args, title=None, button_color=None, background_color=None, text_co
     :param image:  Image to include at the top of the popup window
     :type image: (str) or (bytes)
     """
-    Popup(*args, title=title, button_type=POPUP_BUTTONS_OK, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location, image=image)
+    Popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_OK,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 # --------------------------- PopupOKCancel ---------------------------
-def PopupOKCancel(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-                  auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                  no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+def PopupOKCancel(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
     Display popup with OK and Cancel buttons
     :param *args:  Variable number of your arguments.  Load up the call with stuff to see!
@@ -9380,16 +13682,46 @@ def PopupOKCancel(*args, title=None, button_color=None, background_color=None, t
     :return: OK, Cancel or None
     :rtype: Union[str, None]
     """
-    return Popup(*args, title=title, button_type=POPUP_BUTTONS_OK_CANCEL, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    return Popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_OK_CANCEL,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 # --------------------------- PopupYesNo ---------------------------
-def PopupYesNo(*args, title=None, button_color=None, background_color=None, text_color=None, auto_close=False,
-               auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-               no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+def PopupYesNo(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
     Display Popup with Yes and No buttons
 
@@ -9426,10 +13758,25 @@ def PopupYesNo(*args, title=None, button_color=None, background_color=None, text
     :return: Yes, No or None
     :rtype: Union[str, None]
     """
-    return Popup(*args, title=title, button_type=POPUP_BUTTONS_YES_NO, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location, image=image)
+    return Popup(
+        *args,
+        title=title,
+        button_type=POPUP_BUTTONS_YES_NO,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+        image=image,
+    )
 
 
 ##############################################################################
@@ -9439,9 +13786,24 @@ def PopupYesNo(*args, title=None, button_color=None, background_color=None, text
 # --------------------------- PopupGetFolder ---------------------------
 
 
-def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(None, None), button_color=None,
-                   background_color=None, text_color=None, icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False,
-                   grab_anywhere=False, keep_on_top=False, location=(None, None), initial_folder=None, image=None):
+def PopupGetFolder(
+    message,
+    title=None,
+    default_path='',
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    initial_folder=None,
+    image=None,
+):
     """
     Display popup with text entry field and browse button. Browse for folder
     :param message: message displayed to user
@@ -9480,7 +13842,6 @@ def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(
     :rtype: Union[str, None]
     """
 
-
     if no_window:
         if Window.QTApplication is None:
             Window.QTApplication = QApplication(sys.argv)
@@ -9495,15 +13856,26 @@ def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(
             layout = [[Image(data_base64=image)]]
     else:
         layout = [[]]
-    layout += [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
-              [InputText(default_text=default_path, size=size, key='_INPUT_'), FolderBrowse(initial_folder=initial_folder)],
-              [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))]]
+    layout += [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
+        [InputText(default_text=default_path, size=size, key='_INPUT_'), FolderBrowse(initial_folder=initial_folder)],
+        [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))],
+    ]
 
     _title = title if title is not None else message
-    window = Window(title=_title, layout=layout, icon=icon, auto_size_text=True, button_color=button_color,
-                    background_color=background_color,
-                    font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top,
-                    location=location)
+    window = Window(
+        title=_title,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        background_color=background_color,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.close()
@@ -9516,10 +13888,28 @@ def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(
 
 # --------------------------- PopupGetFile ---------------------------
 
-def PopupGetFile(message, title=None, default_path='', default_extension='', save_as=False, file_types=(('ALL Files', '*'),),
-                 no_window=False, size=(None, None), button_color=None, background_color=None, text_color=None,
-                 icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                 location=(None, None), initial_folder=None, image=None):
+
+def PopupGetFile(
+    message,
+    title=None,
+    default_path='',
+    default_extension='',
+    save_as=False,
+    file_types=(('ALL Files', '*'),),
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    initial_folder=None,
+    image=None,
+):
     """
         Display popup with text entry field and browse button. Browse for file
 
@@ -9579,10 +13969,11 @@ def PopupGetFile(message, title=None, default_path='', default_extension='', sav
             filename = QFileDialog.getOpenFileName(dir=initial_folder, filter=qt_types)
         return filename[0]
 
-
-    browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder) if save_as else FileBrowse(
-        file_types=file_types, initial_folder=initial_folder)
-
+    browse_button = (
+        SaveAs(file_types=file_types, initial_folder=initial_folder)
+        if save_as
+        else FileBrowse(file_types=file_types, initial_folder=initial_folder)
+    )
 
     if image is not None:
         if isinstance(image, str):
@@ -9592,15 +13983,27 @@ def PopupGetFile(message, title=None, default_path='', default_extension='', sav
     else:
         layout = [[]]
 
-    layout += [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
-              [InputText(default_text=default_path, size=(30,1), key='_INPUT_'), browse_button],
-              [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))]]
+    layout += [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
+        [InputText(default_text=default_path, size=(30, 1), key='_INPUT_'), browse_button],
+        [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))],
+    ]
 
     _title = title if title is not None else message
 
-    window = Window(title=_title, layout=layout, icon=icon, auto_size_text=True, button_color=button_color, font=font,
-                    background_color=background_color,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    window = Window(
+        title=_title,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        font=font,
+        background_color=background_color,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.close()
@@ -9613,9 +14016,24 @@ def PopupGetFile(message, title=None, default_path='', default_extension='', sav
 
 # --------------------------- PopupGetText ---------------------------
 
-def PopupGetText(message, title=None, default_text='', password_char='', size=(None, None), button_color=None,
-                 background_color=None, text_color=None, icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False,
-                 grab_anywhere=False, keep_on_top=False, location=(None, None), image=None):
+
+def PopupGetText(
+    message,
+    title=None,
+    default_text='',
+    password_char='',
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    image=None,
+):
     """
     Display Popup with text entry field
     :param message: message displayed to user
@@ -9660,15 +14078,26 @@ def PopupGetText(message, title=None, default_text='', password_char='', size=(N
     else:
         layout = [[]]
 
-    layout += [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color, font=font)],
-              [InputText(default_text=default_text, size=size, password_char=password_char, key='_INPUT_')],
-              [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))]]
+    layout += [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color, font=font)],
+        [InputText(default_text=default_text, size=size, password_char=password_char, key='_INPUT_')],
+        [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))],
+    ]
 
     _title = title if title is not None else message
 
-    window = Window(title=_title, layout=layout, icon=icon, auto_size_text=True, button_color=button_color, no_titlebar=no_titlebar,
-                    background_color=background_color, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top,
-                    location=location)
+    window = Window(
+        title=_title,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        no_titlebar=no_titlebar,
+        background_color=background_color,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.close()
@@ -9702,11 +14131,21 @@ ICON_BASE64_THINK = b'iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAACXBIWXMAAA
 ICON_BASE64_PALM = b'iVBORw0KGgoAAAANSUhEUgAAAEkAAAA8CAMAAAAdQmecAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAMAUExURQAAAB8SDx4UEiAUDyAUEiMZFSUbGSsUEy8aFiwbGTsUFTkdICwiHTIjHDQrHzsiGysjIjIlIDMqIzMsKjsgIzotID0uKT01IzszMUkYHE0ZIFkbKEQhHkUqH0sgHUUgI0MtIkUoKEsmIEwqIkwqL00rM0I1I0s1JEswKE04J0w7LUc9OVYpJ1omMVM0JVQ1K1I4JVU7KlszK1k6J1s7KVw4NGEdLmQeMWghNmE5LWQ4NXIiPWs2RHkkQnAzRVRENVNDOF1ENFxEOVpKOWNDM2NHPWNMPGxFOWxKPG9QPnJKPHVQP05HRFJMSltUUWpLQ2lUQ2NcWndNQndIU3JUQ3JUSHRZTHxSRHxVSHxZSnlaVH1YYmZgX39gVmZjYnZran14doFURoNWSYNbTYNeUoleUItbaYRgT4VhU4JiWIVoXIpjVIxlWo1oVo1pWpFiVpFlWZJsXZRxX4JmZYVsY4trY4pzaoN9e5NtYpRtaJltY5ZxYpRyaZpzZZx1ap14a5N4eJx1cJp3eJ15cZp6eqB2a6J6baN8cqJ7eax9cah+epx7hImBf5uBeqWAdKOCe6qCdKqDequJfbKJfY2EgpmIiZqVk52Zk6SBhKaFiKyDgqqFiayJgqyNi6aLkayNlKGQi6uRja+QlqySm6qZlLKMhLKOi7SRi76Th7qTi7KTk7KVm7KYk7SZm7iWk7yZk7ucm7Sco7ScqbqeorOfsK2knrmhnKukoqyop7GrqrqhpLqlq7mup7urqrSosbKuubqjsrymubyps7qqub6xrbSxsLizvbe1wr68ycKYi8OcmsCmo8KmqcGup8Ooq8qqqcersMGvv8yutMKxu8uwtM2zusy+v9G3usCwwsS0yca8xsW7y82/x8m9ysm90Ne8wMjAvMPCxsLAyc3Ax8vAy8/IzMbD0c3F08zK2NPLx9DJztnBydLO09LL2tPS19TS29rU29bU4dnT5NzV6NvZ4+Hf5uDd6+Pi7eXj8ejl9Ozp9/Lw+wAAAAAAAAAAAAAAAErQjXwAAAEAdFJOU////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////wBT9wclAAAACXBIWXMAAA7DAAAOwwHHb6hkAAAHU0lEQVRYR5WWf1gbZx3A8bw2y7nJVq00ZM9Eq63t0o3QFNKkrLbjoRjXsWFHCI+T0gNNe2nWm4Ndm9xFTLmj1UFONsUU1s2aZRRxdP7otNZN1Omc1inTdbad06danzlkVoR2/hG/7w8gNG/Y9iE/uPf9vp/7vt/37r0UZPLx34nxiYmJNybp4VuSxzQ9MXn5zempqelLlybfpotteu31ifFzfzp7/sL45PT09MS/aPOCME1jZ8+fGxs9Njw0fGLswuT01D/+SjsWgmU6fnJs7IUTx7410N8/MDx64eKlqV++DRXD9M2BkZOnfjicTvV0d/f0Hx09f/HNf//iL7QzP7mmn0XN9BMjR9PpfhOpkkdHz0z97+9PT9DuvOSa7gvHus2vYEzT6E4MDP10/PKlM0/T7rzkmoLBeyORWMwwzf6UaZowvydPX7z8nzPP0v585JhO7pIkWZbvVXUzlUomzYNmcui7L49fvPDs6zQiDzmmr9UHg7vDu8MRVTcOHESq5KEjz7z8yitnfkwj8pBr2njHNjEo7ZbliGFAQsk+eB155vTpc6f/RkPY5JiOr7i1uh5UYUVROw4ehEolk1193zj2k9+NLpxUbsWXrt5YfdfnpDAUS9UgLaCrq2/g6JETT9IINrmmJStWb9wUCKK6K0h1wDCMDs1IHjr8Tk23F63aeOsdooSXUNU6O7QOTdM7937x0NAbNIRJrumrS4tWb64OiFKrJEshWdnXqWr7QqGO/fuHztIQJrmmzKKiFauc9aLYIkp7xHvkfXtCLSG5Y+TU1w8foRFMGKat7y1asbLaH/CLkNeO5h2trZJk/Oq3I/uHh/9IQ1gwTD+4qnBpkbPK5xf9zTua/c1+fyT1WLLnvi+8MPwoDWHBMEWDjuuFpc5P+Hz3iM3Ndb5mPZVOKfU93xnqj/2GxjDINb3q8PicJYUly2vkutZWURR1PdErtwz8+vloQPk+DWLAyMnjWb58ZUnhrsf3SJ9s8fl1TVWlwODzI/HaxrYFpscw1fscxY7Slc7Yc5LkatDhTpZE3YzH133+1EsP0RgGDNOPqm74cJWrtHRbond9Q0LVdSmsmWa4rf3Ffw4/QmMYMEyZ9rIy502u0hpDlRK6HtNN40BCjI68+IeBtndWp0xmU5VrpWttFdqiensff27QjIuxwf6+/Y13v0YjGDBNr25yrV3rqoL7t7fX1A/0Girs6Eqw7fcPfJlGMGCaMt+rdt7k3Natqwkjpmnm4BNpQ27o+fNLD7yL4xYt+/RxGjYPtimTKSxxqYluEOm63psaTBtB89tDfe2LeY7neW7xnT+ncXPkMT109aoaJaYaugY7CmxSj6UHU12haNPV4EFw3I00cpY8psWLVlcHIxFdVTUtFod9Lm0aO+/adSMVAZy1icZSmKb738fzSzY1yJCRYcBGF48qWpdW11j/AapBQMW203gMw7SVRG4ORBKaqsXjWjSqaRGldkvV5utIF8JqFazWB+kQRI5pK4eLyvPVElQbyqRF92rxDll0rK+pXQRd8LK+/6MbNtzidrvXHKOjgCtMTVTD8++uDet6J1RJaVOie5XglrK6xlrUYf3QOo8HLG6v1+uuOEwHXmHajs45w05Fhx3c0JRQOBRUAi7P+pprIJuPrHHY7cXwZ3eAraJ8Nqss01NLqANzTbumxLSIrijhnTvDQWepq+x6oVAQBAuCh7dgs9sryj10dJbpttmJYT7eDlWOaJEwiO5uuRlJLNDMcSgK3lBOjkeyE3Q8NW1fNk8D1WiD9YJnZ1gOB1sCH0MK2oO/LYIF0gO3RWgkBmJ6cG51yRk5vkbR1IgcDisxWWwoIX0ILBAEm2AjCPx7sIeYbpvLx3odmgLPCaFIREY/WGDnrYOM5sAqUNgJNkEgImRaTGN44YPF0AFYhJsDIXicS/I+EC2n3QBHc7LZYO0q0KXgtttmTdfijDhLMQAiGxxYINK3Ax6ccqcq3jCzVrBaWAKdOKNyckk56N5esJ3UBqLQrAGYHg531CGV5ENtuAEDuSDWVKCMvN5Kb6X7s9R0O8poZvZ4FB0n2MrqGhr8vjLSij5JnYnMDSpIqbLS66amZbOiOSB9PNzmqdtSVVhL2rAcXtCHTeVIVQl4yfQKrs0WoWuNDKLp2dZ5eCvVzkGSmlWRpMCEhtORxIqj8TEBH88ja4IoKfxrqAC2wbmxUG0O7id6NAM+no+9GMuo6hZs+gxZKQQaRTPMFjFMUCuaFlo/Mr2CJkgJReNPfIFfmRM+ZIBVFfhS+BLOCZWb3C7kPofLEkM0CNqQy4zKuwGZ7iTRWIURIPW3mt0MMyo0vYL7s64luCt4Hu6ZeR4EHcgAuaBYcJ0XZPATAC0ampyAJ0fHz0IGZTPXiFTgQiYyJwAnh+pNd4QsZrcjgDYB5Bir7BvAhB5vKCvUZ+F4vMQ4cB54EP0/C2ik9/TDBZmnyG6BGqHuWJR9XvqdD2yCXcq+Dna6JtpIYJ15QWB+5W6v+1P/B0gPXHqaGwimAAAAAElFTkSuQmCC'
 
 
-ICON_BASE64_LIST = [ICON_BASE64_BLOB_HEADACHE, ICON_BASE64_BLOB_PALM, ICON_BASE64_BLOB_PAT, ICON_BASE64_BLOB_THINK, ICON_BASE64_BLOB_THINK2, ICON_BASE64_BROW, ICON_BASE64_LEGO_THINK, ICON_BASE64_PALM, ICON_BASE64_THINK]
+ICON_BASE64_LIST = [
+    ICON_BASE64_BLOB_HEADACHE,
+    ICON_BASE64_BLOB_PALM,
+    ICON_BASE64_BLOB_PAT,
+    ICON_BASE64_BLOB_THINK,
+    ICON_BASE64_BLOB_THINK2,
+    ICON_BASE64_BROW,
+    ICON_BASE64_LEGO_THINK,
+    ICON_BASE64_PALM,
+    ICON_BASE64_THINK,
+]
+
 
 def _random_error_icon():
     return random.choice(ICON_BASE64_LIST)
-
 
 
 #                        d8b
@@ -9731,19 +14170,55 @@ def main():
 
     ver = version.split('\n')[0]
 
-
-    menu_def = [['&File', ['!&Open::KeyOpen', '&Save::KeySave', '---', '&Properties::KeyProp', 'E&xit']],
-                ['&Edit', ['&Paste', ['Special::KeySpecial', '!Normal', ], 'Undo'], ],
-                ['!&Toolbar', ['Command &1', 'Command &2', 'Command &3', 'Command &4']],
-                ['&Help', '&About...'], ]
+    menu_def = [
+        ['&File', ['!&Open::KeyOpen', '&Save::KeySave', '---', '&Properties::KeyProp', 'E&xit']],
+        [
+            '&Edit',
+            [
+                '&Paste',
+                [
+                    'Special::KeySpecial',
+                    '!Normal',
+                ],
+                'Undo',
+            ],
+        ],
+        ['!&Toolbar', ['Command &1', 'Command &2', 'Command &3', 'Command &4']],
+        ['&Help', '&About...'],
+    ]
 
     treedata = TreeData()
 
-    treedata.Insert('', '_A_', 'Tree Item 1', [1, 2, 3], )
-    treedata.Insert('', '_B_', 'B', [4, 5, 6], )
-    treedata.Insert('_A_', '_A1_', 'Sub Item 1', ['can', 'be', 'anything'], )
-    treedata.Insert('', '_C_', 'C', [], )
-    treedata.Insert('_C_', '_C1_', 'C1', ['or'], )
+    treedata.Insert(
+        '',
+        '_A_',
+        'Tree Item 1',
+        [1, 2, 3],
+    )
+    treedata.Insert(
+        '',
+        '_B_',
+        'B',
+        [4, 5, 6],
+    )
+    treedata.Insert(
+        '_A_',
+        '_A1_',
+        'Sub Item 1',
+        ['can', 'be', 'anything'],
+    )
+    treedata.Insert(
+        '',
+        '_C_',
+        'C',
+        [],
+    )
+    treedata.Insert(
+        '_C_',
+        '_C1_',
+        'C1',
+        ['or'],
+    )
     treedata.Insert('_A_', '_A2_', 'Sub Item 2', [None, None])
     treedata.Insert('_A1_', '_A3_', 'A30', ['getting deep'])
     treedata.Insert('_C_', '_C2_', 'C2', ['nothing', 'at', 'all'])
@@ -9753,14 +14228,25 @@ def main():
 
     frame1 = [
         [Input('Input Text', do_not_clear=True, size=(250, 35), tooltip='Input'), FileBrowse(), Stretch()],
-        [Multiline(size=(250, 75), do_not_clear=True, default_text='Multiline Input', tooltip='Multiline input'),
-         MultilineOutput(size=(250, 75), default_text='Multiline Output', tooltip='Multiline output', key='-MLINE-')],
+        [
+            Multiline(size=(250, 75), do_not_clear=True, default_text='Multiline Input', tooltip='Multiline input'),
+            MultilineOutput(size=(250, 75), default_text='Multiline Output', tooltip='Multiline output', key='-MLINE-'),
+        ],
     ]
 
     frame2 = [
-        [Listbox(['Listbox 1', 'Listbox 2', 'Listbox 3', 'Item 4', 'Item 5'], default_values=['Listbox 2', 'Listbox 3'], size=(200, 85), tooltip='Listbox',
-                    key='_LISTBOX_', font='Courier 12', text_color='red',)],
-        [Combo([1,2,3], size=(200, 35), tooltip='Combo', visible_items=2, key='_COMBO_')],
+        [
+            Listbox(
+                ['Listbox 1', 'Listbox 2', 'Listbox 3', 'Item 4', 'Item 5'],
+                default_values=['Listbox 2', 'Listbox 3'],
+                size=(200, 85),
+                tooltip='Listbox',
+                key='_LISTBOX_',
+                font='Courier 12',
+                text_color='red',
+            )
+        ],
+        [Combo([1, 2, 3], size=(200, 35), tooltip='Combo', visible_items=2, key='_COMBO_')],
         [Spin([1, 2, 3], size=(40, 30), tooltip='Spinner', key='_SPIN1_')],
         [Spin(['Spin item 1', 'Spin item 2', 'Spin item 3'], size=(240, 30), tooltip='Spinner', key='_SPIN2_')],
     ]
@@ -9771,20 +14257,46 @@ def main():
     ]
 
     frame4 = [
-        [Slider(range=(0, 100), tick_interval=None, orientation='v', size=(3, 30), default_value=40, tooltip='Slider'),
-         Dial(range=(0, 100), tick_interval=1, resolution=1, size=(150, 150), default_value=40, tooltip='Dial'),
-         Stretch()],
+        [
+            Slider(
+                range=(0, 100), tick_interval=None, orientation='v', size=(3, 30), default_value=40, tooltip='Slider'
+            ),
+            Dial(range=(0, 100), tick_interval=1, resolution=1, size=(150, 150), default_value=40, tooltip='Dial'),
+            Stretch(),
+        ],
     ]
     matrix = [[str(x * y) for x in range(4)] for y in range(8)]
 
     frame5 = [
-        [Table(values=matrix, max_col_width=25, headings=('aaa', 'bbb', 'ccc', 'ddd'),
-                  auto_size_columns=True, display_row_numbers=True, enable_events=True, bind_return_key=True,
-                  justification='right', num_rows=6, alternating_row_color='lightblue', key='_table_',
-                   tooltip='Table'),
-         Tree(data=treedata, headings=['col1', 'col2', 'col3'], enable_events=True, auto_size_columns=True,
-                 num_rows=10, col0_width=10, key='_TREE_', show_expanded=True, size=(200, 150), tooltip='Tree'),
-         Stretch()],
+        [
+            Table(
+                values=matrix,
+                max_col_width=25,
+                headings=('aaa', 'bbb', 'ccc', 'ddd'),
+                auto_size_columns=True,
+                display_row_numbers=True,
+                enable_events=True,
+                bind_return_key=True,
+                justification='right',
+                num_rows=6,
+                alternating_row_color='lightblue',
+                key='_table_',
+                tooltip='Table',
+            ),
+            Tree(
+                data=treedata,
+                headings=['col1', 'col2', 'col3'],
+                enable_events=True,
+                auto_size_columns=True,
+                num_rows=10,
+                col0_width=10,
+                key='_TREE_',
+                show_expanded=True,
+                size=(200, 150),
+                tooltip='Tree',
+            ),
+            Stretch(),
+        ],
     ]
 
     graph_elem = Graph((880, 150), (0, 0), (600, 300), key='+GRAPH+', tooltip='Graph')
@@ -9799,33 +14311,49 @@ def main():
     layout = [
         [Menu(menu_def, key='_REALMENU_', background_color='white')],
         [Text('You are running the PySimpleGUI.py file itself', font=('ANY', 15, 'Bold'), text_color='yellow')],
-                  [Text('You should be importing it rather than running it', font='ANY 15')],
-        [Text('VERSION {}'.format(ver), size=(85,1), text_color='yellow', font='ANY 18')],
-
+        [Text('You should be importing it rather than running it', font='ANY 15')],
+        [Text('VERSION {}'.format(ver), size=(85, 1), text_color='yellow', font='ANY 18')],
         # [Image(data_base64=logo, tooltip='Image', click_submits=True, key='_IMAGE_'),
-         [Frame('Input Text Group', frame1, title_color='yellow', tooltip='Text Group', frame_color='yellow', pad=(0,0)), Stretch()],
-        [Frame('Multiple Choice Group', frame2, title_color=theme_text_color(), frame_color='yellow'),
-         # Column([[Frame('Binary Choice Group', frame3, frame_color='white', title_color='white')]], pad=(0,0)),
-         Frame('Binary Choice Group', frame3, frame_color='white', title_color='white'),
-         Frame('Variable Choice Group', frame4, title_color='blue'), Stretch()],
-        [Frame('Structured Data Group', frame5, title_color='yellow'), ],
+        [
+            Frame(
+                'Input Text Group', frame1, title_color='yellow', tooltip='Text Group', frame_color='yellow', pad=(0, 0)
+            ),
+            Stretch(),
+        ],
+        [
+            Frame('Multiple Choice Group', frame2, title_color=theme_text_color(), frame_color='yellow'),
+            # Column([[Frame('Binary Choice Group', frame3, frame_color='white', title_color='white')]], pad=(0,0)),
+            Frame('Binary Choice Group', frame3, frame_color='white', title_color='white'),
+            Frame('Variable Choice Group', frame4, title_color='blue'),
+            Stretch(),
+        ],
+        [
+            Frame('Structured Data Group', frame5, title_color='yellow'),
+        ],
         # [Frame('Graphing Group', frame6)],
-        [TabGroup([[tab1, tab2]],title_color='black')],
-        [ProgressBar(max_value=600, start_value=400, size=(600, 25), key='+PROGRESS+'),
-         Text('', key='_PROGTEXT_'), Stretch(),
-         ButtonMenu('&Menu', ['Menu', ['&Pause Graph', 'Menu item::optional_key']], key='_MENU_',
-                       tooltip='Button Menu'),
-         Button('Button'), Button('Exit', tooltip='Exit button')],
+        [TabGroup([[tab1, tab2]], title_color='black')],
+        [
+            ProgressBar(max_value=600, start_value=400, size=(600, 25), key='+PROGRESS+'),
+            Text('', key='_PROGTEXT_'),
+            Stretch(),
+            ButtonMenu(
+                '&Menu', ['Menu', ['&Pause Graph', 'Menu item::optional_key']], key='_MENU_', tooltip='Button Menu'
+            ),
+            Button('Button'),
+            Button('Exit', tooltip='Exit button'),
+        ],
     ]
 
-    window = Window('Window Title', layout,
-                       font=('Helvetica', 13),
-                       # default_button_element_size=(100, 30),
-                       # auto_size_buttons=False,
-                       default_element_size=(200, 22),
-                        # margins = (40,40),
-                       # border_depth=1,
-                       )
+    window = Window(
+        'Window Title',
+        layout,
+        font=('Helvetica', 13),
+        # default_button_element_size=(100, 30),
+        # auto_size_buttons=False,
+        default_element_size=(200, 22),
+        # margins = (40,40),
+        # border_depth=1,
+    )
     # graph_elem.DrawCircle((200, 200), 50, 'blue')
     i = 0
     graph_paused = False
@@ -9845,12 +14373,14 @@ def main():
         if not graph_paused:
 
             if i < 600:
-                graph_elem.DrawLine((i, 0), (i, random.randint(0, 300)), width=1,
-                                    color='#{:06x}'.format(random.randint(0, 0xffffff)))
+                graph_elem.DrawLine(
+                    (i, 0), (i, random.randint(0, 300)), width=1, color='#{:06x}'.format(random.randint(0, 0xFFFFFF))
+                )
             else:
                 graph_elem.Move(-1, 0)
-                graph_elem.DrawLine((i, 0), (i, random.randint(0, 300)), width=1,
-                                    color='#{:06x}'.format(random.randint(0, 0xffffff)))
+                graph_elem.DrawLine(
+                    (i, 0), (i, random.randint(0, 300)), width=1, color='#{:06x}'.format(random.randint(0, 0xFFFFFF))
+                )
 
         window.FindElement('+PROGRESS+').UpdateBar(i % 600)
         window.FindElement('_PROGTEXT_').Update((i % 600) // 6)
@@ -9858,8 +14388,6 @@ def main():
 
         # TimerStop()
     window.close()
-
-
 
     # layout = [[Text('You are running the PySimpleGUI.py file itself')],
     #           [Text('You should be importing it rather than running it')],
@@ -9878,9 +14406,10 @@ def main():
     # print(event, values)
     # window.Close()
 
-#------------------------------------------------------------------#
-#------------------------ PEP8-ify The SDK ------------------------#
-#------------------------------------------------------------------#
+
+# ------------------------------------------------------------------#
+# ------------------------ PEP8-ify The SDK ------------------------#
+# ------------------------------------------------------------------#
 
 change_look_and_feel = ChangeLookAndFeel
 easy_print = EasyPrint
@@ -9920,7 +14449,7 @@ timer_start = TimerStart
 timer_stop = TimerStop
 
 
-#------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
+# ------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
 theme(CURRENT_LOOK_AND_FEEL)
 
 

--- a/FreeSimpleGUIQt/setup.py
+++ b/FreeSimpleGUIQt/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/FreeSimpleGUIWeb/FreeSimpleGUIWeb/FreeSimpleGUIWeb.py
+++ b/FreeSimpleGUIWeb/FreeSimpleGUIWeb/FreeSimpleGUIWeb.py
@@ -382,9 +382,7 @@ class Element:
         self.ParentForm.LastButtonClicked = self.Key if self.Key is not None else ''
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
 
-    def Update(
-        self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None
-    ):
+    def Update(self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None):
         if font is not None:
             font_info = font_parse_string(font)  # family, point size, other
             widget.style['font-family'] = font_info[0]
@@ -510,9 +508,7 @@ class InputText(Element):
         widget.set_value(widget.get_value() + key)
         return (key, keycode, ctrl, shift, alt)
 
-    def Update(
-        self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.Widget.set_value(str(value))
         if disabled is True:
@@ -1085,14 +1081,10 @@ class Spin(Element):
         )
         return
 
-    def Update(
-        self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.Widget.set_value(value)
-        super().Update(
-            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         return self.Widget.get_value()
@@ -1204,9 +1196,7 @@ class Multiline(Element):
         #     self.WxTextCtrl.Enable(True)
         # elif disabled is False:
         #     self.WxTextCtrl.Enable(False)
-        super().Update(
-            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def print(self, *args, end=None, sep=None, text_color=None, background_color=None):
         """
@@ -1330,9 +1320,7 @@ class MultilineOutput(Element):
                 }
             )
 
-        super().Update(
-            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def print(self, *args, end=None, sep=None, text_color=None, background_color=None):
         """
@@ -1430,9 +1418,7 @@ class Text(Element):
     def Update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.Widget.set_text(str(value))
-        super().Update(
-            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     update = Update
 
@@ -1472,11 +1458,7 @@ class Output(Element):
         '''
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         # fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        fg = (
-            text_color
-            if text_color is not None
-            else 'black' if DEFAULT_INPUT_TEXT_COLOR == COLOR_SYSTEM_DEFAULT else DEFAULT_INPUT_TEXT_COLOR
-        )
+        fg = text_color if text_color is not None else 'black' if DEFAULT_INPUT_TEXT_COLOR == COLOR_SYSTEM_DEFAULT else DEFAULT_INPUT_TEXT_COLOR
         self.Disabled = disabled
         self.Widget = None  # type: remi.gui.TextInput
         if size_px == (None, None) and size == (None, None):
@@ -1496,9 +1478,7 @@ class Output(Element):
             key=key,
         )
 
-    def Update(
-        self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
         if value is not None and not append:
             self.Widget.set_value(str(value))
             self.CurrentValue = str(value)
@@ -1508,14 +1488,9 @@ class Output(Element):
         self.Widget._set_updated()
         app = self.ParentForm.App
         if hasattr(app, 'websockets'):
-            app.execute_javascript(
-                'element=document.getElementById("%(id)s"); element.innerHTML=`%(content)s`; element.scrollTop=999999; '
-                % {'id': self.Widget.identifier, 'content': self.Widget.get_value()}
-            )
+            app.execute_javascript('element=document.getElementById("%(id)s"); element.innerHTML=`%(content)s`; element.scrollTop=999999; ' % {'id': self.Widget.identifier, 'content': self.Widget.get_value()})
 
-        super().Update(
-            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     update = Update
 
@@ -1668,9 +1643,7 @@ class Button(Element):
         elif self.BType == BUTTON_TYPE_BROWSE_FILE:  # Browse File
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(
-                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN
-                )
+                dialog = wx.FileDialog(self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN)
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_OPEN)
             file_name = ''
@@ -1686,9 +1659,7 @@ class Button(Element):
         elif self.BType == BUTTON_TYPE_BROWSE_FILES:  # Browse Files
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(
-                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE
-                )
+                dialog = wx.FileDialog(self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE)
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_MULTIPLE)
             file_names = ''
@@ -1712,9 +1683,7 @@ class Button(Element):
                     style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
                 )
             else:
-                dialog = wx.FileDialog(
-                    self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
-                )
+                dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
             file_name = ''
             if dialog.ShowModal() == wx.ID_OK:
                 file_name = dialog.GetPath()
@@ -1761,9 +1730,7 @@ class Button(Element):
             element_callback_quit_mainloop(self)
             self.ParentForm._Close()
             Window._DecrementOpenCount()
-        elif (
-            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
-        ):  # this is a return type button so GET RESULTS and destroy window
+        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
             should_submit_window = False
 
         if should_submit_window:
@@ -2126,9 +2093,7 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        line = remi.gui.SvgLine(
-            converted_point_from[0], converted_point_from[1], converted_point_to[0], converted_point_to[1]
-        )
+        line = remi.gui.SvgLine(converted_point_from[0], converted_point_from[1], converted_point_to[0], converted_point_to[1])
         line.set_stroke(width, color)
         self.SvgGroup.append(
             [
@@ -2426,9 +2391,7 @@ class Graph(Element):
 class CLASSframe(remi.gui.VBox):
     def __init__(self, title, *args, **kwargs):
         super(CLASSframe, self).__init__(*args, **kwargs)
-        self.style.update(
-            {'overflow': 'visible', 'border-width': '1px', 'border-style': 'solid', 'border-color': '#7d7d7d'}
-        )
+        self.style.update({'overflow': 'visible', 'border-width': '1px', 'border-style': 'solid', 'border-color': '#7d7d7d'})
         self.frame_label = remi.gui.Label('frame label')
         self.frame_label.style.update(
             {
@@ -3210,9 +3173,7 @@ class Tree(Element):
     def add_treeview_data(self, node):
         # print(f'Inserting {node.key} under parent {node.parent}')
         if node.key != '':
-            self.TKTreeview.insert(
-                node.parent, 'end', node.key, text=node.text, values=node.values, open=self.ShowExpanded
-            )
+            self.TKTreeview.insert(node.parent, 'end', node.key, text=node.text, values=node.values, open=self.ShowExpanded)
         for node in node.children:
             self.add_treeview_data(node)
 
@@ -3269,10 +3230,7 @@ class TreeData(object):
         return self._NodeStr(self.root_node, 1)
 
     def _NodeStr(self, node, level):
-        return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text)]
-            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
-        )
+        return '\n'.join([str(node.key) + ' : ' + str(node.text)] + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
 
     insert = Insert
 
@@ -3403,11 +3361,7 @@ class Window:
         self.Title = title
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = convert_tkinter_size_to_Wx(default_element_size)
-        self.DefaultButtonElementSize = (
-            convert_tkinter_size_to_Wx(default_button_element_size)
-            if default_button_element_size != (None, None)
-            else DEFAULT_BUTTON_ELEMENT_SIZE
-        )
+        self.DefaultButtonElementSize = convert_tkinter_size_to_Wx(default_button_element_size) if default_button_element_size != (None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
         self.Location = location
         self.ButtonColor = button_color if button_color else DEFAULT_BUTTON_COLOR
         self.BackgroundColor = background_color if background_color else DEFAULT_BACKGROUND_COLOR
@@ -3516,9 +3470,7 @@ class Window:
         return self
 
     def LayoutAndRead(self, rows, non_blocking=False):
-        raise DeprecationWarning(
-            'LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()'
-        )
+        raise DeprecationWarning('LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()')
         # self.AddRows(rows)
         # self.Show(non_blocking=non_blocking)
         # return self.ReturnValues
@@ -3856,18 +3808,10 @@ class Window:
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        (
-                            print('*** Duplicate key found in your layout {} ***'.format(element.Key))
-                            if element.Type != ELEM_TYPE_BUTTON
-                            else None
-                        )
+                        (print('*** Duplicate key found in your layout {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None)
                         element.Key = element.Key + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
-                        (
-                            print('*** Replaced new key with {} ***'.format(element.Key))
-                            if element.Type != ELEM_TYPE_BUTTON
-                            else None
-                        )
+                        (print('*** Replaced new key with {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None)
                     key_dict[element.Key] = element
         return key_dict
 
@@ -4097,9 +4041,7 @@ class Window:
         # remi.start(self.MyApp, standalone=True, debug=True, userdata=(self,) )            # Can't do this because of a threading problem
         print('Returned from Remi Start command... now sending None event')
 
-        self.MessageQueue.put(
-            None
-        )  # if returned from start call, then the window has been destroyed and a None event should be generated
+        self.MessageQueue.put(None)  # if returned from start call, then the window has been destroyed and a None event should be generated
 
     class MyApp(remi.App):
         def __init__(self, *args, userdata2=None):
@@ -4230,9 +4172,7 @@ def convert_tkinter_size_to_Wx(size):
     :return: size in pixels, pixels
     """
     qtsize = size
-    if (
-        size[1] is not None and size[1] < DEFAULT_PIXEL_TO_CHARS_CUTOFF
-    ):  # change from character based size to pixels (roughly)
+    if size[1] is not None and size[1] < DEFAULT_PIXEL_TO_CHARS_CUTOFF:  # change from character based size to pixels (roughly)
         qtsize = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
     return qtsize
 
@@ -5312,11 +5252,7 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 if element.Type == ELEM_TYPE_INPUT_TEXT:
                     element = element  # type: InputText
                     value = element.Widget.get_value()
-                    if (
-                        not top_level_form.NonBlocking
-                        and not element.do_not_clear
-                        and not top_level_form.ReturnKeyboardEvents
-                    ):
+                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
                         element.Widget.set_value('')
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
                     element = element  # type: Checkbox
@@ -5388,29 +5324,12 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 value = None
 
             # if an input type element, update the results
-            if (
-                element.Type != ELEM_TYPE_BUTTON
-                and element.Type != ELEM_TYPE_TEXT
-                and element.Type != ELEM_TYPE_IMAGE
-                and element.Type != ELEM_TYPE_OUTPUT
-                and element.Type != ELEM_TYPE_PROGRESS_BAR
-                and element.Type != ELEM_TYPE_COLUMN
-                and element.Type != ELEM_TYPE_FRAME
-                and element.Type != ELEM_TYPE_TAB
-            ):
+            if element.Type != ELEM_TYPE_BUTTON and element.Type != ELEM_TYPE_TEXT and element.Type != ELEM_TYPE_IMAGE and element.Type != ELEM_TYPE_OUTPUT and element.Type != ELEM_TYPE_PROGRESS_BAR and element.Type != ELEM_TYPE_COLUMN and element.Type != ELEM_TYPE_FRAME and element.Type != ELEM_TYPE_TAB:
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
             elif (
-                (
-                    element.Type == ELEM_TYPE_BUTTON
-                    and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER
-                    and element.Target == (None, None)
-                )
-                or (
-                    element.Type == ELEM_TYPE_BUTTON
-                    and element.BType == BUTTON_TYPE_COLOR_CHOOSER
-                    and element.Target == (None, None)
-                )
+                (element.Type == ELEM_TYPE_BUTTON and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER and element.Target == (None, None))
+                or (element.Type == ELEM_TYPE_BUTTON and element.BType == BUTTON_TYPE_COLOR_CHOOSER and element.Target == (None, None))
                 or (
                     element.Type == ELEM_TYPE_BUTTON
                     and element.Key is not None
@@ -5595,9 +5514,7 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False)
                         if pos == 0 or sub_menu_info[i][pos - 1] != '\\':
                             sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1 :]
                     if sub_menu_info[i][0] == MENU_DISABLED_CHARACTER:
-                        new_menu = remi.gui.MenuItem(
-                            sub_menu_info[i][len(MENU_DISABLED_CHARACTER) :], width=100, height=30
-                        )
+                        new_menu = remi.gui.MenuItem(sub_menu_info[i][len(MENU_DISABLED_CHARACTER) :], width=100, height=30)
                         new_menu.set_enabled(False)
 
                         # TODO Disable Entry
@@ -5777,16 +5694,10 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.Widget = remi.gui.Button(element.ButtonText, width=size[0], height=size[1], margin='10px')
                 element.Widget.onclick.connect(element._ButtonCallBack)
                 do_font_and_color(element.Widget)
-                if (
-                    element.AutoSizeButton
-                    or (toplevel_form.AutoSizeButtons and element.AutoSizeButton is not False)
-                    and element.Size == (None, None)
-                ):
+                if element.AutoSizeButton or (toplevel_form.AutoSizeButtons and element.AutoSizeButton is not False) and element.Size == (None, None):
                     del element.Widget.style['width']
                 if element.ImageFilename:
-                    element.ImageWidget = SuperImage(
-                        element.ImageFilename if element.ImageFilename is not None else element.ImageData
-                    )
+                    element.ImageWidget = SuperImage(element.ImageFilename if element.ImageFilename is not None else element.ImageData)
                     element.Widget.append(element.ImageWidget)
                 tk_row_frame.append(element.Widget)
 
@@ -6400,11 +6311,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 # -------------------------  SLIDER element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_SLIDER:
                 element = element  # type: Slider
-                orient = (
-                    remi.gui.Container.LAYOUT_HORIZONTAL
-                    if element.Orientation.lower().startswith('h')
-                    else remi.gui.Container.LAYOUT_VERTICAL
-                )
+                orient = remi.gui.Container.LAYOUT_HORIZONTAL if element.Orientation.lower().startswith('h') else remi.gui.Container.LAYOUT_VERTICAL
                 # print(f'slider orient = {orient}')
                 element.Widget = remi.gui.Slider(
                     layout_orientation=orient,
@@ -6721,8 +6628,7 @@ def setup_remi_window(app: Window.MyApp, window: Window):
         tag = remi.gui.Tag(_type='script')
         tag.add_child(
             'javascript',
-            """window.onunload=function(e){sendCallback('%s','%s');return "close?";};"""
-            % (str(id(app)), 'on_window_close'),
+            """window.onunload=function(e){sendCallback('%s','%s');return "close?";};""" % (str(id(app)), 'on_window_close'),
         )
         master_widget.add_child('onunloadevent', tag)
 
@@ -6840,17 +6746,7 @@ def ConvertArgsToSingleString(*args):
 
 # ============================== ProgressMeter  =====#
 # ===================================================#
-def _ProgressMeter(
-    title,
-    max_value,
-    *args,
-    orientation=None,
-    bar_color=(None, None),
-    button_color=None,
-    size=DEFAULT_PROGRESS_BAR_SIZE,
-    border_width=None,
-    grab_anywhere=False
-):
+def _ProgressMeter(title, max_value, *args, orientation=None, bar_color=(None, None), button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
     '''
     Create and show a form on tbe caller's behalf.
     :param title:
@@ -6987,17 +6883,7 @@ class EasyProgressMeterDataClass:
 
 
 # ============================== EasyProgressMeter  =====#
-def EasyProgressMeter(
-    title,
-    current_value,
-    max_value,
-    *args,
-    orientation=None,
-    bar_color=(None, None),
-    button_color=None,
-    size=DEFAULT_PROGRESS_BAR_SIZE,
-    border_width=None
-):
+def EasyProgressMeter(title, current_value, max_value, *args, orientation=None, bar_color=(None, None), button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None):
     '''
     A ONE-LINE progress meter. Add to your code where ever you need a meter. No need for a second
     function call before your loop. You've got enough code to write!
@@ -7019,26 +6905,14 @@ def EasyProgressMeter(
     EasyProgressMeter.Data = getattr(EasyProgressMeter, 'Data', EasyProgressMeterDataClass())
     # if no meter currently running
     if EasyProgressMeter.Data.MeterID is None:  # Starting a new meter
-        print(
-            'Please change your call of EasyProgressMeter to use OneLineProgressMeter. EasyProgressMeter will be removed soon'
-        )
+        print('Please change your call of EasyProgressMeter to use OneLineProgressMeter. EasyProgressMeter will be removed soon')
         if int(current_value) >= int(max_value):
             return False
         del EasyProgressMeter.Data
         EasyProgressMeter.Data = EasyProgressMeterDataClass(title, 1, int(max_value), datetime.datetime.utcnow(), [])
         EasyProgressMeter.Data.ComputeProgressStats()
         message = '\n'.join([line for line in EasyProgressMeter.Data.StatMessages])
-        EasyProgressMeter.Data.MeterID, EasyProgressMeter.Data.MeterText = _ProgressMeter(
-            title,
-            int(max_value),
-            message,
-            *args,
-            orientation=orientation,
-            bar_color=bar_color,
-            size=size,
-            button_color=button_color,
-            border_width=local_border_width
-        )
+        EasyProgressMeter.Data.MeterID, EasyProgressMeter.Data.MeterText = _ProgressMeter(title, int(max_value), message, *args, orientation=orientation, bar_color=bar_color, size=size, button_color=button_color, border_width=local_border_width)
         EasyProgressMeter.Data.ParentForm = EasyProgressMeter.Data.MeterID.ParentForm
         return True
     # if exactly the same values as before, then ignore.
@@ -7069,19 +6943,10 @@ def EasyProgressMeter(
 
 
 def EasyProgressMeterCancel(title, *args):
-    EasyProgressMeter.EasyProgressMeterData = getattr(
-        EasyProgressMeter, 'EasyProgressMeterData', EasyProgressMeterDataClass()
-    )
+    EasyProgressMeter.EasyProgressMeterData = getattr(EasyProgressMeter, 'EasyProgressMeterData', EasyProgressMeterDataClass())
     if EasyProgressMeter.EasyProgressMeterData.MeterID is not None:
         # tell the normal meter update that we're at max value which will close the meter
-        rc = EasyProgressMeter(
-            title,
-            EasyProgressMeter.EasyProgressMeterData.MaxValue,
-            EasyProgressMeter.EasyProgressMeterData.MaxValue,
-            ' *** CANCELLING ***',
-            'Caller requested a cancel',
-            *args
-        )
+        rc = EasyProgressMeter(title, EasyProgressMeter.EasyProgressMeterData.MaxValue, EasyProgressMeter.EasyProgressMeterData.MaxValue, ' *** CANCELLING ***', 'Caller requested a cancel', *args)
         return rc
     return True
 
@@ -7091,19 +6956,7 @@ _one_line_progress_meters = {}
 
 
 # ============================== OneLineProgressMeter  =====#
-def OneLineProgressMeter(
-    title,
-    current_value,
-    max_value,
-    key='OK for 1 meter',
-    *args,
-    orientation=None,
-    bar_color=(None, None),
-    button_color=None,
-    size=DEFAULT_PROGRESS_BAR_SIZE,
-    border_width=None,
-    grab_anywhere=False
-):
+def OneLineProgressMeter(title, current_value, max_value, key='OK for 1 meter', *args, orientation=None, bar_color=(None, None), button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
     global _one_line_progress_meters
 
     local_border_width = DEFAULT_PROGRESS_BAR_BORDER_WIDTH if border_width is not None else border_width
@@ -7116,18 +6969,7 @@ def OneLineProgressMeter(
         _one_line_progress_meters[key] = meter_data
         meter_data.ComputeProgressStats()
         message = '\n'.join([line for line in meter_data.StatMessages])
-        meter_data.MeterID, meter_data.MeterText = _ProgressMeter(
-            title,
-            int(max_value),
-            message,
-            *args,
-            orientation=orientation,
-            bar_color=bar_color,
-            size=size,
-            button_color=button_color,
-            border_width=local_border_width,
-            grab_anywhere=grab_anywhere
-        )
+        meter_data.MeterID, meter_data.MeterText = _ProgressMeter(title, int(max_value), message, *args, orientation=orientation, bar_color=bar_color, size=size, button_color=button_color, border_width=local_border_width, grab_anywhere=grab_anywhere)
         meter_data.ParentForm = meter_data.MeterID.ParentForm
         return True
 
@@ -7238,18 +7080,7 @@ def PrintClose():
     EasyPrintClose()
 
 
-def EasyPrint(
-    *args,
-    size=(None, None),
-    end=None,
-    sep=None,
-    location=(None, None),
-    font=None,
-    no_titlebar=False,
-    no_button=False,
-    grab_anywhere=False,
-    keep_on_top=False
-):
+def EasyPrint(*args, size=(None, None), end=None, sep=None, location=(None, None), font=None, no_titlebar=False, no_button=False, grab_anywhere=False, keep_on_top=False):
     global _easy_print_data
 
     if _easy_print_data is None:
@@ -7311,19 +7142,7 @@ def cprint_set_output_destination(window, multiline_key):
 
 
 # def cprint(*args, **kwargs):
-def cprint(
-    *args,
-    end=None,
-    sep=' ',
-    text_color=None,
-    t=None,
-    background_color=None,
-    b=None,
-    colors=None,
-    c=None,
-    window=None,
-    key=None
-):
+def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=None, b=None, colors=None, c=None, window=None, key=None):
     """
     Color print to a multiline element in a window of your choice.
     Must have EITHER called cprint_set_output_destination prior to making this call so that the
@@ -7419,9 +7238,7 @@ def cprint(
 # ------------------------------------------------------------------------------------------------ #
 # A print-like call that can be used to output to a multiline element as if it's an Output element #
 # ------------------------------------------------------------------------------------------------ #
-def _print_to_element(
-    multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True
-):
+def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True):
     """
     Print like Python normally prints except route the output to a multline element and also add colors if desired
 
@@ -7451,16 +7268,12 @@ def _print_to_element(
             outstring += sep_str
     outstring += end_str
 
-    multiline_element.update(
-        outstring, append=True, text_color=text_color, background_color=background_color, autoscroll=autoscroll
-    )
+    multiline_element.update(outstring, append=True, text_color=text_color, background_color=background_color, autoscroll=autoscroll)
 
 
 # ========================  Scrolled Text Box   =====#
 # ===================================================#
-def PopupScrolled(
-    *args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None, size=(None, None)
-):
+def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None, size=(None, None)):
     if not args:
         return
     width, height = size
@@ -7486,9 +7299,7 @@ def PopupScrolled(
         height_computed += lines_needed
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = (
-        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
-    )
+    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
     if height:
         height_computed = height
     form.AddRow(Multiline(complete_output, size=(max_line_width, height_computed)))
@@ -9884,35 +9695,13 @@ sprint = ScrolledTextBox
 def ObjToStringSingleObj(obj):
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
-    )
+    return str(obj.__class__) + '\n' + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
 
 
 def ObjToString(obj, extra='    '):
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join(
-            (
-                extra
-                + (
-                    str(item)
-                    + ' = '
-                    + (
-                        ObjToString(obj.__dict__[item], extra + '    ')
-                        if hasattr(obj.__dict__[item], '__dict__')
-                        else str(obj.__dict__[item])
-                    )
-                )
-                for item in sorted(obj.__dict__)
-            )
-        )
-    )
+    return str(obj.__class__) + '\n' + '\n'.join((extra + (str(item) + ' = ' + (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(obj.__dict__[item]))) for item in sorted(obj.__dict__)))
 
 
 # ------------------------------------------------------------------------------------------------------------------ #
@@ -9923,24 +9712,7 @@ def ObjToString(obj, extra='    '):
 # ----------------------------------- The mighty Popup! ------------------------------------------------------------ #
 
 
-def Popup(
-    *args,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    button_type=POPUP_BUTTONS_OK,
-    auto_close=False,
-    auto_close_duration=None,
-    custom_text=(None, None),
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def Popup(*args, button_color=None, background_color=None, text_color=None, button_type=POPUP_BUTTONS_OK, auto_close=False, auto_close_duration=None, custom_text=(None, None), non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Popup - Display a popup box with as many parms as you wish to include
     :param args:
@@ -9998,9 +9770,7 @@ def Popup(
         max_line_total = max(max_line_total, width_used)
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
-        window.AddRow(
-            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)
-        )
+        window.AddRow(Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color))
         total_lines += height
 
     if non_blocking:
@@ -10010,11 +9780,7 @@ def Popup(
     # show either an OK or Yes/No depending on paramater
     if custom_text != (None, None):
         if type(custom_text) is not tuple:
-            window.AddRow(
-                PopupButton(
-                    custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True, bind_return_key=True
-                )
-            )
+            window.AddRow(PopupButton(custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True, bind_return_key=True))
         elif custom_text[1] is None:
             window.AddRow(
                 PopupButton(
@@ -10038,21 +9804,13 @@ def Popup(
             )
     elif button_type is POPUP_BUTTONS_YES_NO:
         window.AddRow(
-            PopupButton(
-                'Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3), size=(5, 1)
-            ),
+            PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3), size=(5, 1)),
             PopupButton('No', button_color=button_color, size=(5, 1)),
         )
     elif button_type is POPUP_BUTTONS_CANCELLED:
-        window.AddRow(
-            PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3))
-        )
+        window.AddRow(PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
     elif button_type is POPUP_BUTTONS_ERROR:
-        window.AddRow(
-            PopupButton(
-                'Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
-            )
-        )
+        window.AddRow(PopupButton('Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
     elif button_type is POPUP_BUTTONS_OK_CANCEL:
         window.AddRow(
             PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
@@ -10061,11 +9819,7 @@ def Popup(
     elif button_type is POPUP_BUTTONS_NO_BUTTONS:
         pass
     else:
-        window.AddRow(
-            PopupButton(
-                'OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
-            )
-        )
+        window.AddRow(PopupButton('OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
 
     if non_blocking:
         button, values = window.Read(timeout=0)
@@ -10085,22 +9839,7 @@ def MsgBox(*args):
 
 
 # --------------------------- PopupNoButtons ---------------------------
-def PopupNoButtons(
-    *args,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupNoButtons(*args, button_color=None, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Show a Popup but without any buttons
     :param args:
@@ -10139,23 +9878,7 @@ def PopupNoButtons(
 
 
 # --------------------------- PopupNonBlocking ---------------------------
-def PopupNonBlocking(
-    *args,
-    button_type=POPUP_BUTTONS_OK,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=True,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupNonBlocking(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=True, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Show Popup box and immediately return (does not block)
     :param args:
@@ -10175,46 +9898,14 @@ def PopupNonBlocking(
     :param location:
     :return:
     """
-    Popup(
-        *args,
-        button_color=button_color,
-        background_color=background_color,
-        text_color=text_color,
-        button_type=button_type,
-        auto_close=auto_close,
-        auto_close_duration=auto_close_duration,
-        non_blocking=non_blocking,
-        icon=icon,
-        line_width=line_width,
-        font=font,
-        no_titlebar=no_titlebar,
-        grab_anywhere=grab_anywhere,
-        keep_on_top=keep_on_top,
-        location=location
-    )
+    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color, button_type=button_type, auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon, line_width=line_width, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
 
 
 PopupNoWait = PopupNonBlocking
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup  ---------------------------
-def PopupQuick(
-    *args,
-    button_type=POPUP_BUTTONS_OK,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=True,
-    auto_close_duration=2,
-    non_blocking=True,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupQuick(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None, auto_close=True, auto_close_duration=2, non_blocking=True, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Show Popup box that doesn't block and closes itself
     :param args:
@@ -10234,43 +9925,11 @@ def PopupQuick(
     :param location:
     :return:
     """
-    Popup(
-        *args,
-        button_color=button_color,
-        background_color=background_color,
-        text_color=text_color,
-        button_type=button_type,
-        auto_close=auto_close,
-        auto_close_duration=auto_close_duration,
-        non_blocking=non_blocking,
-        icon=icon,
-        line_width=line_width,
-        font=font,
-        no_titlebar=no_titlebar,
-        grab_anywhere=grab_anywhere,
-        keep_on_top=keep_on_top,
-        location=location
-    )
+    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color, button_type=button_type, auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon, line_width=line_width, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup with no titlebar and no buttons ---------------------------
-def PopupQuickMessage(
-    *args,
-    button_type=POPUP_BUTTONS_NO_BUTTONS,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=True,
-    auto_close_duration=2,
-    non_blocking=True,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=True,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupQuickMessage(*args, button_type=POPUP_BUTTONS_NO_BUTTONS, button_color=None, background_color=None, text_color=None, auto_close=True, auto_close_duration=2, non_blocking=True, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=True, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Show Popup box that doesn't block and closes itself
     :param args:
@@ -10290,42 +9949,11 @@ def PopupQuickMessage(
     :param location:
     :return:
     """
-    Popup(
-        *args,
-        button_color=button_color,
-        background_color=background_color,
-        text_color=text_color,
-        button_type=button_type,
-        auto_close=auto_close,
-        auto_close_duration=auto_close_duration,
-        non_blocking=non_blocking,
-        icon=icon,
-        line_width=line_width,
-        font=font,
-        no_titlebar=no_titlebar,
-        grab_anywhere=grab_anywhere,
-        keep_on_top=keep_on_top,
-        location=location
-    )
+    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color, button_type=button_type, auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon, line_width=line_width, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
 
 
 # --------------------------- PopupNoTitlebar ---------------------------
-def PopupNoTitlebar(
-    *args,
-    button_type=POPUP_BUTTONS_OK,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    grab_anywhere=True,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupNoTitlebar(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, grab_anywhere=True, keep_on_top=False, location=(None, None)):
     """
     Display a Popup without a titlebar.   Enables grab anywhere so you can move it
     :param args:
@@ -10344,23 +9972,7 @@ def PopupNoTitlebar(
     :param location:
     :return:
     """
-    Popup(
-        *args,
-        button_color=button_color,
-        background_color=background_color,
-        text_color=text_color,
-        button_type=button_type,
-        auto_close=auto_close,
-        auto_close_duration=auto_close_duration,
-        non_blocking=non_blocking,
-        icon=icon,
-        line_width=line_width,
-        font=font,
-        no_titlebar=True,
-        grab_anywhere=grab_anywhere,
-        keep_on_top=keep_on_top,
-        location=location
-    )
+    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color, button_type=button_type, auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon, line_width=line_width, font=font, no_titlebar=True, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
 
 
 PopupNoFrame = PopupNoTitlebar
@@ -10369,23 +9981,7 @@ PopupAnnoying = PopupNoTitlebar
 
 
 # --------------------------- PopupAutoClose ---------------------------
-def PopupAutoClose(
-    *args,
-    button_type=POPUP_BUTTONS_OK,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=True,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupAutoClose(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None, auto_close=True, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Popup that closes itself after some time period
     :param args:
@@ -10405,45 +10001,14 @@ def PopupAutoClose(
     :param location:
     :return:
     """
-    Popup(
-        *args,
-        button_color=button_color,
-        background_color=background_color,
-        text_color=text_color,
-        button_type=button_type,
-        auto_close=auto_close,
-        auto_close_duration=auto_close_duration,
-        non_blocking=non_blocking,
-        icon=icon,
-        line_width=line_width,
-        font=font,
-        no_titlebar=no_titlebar,
-        grab_anywhere=grab_anywhere,
-        keep_on_top=keep_on_top,
-        location=location
-    )
+    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color, button_type=button_type, auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon, line_width=line_width, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
 
 
 PopupTimed = PopupAutoClose
 
 
 # --------------------------- PopupError ---------------------------
-def PopupError(
-    *args,
-    button_color=DEFAULT_ERROR_BUTTON_COLOR,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupError(*args, button_color=DEFAULT_ERROR_BUTTON_COLOR, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Popup with colored button and 'Error' as button text
     :param args:
@@ -10482,22 +10047,7 @@ def PopupError(
 
 
 # --------------------------- PopupCancel ---------------------------
-def PopupCancel(
-    *args,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupCancel(*args, button_color=None, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Display Popup with "cancelled" button text
     :param args:
@@ -10536,22 +10086,7 @@ def PopupCancel(
 
 
 # --------------------------- PopupOK ---------------------------
-def PopupOK(
-    *args,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupOK(*args, button_color=None, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Display Popup with OK button only
     :param args:
@@ -10590,22 +10125,7 @@ def PopupOK(
 
 
 # --------------------------- PopupOKCancel ---------------------------
-def PopupOKCancel(
-    *args,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupOKCancel(*args, button_color=None, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Display popup with OK and Cancel buttons
     :param args:
@@ -10644,22 +10164,7 @@ def PopupOKCancel(
 
 
 # --------------------------- PopupYesNo ---------------------------
-def PopupYesNo(
-    *args,
-    button_color=None,
-    background_color=None,
-    text_color=None,
-    auto_close=False,
-    auto_close_duration=None,
-    non_blocking=False,
-    icon=DEFAULT_WINDOW_ICON,
-    line_width=None,
-    font=None,
-    no_titlebar=False,
-    grab_anywhere=False,
-    keep_on_top=False,
-    location=(None, None)
-):
+def PopupYesNo(*args, button_color=None, background_color=None, text_color=None, auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
     """
     Display Popup with Yes and No buttons
     :param args:
@@ -10837,21 +10342,13 @@ def PopupGetFile(
         except:
             pass
         if save_as:
-            filename = tk.filedialog.asksaveasfilename(
-                filetypes=file_types, defaultextension=default_extension
-            )  # show the 'get file' dialog box
+            filename = tk.filedialog.asksaveasfilename(filetypes=file_types, defaultextension=default_extension)  # show the 'get file' dialog box
         else:
-            filename = tk.filedialog.askopenfilename(
-                filetypes=file_types, defaultextension=default_extension
-            )  # show the 'get file' dialog box
+            filename = tk.filedialog.askopenfilename(filetypes=file_types, defaultextension=default_extension)  # show the 'get file' dialog box
         root.destroy()
         return filename
 
-    browse_button = (
-        SaveAs(file_types=file_types, initial_folder=initial_folder)
-        if save_as
-        else FileBrowse(file_types=file_types, initial_folder=initial_folder)
-    )
+    browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder) if save_as else FileBrowse(file_types=file_types, initial_folder=initial_folder)
 
     layout = [
         [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
@@ -11008,11 +10505,7 @@ def main():
     ver = version.split('\n')[0]
 
     def VerLine(version, description, size=(30, 1)):
-        return [
-            Column(
-                [[T(description, font='Courier 18', text_color='yellow')], [T(version, font='Courier 18', size=size)]]
-            )
-        ]
+        return [Column([[T(description, font='Courier 18', text_color='yellow')], [T(version, font='Courier 18', size=size)]])]
 
     menu_def = [
         ['&File', ['&Open', '&Save', 'E&xit', 'Properties']],
@@ -11099,11 +10592,7 @@ def main():
             Column(col1, background_color='red'),
         ],
         [T('Up Time'), Text('Text', key='_TEXT_UPTIME_', font='Arial 18', text_color='black', size=(30, 1))],
-        [
-            Input(
-                'Single Line Input', do_not_clear=True, enable_events=False, size=(30, 1), text_color='red', key='_IN_'
-            )
-        ],
+        [Input('Single Line Input', do_not_clear=True, enable_events=False, size=(30, 1), text_color='red', key='_IN_')],
         [Multiline('Multiline Input', do_not_clear=True, size=(40, 4), enable_events=False, key='_MULTI_IN_')],
         # [Output(size=(60,10))],
         [

--- a/FreeSimpleGUIWeb/FreeSimpleGUIWeb/FreeSimpleGUIWeb.py
+++ b/FreeSimpleGUIWeb/FreeSimpleGUIWeb/FreeSimpleGUIWeb.py
@@ -1,6 +1,8 @@
-#usr/bin/python3
+# usr/bin/python3
 
-version = __version__ = '0.39.0.6  Unreleased\n , VSeparator added (spelling error), added default key for one_line_progress_meter, auto-add keys to tables & trees, Graph.draw_image now uses image_data property instead of calling set_image, added theme_add_new, changed Remi call menu_item.set_on_click_listener to menu_item.onclick.connect so it can run with latest Remi'
+version = __version__ = (
+    '0.39.0.6  Unreleased\n , VSeparator added (spelling error), added default key for one_line_progress_meter, auto-add keys to tables & trees, Graph.draw_image now uses image_data property instead of calling set_image, added theme_add_new, changed Remi call menu_item.set_on_click_listener to menu_item.onclick.connect so it can run with latest Remi'
+)
 
 port = 'PySimpleGUIWeb'
 
@@ -63,7 +65,6 @@ g_time_end = 0
 g_time_delta = 0
 
 
-
 def TimerStart():
     global g_time_start
 
@@ -75,11 +76,11 @@ def TimerStop():
 
     g_time_end = time.time()
     g_time_delta = g_time_end - g_time_start
-    print(g_time_delta*1000)
+    print(g_time_delta * 1000)
+
 
 # Because looks matter...
 DEFAULT_BASE64_ICON = b'iVBORw0KGgoAAAANSUhEUgAAACEAAAAgCAMAAACrZuH4AAAABGdBTUEAALGPC/xhBQAAAwBQTFRFAAAAMGmYMGqZMWqaMmubMmycM22dNGuZNm2bNm6bNG2dN26cNG6dNG6eNW+fN3CfOHCeOXGfNXCgNnGhN3KiOHOjOXSjOHSkOnWmOnamOnanPHSiPXakPnalO3eoPnimO3ioPHioPHmpPHmqPXqqPnurPnusPnytP3yuQHimQnurQn2sQH2uQX6uQH6vR32qRn+sSXujSHynTH2mTn+nSX6pQH6wTIGsTYKuTYSvQoCxQoCyRIK0R4S1RYS2Roa4SIe4SIe6SIi7Soq7SYm8SYq8Sou+TY2/UYStUYWvVIWtUYeyVoewUIi0VIizUI6+Vo+8WImxXJG5YI2xZI+xZ5CzZJC0ZpG1b5a3apW4aZm/cZi4dJ2/eJ69fJ+9XZfEZZnCZJzHaZ/Jdp/AeKTI/tM8/9Q7/9Q8/9Q9/9Q+/tQ//9VA/9ZA/9ZB/9ZC/9dD/9ZE/tdJ/9dK/9hF/9hG/9hH/9hI/9hJ/9hK/9lL/9pK/9pL/thO/9pM/9pN/9tO/9tP/9xP/tpR/9xQ/9xR/9xS/9xT/91U/91V/t1W/95W/95X/95Y/95Z/99a/99b/txf/txh/txk/t5l/t1q/t5v/+Bb/+Bc/+Bd/+Be/+Bf/+Bg/+Fh/+Fi/+Jh/+Ji/uJk/uJl/+Jm/+Rm/uJo/+Ro/+Rr/+Zr/+Vs/+Vu/+Zs/+Zu/uF0/uVw/+dw/+dz/+d2/uB5/uB6/uJ9/uR7/uR+/uV//+hx/+hy/+h0/+h2/+l4/+l7/+h8gKXDg6vLgazOhKzMiqrEj6/KhK/Qka/Hk7HJlLHJlLPMmLTLmbbOkLXSmLvXn77XoLrPpr/Tn8DaocLdpcHYrcjdssfZus/g/uOC/uOH/uaB/uWE/uaF/uWK/+qA/uqH/uqI/uuN/uyM/ueS/ueW/ueY/umQ/uqQ/uuS/uuW/uyU/uyX/uqa/uue/uye/uyf/u6f/uyq/u+r/u+t/vCm/vCp/vCu/vCy/vC2/vK2/vO8/vO/wtTjwtXlzdrl/vTA/vPQAAAAiNpY5gAAAQB0Uk5T////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////AFP3ByUAAAAJcEhZcwAAFw8AABcPASe7rwsAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjEuMWMqnEsAAAKUSURBVDhPhdB3WE1xHMdxt5JV0dANoUiyd8kqkey996xclUuTlEKidO3qVnTbhIyMW/bee5NskjJLmR/f3++cK/94vP76Ps/n/Zx7z6mE/6koJowcK154vvHOL/GsKCZXkUgkWlf4vWGWq5tsDz+JWIzSokAiqXGe7nWu3HxhEYof7fhOqp1GtptQuMruVhQdxZ05U5G47tYUHbQ4oah6Fg9Z4ubm7i57JhQjdHS0RSzUPoG17u6zZTKZh8c8XlytqW9YWUOH1LqFOZ6enl5ec+XybFb0rweM1tPTM6yuq6vLs0lYJJfLvb19fHwDWGF0jh5lYNAe4/QFemOwxtfXz8/fPyBgwVMqzAcCF4ybAZ2MRCexJGBhYGBQUHDw4u1UHDG1G2ZqB/Q1MTHmzAE+kpCwL1RghlTaBt/6SaXS2kx9YH1IaOjSZST8vfA9JtoDnSngGgL7wkg4WVkofA9mcF1Sx8zMzBK4v3wFiYiMVLxlEy9u21syFhYNmgN7IyJXEYViNZvEYoCVVWOmUVvgQVSUQqGIjolRFvOAFd8HWVs34VoA+6OjY2JjY5Vxm4BC1UuhGG5jY9OUaQXci1MqlfHx8YmqjyhOViW9ZsUN29akJRmPFwkJCZsTSXIpilJffXiTzorLXYgtcxRJKpUqKTklJQ0oSt9FP/EonxVdNY4jla1kK4q2ZB6mIr+AipvduzFUzMSOtLT09IyMzMxtJKug/F0u/6dTexAWDcXXLGEjapKjfsILOLKEuYiSnTQeYCt3UHhbwEHjGMrETfBJU5zq5dSTcXC8hLJccSWP2cgLXHPu7cQNAcpyxF1dyjehAKb0cSYUAOXCUw6V8OFPgevTXFymC+fPPLU677Nw/1X8A/AbfAKGulaqFlIAAAAASUVORK5CYII='
-
 
 
 # ----====----====----==== Constants the user CAN safely change ====----====----====----#
@@ -100,8 +101,8 @@ DEFAULT_WINDOW_LOCATION = (None, None)
 MAX_SCROLLED_TEXT_BOX_HEIGHT = 50
 DEFAULT_TOOLTIP_TIME = 400
 
-DEFAULT_PIXELS_TO_CHARS_SCALING = (10,26)      # 1 character represents x by y pixels
-DEFAULT_PIXEL_TO_CHARS_CUTOFF = 20             # number of chars that triggers using pixels instead of chars
+DEFAULT_PIXELS_TO_CHARS_SCALING = (10, 26)  # 1 character represents x by y pixels
+DEFAULT_PIXEL_TO_CHARS_CUTOFF = 20  # number of chars that triggers using pixels instead of chars
 
 #################### COLOR STUFF ####################
 BLUES = ('#082567', '#0A37A3', '#00345B')
@@ -109,12 +110,14 @@ PURPLES = ('#480656', '#4F2398', '#380474')
 GREENS = ('#01826B', '#40A860', '#96D2AB', '#00A949', '#003532')
 YELLOWS = ('#F3FB62', '#F0F595')
 TANS = ('#FFF9D5', '#F4EFCF', '#DDD8BA')
-NICE_BUTTON_COLORS = ((GREENS[3], TANS[0]),
-                      ('#000000', '#FFFFFF'),
-                      ('#FFFFFF', '#000000'),
-                      (YELLOWS[0], PURPLES[1]),
-                      (YELLOWS[0], GREENS[3]),
-                      (YELLOWS[0], BLUES[2]))
+NICE_BUTTON_COLORS = (
+    (GREENS[3], TANS[0]),
+    ('#000000', '#FFFFFF'),
+    ('#FFFFFF', '#000000'),
+    (YELLOWS[0], PURPLES[1]),
+    (YELLOWS[0], GREENS[3]),
+    (YELLOWS[0], BLUES[2]),
+)
 
 COLOR_SYSTEM_DEFAULT = '1234567890'  # Colors should never be this long
 
@@ -223,10 +226,8 @@ MENU_DISABLED_CHARACTER = '!'
 MENU_KEY_SEPARATOR = '::'
 
 
-
-
 # a shameful global variable. This represents the top-level window information. Needed because opening a second window is different than opening the first.
-class MyWindows():
+class MyWindows:
     def __init__(self):
         self._NumOpenWindows = 0
         self.user_defined_icon = None
@@ -247,7 +248,8 @@ _my_windows = MyWindows()  # terrible hack using globals... means need a class f
 # ====================================================================== #
 # One-liner functions that are handy as f_ck                             #
 # ====================================================================== #
-def RGB(red, green, blue): return '#%02x%02x%02x' % (red, green, blue)
+def RGB(red, green, blue):
+    return '#%02x%02x%02x' % (red, green, blue)
 
 
 # ====================================================================== #
@@ -268,7 +270,7 @@ BUTTON_TYPE_REALTIME = 9
 BUTTON_TYPE_CALENDAR_CHOOSER = 30
 BUTTON_TYPE_COLOR_CHOOSER = 40
 
-BROWSE_FILES_DELIMITER = ';'            # the delimeter to be used between each file in the returned string
+BROWSE_FILES_DELIMITER = ';'  # the delimeter to be used between each file in the returned string
 
 # -------------------------  Element types  ------------------------- #
 # These used to be enums ElementType(Enum):
@@ -320,9 +322,22 @@ POPUP_BUTTONS_NO_BUTTONS = 5
 # ------------------------------------------------------------------------- #
 #                       Element CLASS                                       #
 # ------------------------------------------------------------------------- #
-class Element():
-    def __init__(self, elem_type, size=(None, None), auto_size_text=None, font=None, background_color=None, text_color=None,
-                 key=None, pad=None, tooltip=None, visible=True, size_px=(None, None), metadata=None):
+class Element:
+    def __init__(
+        self,
+        elem_type,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
 
         if elem_type != ELEM_TYPE_GRAPH:
             self.Size = convert_tkinter_size_to_Wx(size)
@@ -347,7 +362,7 @@ class Element():
         self.TKEntry = None
         self.TKImage = None
 
-        self.ParentForm = None      # type: Window
+        self.ParentForm = None  # type: Window
         self.ParentContainer = None  # will be a Form, Column, or Frame element
         self.TextInputDefault = None
         self.Position = (0, 0)  # Default position Row 0, Col 0
@@ -357,8 +372,7 @@ class Element():
         self.Tooltip = tooltip
         self.TooltipObject = None
         self.Visible = visible
-        self.metadata = metadata                # type: Any
-
+        self.metadata = metadata  # type: Any
 
     # -------------------------  REMI CHANGED CALLBACK -----------------------
     # called when a widget has changed and the element has events enabled
@@ -368,7 +382,9 @@ class Element():
         self.ParentForm.LastButtonClicked = self.Key if self.Key is not None else ''
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
 
-    def Update(self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None):
+    def Update(
+        self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None
+    ):
         if font is not None:
             font_info = font_parse_string(font)  # family, point size, other
             widget.style['font-family'] = font_info[0]
@@ -386,10 +402,9 @@ class Element():
         if visible is False:
             widget.attributes['hidden'] = 'true'
         elif visible is True:
-            del(widget.attributes['hidden'])
+            del widget.attributes['hidden']
         if tooltip is not None:
             widget.attributes['title'] = tooltip
-
 
         # if font:
         #     widget.SetFont(font_to_wx_font(font))
@@ -412,8 +427,7 @@ class Element():
         if visible is False:
             widget.attributes['hidden'] = 'true'
         elif visible is True:
-            del(widget.attributes['hidden'])
-
+            del widget.attributes['hidden']
 
     def __call__(self, *args, **kwargs):
         """
@@ -435,10 +449,26 @@ class Element():
 #                           Input Class                                  #
 # ---------------------------------------------------------------------- #
 class InputText(Element):
-    def __init__(self, default_text='', size=(None, None), disabled=False, password_char='',
-                 justification=None, background_color=None, text_color=None, font=None, tooltip=None,
-                 change_submits=False, enable_events=False,
-                 do_not_clear=True, key=None, focus=False, pad=None, visible=True, size_px=(None, None)):
+    def __init__(
+        self,
+        default_text='',
+        size=(None, None),
+        disabled=False,
+        password_char='',
+        justification=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        tooltip=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        focus=False,
+        pad=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Input a line of text Element
         :param default_text: Default value to display
@@ -458,19 +488,31 @@ class InputText(Element):
         self.QT_QLineEdit = None
         self.ValueWasChanged = False
         self.Widget = None  # type: remi.gui.TextInput
-        super().__init__(ELEM_TYPE_INPUT_TEXT, size=size, background_color=bg, text_color=fg, key=key, pad=pad,
-                         font=font, tooltip=tooltip, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_TEXT,
+            size=size,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            font=font,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
 
-    def _InputTextCallback(self,widget, key, keycode, ctrl, shift, alt):
+    def _InputTextCallback(self, widget, key, keycode, ctrl, shift, alt):
         # print(f'text widget value = {widget.get_value()}')
         # widget.set_value('')
         # widget.set_value(value)
         self.ParentForm.LastButtonClicked = key
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
-        widget.set_value(widget.get_value()+key)
+        widget.set_value(widget.get_value() + key)
         return (key, keycode, ctrl, shift, alt)
 
-    def Update(self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None
+    ):
         if value is not None:
             self.Widget.set_value(str(value))
         if disabled is True:
@@ -481,30 +523,33 @@ class InputText(Element):
     def Get(self):
         return self.Widget.get_value()
 
-
     get = Get
     update = Update
 
     class TextInput_raw_onkeyup(remi.gui.TextInput):
         @remi.gui.decorate_set_on_listener('(self, emitter, key, keycode, ctrl, shift, alt)')
-        @remi.gui.decorate_event_js("""var params={};params['key']=event.key;
+        @remi.gui.decorate_event_js(
+            """var params={};params['key']=event.key;
                 params['keycode']=(event.which||event.keyCode);
                 params['ctrl']=event.ctrlKey;
                 params['shift']=event.shiftKey;
                 params['alt']=event.altKey;
                 sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
-                event.stopPropagation();event.preventDefault();return false;""")
+                event.stopPropagation();event.preventDefault();return false;"""
+        )
         def onkeyup(self, key, keycode, ctrl, shift, alt):
             return (key, keycode, ctrl, shift, alt)
 
         @remi.gui.decorate_set_on_listener('(self, emitter, key, keycode, ctrl, shift, alt)')
-        @remi.gui.decorate_event_js("""var params={};params['key']=event.key;
+        @remi.gui.decorate_event_js(
+            """var params={};params['key']=event.key;
                 params['keycode']=(event.which||event.keyCode);
                 params['ctrl']=event.ctrlKey;
                 params['shift']=event.shiftKey;
                 params['alt']=event.altKey;
                 sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
-                event.stopPropagation();event.preventDefault();return false;""")
+                event.stopPropagation();event.preventDefault();return false;"""
+        )
         def onkeydown(self, key, keycode, ctrl, shift, alt):
             return (key, keycode, ctrl, shift, alt)
 
@@ -514,13 +559,32 @@ In = InputText
 Input = InputText
 I = InputText
 
+
 # ---------------------------------------------------------------------- #
 #                           Combo                                        #
 # ---------------------------------------------------------------------- #
 class Combo(Element):
-    def __init__(self, values, default_value=None, size=(None, None), auto_size_text=None, background_color=None,
-                 text_color=None, change_submits=False, enable_events=False, disabled=False, key=None, pad=None, tooltip=None,
-                 readonly=False, visible_items=10, font=None, auto_complete=True, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        key=None,
+        pad=None,
+        tooltip=None,
+        readonly=False,
+        visible_items=10,
+        font=None,
+        auto_complete=True,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Input Combo Box Element (also called Dropdown box)
         :param values:
@@ -538,13 +602,33 @@ class Combo(Element):
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
         self.VisibleItems = visible_items
         self.AutoComplete = auto_complete
-        self.Widget = None          # type: remi.gui.DropDown
-        super().__init__(ELEM_TYPE_INPUT_COMBO, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=size_px)
+        self.Widget = None  # type: remi.gui.DropDown
+        super().__init__(
+            ELEM_TYPE_INPUT_COMBO,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=size_px,
+        )
 
-
-
-    def Update(self, value=None, values=None, set_to_index=None, disabled=None, readonly=None,  background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self,
+        value=None,
+        values=None,
+        set_to_index=None,
+        disabled=None,
+        readonly=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        visible=None,
+    ):
         if values is not None:
             self.Widget.empty()
             for i, item in enumerate(values):
@@ -552,12 +636,19 @@ class Combo(Element):
         if value:
             self.Widget.select_by_value(value)
         if set_to_index is not None:
-            try:            # just in case a bad index is passed in
+            try:  # just in case a bad index is passed in
                 self.Widget.select_by_key(str(set_to_index))
             except:
                 pass
 
-        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible, disabled=disabled)
+        super().Update(
+            self.Widget,
+            background_color=background_color,
+            text_color=text_color,
+            font=font,
+            visible=visible,
+            disabled=disabled,
+        )
 
     update = Update
 
@@ -572,8 +663,19 @@ Drop = Combo
 #                           Option Menu                                  #
 # ---------------------------------------------------------------------- #
 class OptionMenu(Element):
-    def __init__(self, values, default_value=None, size=(None, None), disabled=False, auto_size_text=None,
-                 background_color=None, text_color=None, key=None, pad=None, tooltip=None):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        disabled=False,
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+    ):
         '''
         InputOptionMenu
         :param values:
@@ -594,8 +696,16 @@ class OptionMenu(Element):
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
 
-        super().__init__(ELEM_TYPE_INPUT_OPTION_MENU, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_INPUT_OPTION_MENU,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+        )
 
     def Update(self, value=None, values=None, disabled=None):
         if values is not None:
@@ -615,17 +725,34 @@ class OptionMenu(Element):
             self.TKOptionMenu['state'] = 'normal'
 
 
-
 # -------------------------  OPTION MENU Element lazy functions  ------------------------- #
 InputOptionMenu = OptionMenu
-
 
 
 # ---------------------------------------------------------------------- #
 #                           Listbox                                      #
 # ---------------------------------------------------------------------- #
 class Listbox(Element):
-    def __init__(self, values, default_values=None, select_mode=None, change_submits=False, enable_events=False, bind_return_key=False, size=(None, None), disabled=False, auto_size_text=None, font=None, background_color=None, text_color=None, key=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        values,
+        default_values=None,
+        select_mode=None,
+        change_submits=False,
+        enable_events=False,
+        bind_return_key=False,
+        size=(None, None),
+        disabled=False,
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         """
 
         :param values:
@@ -666,15 +793,35 @@ class Listbox(Element):
             self.SelectMode = DEFAULT_LISTBOX_SELECT_MODE
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        self.Widget = None          # type: remi.gui.ListView
-        tsize = size                # convert tkinter size to pixels
+        self.Widget = None  # type: remi.gui.ListView
+        tsize = size  # convert tkinter size to pixels
         if size[0] is not None and size[0] < 100:
-            tsize = size[0]*DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1]*DEFAULT_PIXELS_TO_CHARS_SCALING[1]
+            tsize = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
 
-        super().__init__(ELEM_TYPE_INPUT_LISTBOX, size=tsize, auto_size_text=auto_size_text, font=font,
-                         background_color=bg, text_color=fg, key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_LISTBOX,
+            size=tsize,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
 
-    def Update(self, values=None, disabled=None, set_to_index=None,background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self,
+        values=None,
+        disabled=None,
+        set_to_index=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        visible=None,
+    ):
         if values is not None:
             self.Values = values
             self.Widget.empty()
@@ -686,7 +833,14 @@ class Listbox(Element):
         #     self.QT_ListWidget.setDisabled(False)
         # if set_to_index is not None:
         #     self.QT_ListWidget.setCurrentRow(set_to_index)
-        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible, disabled=disabled)
+        super().Update(
+            self.Widget,
+            background_color=background_color,
+            text_color=text_color,
+            font=font,
+            visible=visible,
+            disabled=disabled,
+        )
 
         return
 
@@ -696,7 +850,6 @@ class Listbox(Element):
     #         item = self.QT_ListWidget.item(index)
     #         if value in values:
     #             self.QT_ListWidget.setItemSelected(item, True)
-
 
     def GetListValues(self):
         return self.Values
@@ -709,9 +862,22 @@ class Listbox(Element):
 #                           Radio                                        #
 # ---------------------------------------------------------------------- #
 class Radio(Element):
-    def __init__(self, text, group_id, default=False, disabled=False, size=(None, None), auto_size_text=None,
-                 background_color=None, text_color=None, font=None, key=None, pad=None, tooltip=None,
-                 change_submits=False):
+    def __init__(
+        self,
+        text,
+        group_id,
+        default=False,
+        disabled=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        change_submits=False,
+    ):
         '''
         Radio Button Element
         :param text:
@@ -739,9 +905,17 @@ class Radio(Element):
 
         print('*** WARNING - Radio Buttons are not yet available on PySimpleGUIWeb ***')
 
-        super().__init__(ELEM_TYPE_INPUT_RADIO, size=size, auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_INPUT_RADIO,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+        )
 
     def Update(self, value=None, disabled=None):
         print('*** NOT IMPLEMENTED ***')
@@ -764,8 +938,24 @@ class Radio(Element):
 #                           Checkbox                                     #
 # ---------------------------------------------------------------------- #
 class Checkbox(Element):
-    def __init__(self, text, default=False, size=(None, None), auto_size_text=None, font=None, background_color=None,
-                 text_color=None, change_submits=False, enable_events=False, disabled=False, key=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        text,
+        default=False,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Checkbox Element
         :param text:
@@ -786,18 +976,27 @@ class Checkbox(Element):
         self.Disabled = disabled
         self.TextColor = text_color if text_color else DEFAULT_TEXT_COLOR
         self.ChangeSubmits = change_submits or enable_events
-        self.Widget = None      # type: remi.gui.CheckBox
+        self.Widget = None  # type: remi.gui.CheckBox
 
-        super().__init__(ELEM_TYPE_INPUT_CHECKBOX, size=size, auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_CHECKBOX,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
 
     def _ChangedCallback(self, widget, value):
         # type: (remi.Widget, Any) -> None
         # print(f'text widget value = {widget.get_value()}')
         self.ParentForm.LastButtonClicked = self.Key
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
-
 
     def Get(self):
         return self.Widget.get_value()
@@ -824,11 +1023,29 @@ Check = Checkbox
 #                           Spin                                         #
 # ---------------------------------------------------------------------- #
 
+
 class Spin(Element):
     # Values = None
     # TKSpinBox = None
-    def __init__(self, values, initial_value=None, disabled=False, change_submits=False,  enable_events=False, size=(None, None), readonly=True, auto_size_text=None, font=None, background_color=None, text_color=None, key=None, pad=None,
-                 tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        values,
+        initial_value=None,
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        size=(None, None),
+        readonly=True,
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Spinner Element
         :param values:
@@ -852,16 +1069,30 @@ class Spin(Element):
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
         self.CurrentValue = self.DefaultValue
         self.ReadOnly = readonly
-        self.Widget = None      # type: remi.gui.SpinBox
-        super().__init__(ELEM_TYPE_INPUT_SPIN, size, auto_size_text, font=font, background_color=bg, text_color=fg,
-                         key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px)
+        self.Widget = None  # type: remi.gui.SpinBox
+        super().__init__(
+            ELEM_TYPE_INPUT_SPIN,
+            size,
+            auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
-
-    def Update(self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None
+    ):
         if value is not None:
             self.Widget.set_value(value)
-        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font,visible=visible)
+        super().Update(
+            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         return self.Widget.get_value()
@@ -874,9 +1105,28 @@ class Spin(Element):
 #                           Multiline                                    #
 # ---------------------------------------------------------------------- #
 class Multiline(Element):
-    def __init__(self, default_text='', enter_submits=False, disabled=False, autoscroll=False, size=(None, None),
-                 auto_size_text=None, background_color=None, text_color=None, change_submits=False, enable_events=False, do_not_clear=True,
-                 key=None, write_only=False, focus=False, font=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        default_text='',
+        enter_submits=False,
+        disabled=False,
+        autoscroll=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        write_only=False,
+        focus=False,
+        font=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Multiline Element
         :param default_text:
@@ -905,36 +1155,58 @@ class Multiline(Element):
         self.ChangeSubmits = change_submits or enable_events
         self.WriteOnly = write_only
         if size[0] is not None and size[0] < 100:
-            size = size[0]*DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1]*DEFAULT_PIXELS_TO_CHARS_SCALING[1]
-        self.Widget = None      # type: remi.gui.TextInput
+            size = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
+        self.Widget = None  # type: remi.gui.TextInput
 
-        super().__init__(ELEM_TYPE_INPUT_MULTILINE, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_MULTILINE,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
-    def _InputTextCallback(self, widget:remi.Widget, value, keycode):
+    def _InputTextCallback(self, widget: remi.Widget, value, keycode):
         # print(f'text widget value = {widget.get_value()}')
         self.ParentForm.LastButtonClicked = chr(int(keycode))
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
 
-    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None, autoscroll=None):
-            if value is not None and not append:
-                self.Widget.set_value(value)
-            elif value is not None and append:
-                text = self.Widget.get_value() + str(value)
-                self.Widget.set_value(text)
-            # if background_color is not None:
-            #     self.WxTextCtrl.SetBackgroundColour(background_color)
-            # if text_color is not None:
-            #     self.WxTextCtrl.SetForegroundColour(text_color)
-            # if font is not None:
-            #     self.WxTextCtrl.SetFont(font)
-            # if disabled:
-            #     self.WxTextCtrl.Enable(True)
-            # elif disabled is False:
-            #     self.WxTextCtrl.Enable(False)
-            super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+    def Update(
+        self,
+        value=None,
+        disabled=None,
+        append=False,
+        background_color=None,
+        text_color=None,
+        font=None,
+        visible=None,
+        autoscroll=None,
+    ):
+        if value is not None and not append:
+            self.Widget.set_value(value)
+        elif value is not None and append:
+            text = self.Widget.get_value() + str(value)
+            self.Widget.set_value(text)
+        # if background_color is not None:
+        #     self.WxTextCtrl.SetBackgroundColour(background_color)
+        # if text_color is not None:
+        #     self.WxTextCtrl.SetForegroundColour(text_color)
+        # if font is not None:
+        #     self.WxTextCtrl.SetFont(font)
+        # if disabled:
+        #     self.WxTextCtrl.Enable(True)
+        # elif disabled is False:
+        #     self.WxTextCtrl.Enable(False)
+        super().Update(
+            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def print(self, *args, end=None, sep=None, text_color=None, background_color=None):
         """
@@ -948,9 +1220,8 @@ class Multiline(Element):
         """
         _print_to_element(self, *args, end=end, sep=sep, text_color=text_color, background_color=background_color)
 
-
-
     update = Update
+
 
 ML = Multiline
 MLine = Multiline
@@ -960,9 +1231,27 @@ MLine = Multiline
 #                           Multiline Output                             #
 # ---------------------------------------------------------------------- #
 class MultilineOutput(Element):
-    def __init__(self, default_text='', enter_submits=False, disabled=False, autoscroll=False, size=(None, None), auto_size_text=None, background_color=None,
-                 text_color=None, change_submits=False, enable_events=False, do_not_clear=True, key=None, focus=False, font=None, pad=None, tooltip=None,
-                 visible=True, size_px=(None, None)):
+    def __init__(
+        self,
+        default_text='',
+        enter_submits=False,
+        disabled=False,
+        autoscroll=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        focus=False,
+        font=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Multiline Element
         :param default_text:
@@ -995,11 +1284,32 @@ class MultilineOutput(Element):
         self.Widget = None  # type: remi.gui.TextInput
         self.CurrentValue = ''
 
-        super().__init__(ELEM_TYPE_MULTILINE_OUTPUT, size=tsize, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_MULTILINE_OUTPUT,
+            size=tsize,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
-    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None, autoscroll=None):
+    def Update(
+        self,
+        value=None,
+        disabled=None,
+        append=False,
+        background_color=None,
+        text_color=None,
+        font=None,
+        visible=None,
+        autoscroll=None,
+    ):
         autoscroll = self.Autoscroll if autoscroll is None else autoscroll
         if value is not None and not append:
             self.Widget.set_value(str(value))
@@ -1012,10 +1322,17 @@ class MultilineOutput(Element):
 
         if hasattr(app, 'websockets'):
             app.execute_javascript(
-                'element=document.getElementById("%(id)s"); element.innerHTML=`%(content)s`; if(%(autoscroll)s){element.scrollTop=999999;} ' % {
-                    'id': self.Widget.identifier, 'content': self.Widget.get_value(), 'autoscroll': 'true' if autoscroll else 'false'})
+                'element=document.getElementById("%(id)s"); element.innerHTML=`%(content)s`; if(%(autoscroll)s){element.scrollTop=999999;} '
+                % {
+                    'id': self.Widget.identifier,
+                    'content': self.Widget.get_value(),
+                    'autoscroll': 'true' if autoscroll else 'false',
+                }
+            )
 
-        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def print(self, *args, end=None, sep=None, text_color=None, background_color=None):
         """
@@ -1029,10 +1346,6 @@ class MultilineOutput(Element):
         """
         _print_to_element(self, *args, end=end, sep=sep, text_color=text_color, background_color=background_color)
 
-
-
-
-
     update = Update
 
 
@@ -1040,7 +1353,27 @@ class MultilineOutput(Element):
 #                                       Text                             #
 # ---------------------------------------------------------------------- #
 class Text(Element):
-    def __init__(self, text='', size=(None, None),  auto_size_text=None, click_submits=None, enable_events=False, relief=None, border_width=None, font=None, text_color=None, background_color=None, justification=None, pad=None, margins=None, key=None, tooltip=None, visible=True, size_px=(None,None), metadata=None):
+    def __init__(
+        self,
+        text='',
+        size=(None, None),
+        auto_size_text=None,
+        click_submits=None,
+        enable_events=False,
+        relief=None,
+        border_width=None,
+        font=None,
+        text_color=None,
+        background_color=None,
+        justification=None,
+        pad=None,
+        margins=None,
+        key=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+        metadata=None,
+    ):
         """
         Text
         :param text:
@@ -1073,26 +1406,40 @@ class Text(Element):
             bg = background_color
         pixelsize = size
         if size[1] is not None and size[1] < 10:
-            pixelsize = size[0]*10, size[1]*20
+            pixelsize = size[0] * 10, size[1] * 20
         self.BorderWidth = border_width if border_width is not None else DEFAULT_BORDER_WIDTH
         self.Disabled = False
-        self.Widget = None      #type: remi.gui.Label
+        self.Widget = None  # type: remi.gui.Label
 
-        super().__init__(ELEM_TYPE_TEXT, pixelsize, auto_size_text, background_color=bg, font=font if font else DEFAULT_FONT,
-                         text_color=self.TextColor, pad=pad, key=key, tooltip=tooltip, size_px=size_px, visible=visible, metadata=metadata)
+        super().__init__(
+            ELEM_TYPE_TEXT,
+            pixelsize,
+            auto_size_text,
+            background_color=bg,
+            font=font if font else DEFAULT_FONT,
+            text_color=self.TextColor,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            size_px=size_px,
+            visible=visible,
+            metadata=metadata,
+        )
         return
 
     def Update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.Widget.set_text(str(value))
-        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     update = Update
+
 
 # -------------------------  Text Element lazy functions  ------------------------- #
 Txt = Text
 T = Text
-
 
 
 # ---------------------------------------------------------------------- #
@@ -1100,8 +1447,19 @@ T = Text
 #  Routes stdout, stderr to a scrolled window                            #
 # ---------------------------------------------------------------------- #
 class Output(Element):
-    def __init__(self, size=(None, None), background_color=None, text_color=None, pad=None, font=None, tooltip=None,
-                 key=None, visible=True, size_px=(None,None), disabled=False):
+    def __init__(
+        self,
+        size=(None, None),
+        background_color=None,
+        text_color=None,
+        pad=None,
+        font=None,
+        tooltip=None,
+        key=None,
+        visible=True,
+        size_px=(None, None),
+        disabled=False,
+    ):
         '''
         Output Element
         :param size:
@@ -1114,17 +1472,33 @@ class Output(Element):
         '''
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         # fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        fg = text_color if text_color is not None else 'black' if DEFAULT_INPUT_TEXT_COLOR == COLOR_SYSTEM_DEFAULT else DEFAULT_INPUT_TEXT_COLOR
+        fg = (
+            text_color
+            if text_color is not None
+            else 'black' if DEFAULT_INPUT_TEXT_COLOR == COLOR_SYSTEM_DEFAULT else DEFAULT_INPUT_TEXT_COLOR
+        )
         self.Disabled = disabled
-        self.Widget = None      # type: remi.gui.TextInput
+        self.Widget = None  # type: remi.gui.TextInput
         if size_px == (None, None) and size == (None, None):
             size = DEFAULT_OUTPUT_ELEMENT_SIZE
         if size[0] is not None and size[0] < 100:
-            size = size[0]*DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1]*DEFAULT_PIXELS_TO_CHARS_SCALING[1]
-        super().__init__(ELEM_TYPE_OUTPUT, size=size, size_px=size_px, visible=visible, background_color=bg, text_color=fg, pad=pad, font=font, tooltip=tooltip, key=key)
+            size = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
+        super().__init__(
+            ELEM_TYPE_OUTPUT,
+            size=size,
+            size_px=size_px,
+            visible=visible,
+            background_color=bg,
+            text_color=fg,
+            pad=pad,
+            font=font,
+            tooltip=tooltip,
+            key=key,
+        )
 
-
-    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None
+    ):
         if value is not None and not append:
             self.Widget.set_value(str(value))
             self.CurrentValue = str(value)
@@ -1134,10 +1508,14 @@ class Output(Element):
         self.Widget._set_updated()
         app = self.ParentForm.App
         if hasattr(app, 'websockets'):
-            app.execute_javascript('element=document.getElementById("%(id)s"); element.innerHTML=`%(content)s`; element.scrollTop=999999; ' % {
-                'id':self.Widget.identifier, 'content':self.Widget.get_value()})
+            app.execute_javascript(
+                'element=document.getElementById("%(id)s"); element.innerHTML=`%(content)s`; element.scrollTop=999999; '
+                % {'id': self.Widget.identifier, 'content': self.Widget.get_value()}
+            )
 
-        super().Update(self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.Widget, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     update = Update
 
@@ -1146,11 +1524,33 @@ class Output(Element):
 #                           Button Class                                 #
 # ---------------------------------------------------------------------- #
 class Button(Element):
-    def __init__(self, button_text='', button_type=BUTTON_TYPE_READ_FORM, target=(None, None), tooltip=None,
-                 file_types=(('ALL Files', '*'),), initial_folder=None, disabled=False, change_submits=False, enable_events=False,
-                 image_filename=None, image_data=None, image_size=(None, None), image_subsample=None, border_width=None,
-                 size=(None, None), auto_size_button=None, button_color=None, font=None, bind_return_key=False,
-                 focus=False, pad=None, key=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        button_text='',
+        button_type=BUTTON_TYPE_READ_FORM,
+        target=(None, None),
+        tooltip=None,
+        file_types=(('ALL Files', '*'),),
+        initial_folder=None,
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        image_filename=None,
+        image_data=None,
+        image_size=(None, None),
+        image_subsample=None,
+        border_width=None,
+        size=(None, None),
+        auto_size_button=None,
+        button_color=None,
+        font=None,
+        bind_return_key=False,
+        focus=False,
+        pad=None,
+        key=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Button Element
         :param button_text:
@@ -1201,11 +1601,20 @@ class Button(Element):
         self.ColorChosen = None
         self.Relief = None
         # self.temp_size = size if size != (NONE, NONE) else
-        self.Widget = None          # type: remi.gui.Button
-        super().__init__(ELEM_TYPE_BUTTON, size=size, font=font, pad=pad, key=key, tooltip=tooltip, text_color=self.TextColor, background_color=self.BackgroundColor, visible=visible, size_px=size_px)
+        self.Widget = None  # type: remi.gui.Button
+        super().__init__(
+            ELEM_TYPE_BUTTON,
+            size=size,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            text_color=self.TextColor,
+            background_color=self.BackgroundColor,
+            visible=visible,
+            size_px=size_px,
+        )
         return
-
-
 
     # -------  Button Callback  ------- #
     def _ButtonCallBack(self, event):
@@ -1242,7 +1651,7 @@ class Button(Element):
             except:
                 pass
         filetypes = (('ALL Files', '*'),) if self.FileTypes is None else self.FileTypes
-        if self.BType == BUTTON_TYPE_BROWSE_FOLDER:                     # Browse Folder
+        if self.BType == BUTTON_TYPE_BROWSE_FOLDER:  # Browse Folder
             wx_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
                 dialog = wx.DirDialog(self.ParentForm.MasterFrame, style=wx.FD_OPEN)
@@ -1256,10 +1665,12 @@ class Button(Element):
                     target_element.FileOrFolderName = folder_name
                 else:
                     target_element.Update(folder_name)
-        elif self.BType == BUTTON_TYPE_BROWSE_FILE:                     # Browse File
+        elif self.BType == BUTTON_TYPE_BROWSE_FILE:  # Browse File
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame,defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN
+                )
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_OPEN)
             file_name = ''
@@ -1272,10 +1683,12 @@ class Button(Element):
                     target_element.FileOrFolderName = file_name
                 else:
                     target_element.Update(file_name)
-        elif self.BType == BUTTON_TYPE_BROWSE_FILES:                    # Browse Files
+        elif self.BType == BUTTON_TYPE_BROWSE_FILES:  # Browse Files
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame,defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE
+                )
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_MULTIPLE)
             file_names = ''
@@ -1289,12 +1702,19 @@ class Button(Element):
                     target_element.FileOrFolderName = file_names
                 else:
                     target_element.Update(file_names)
-        elif self.BType == BUTTON_TYPE_SAVEAS_FILE:                     # Save As File
+        elif self.BType == BUTTON_TYPE_SAVEAS_FILE:  # Save As File
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame,defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame,
+                    defaultDir=self.InitialFolder,
+                    wildcard=qt_types,
+                    style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+                )
             else:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
+                )
             file_name = ''
             if dialog.ShowModal() == wx.ID_OK:
                 file_name = dialog.GetPath()
@@ -1305,15 +1725,15 @@ class Button(Element):
                     target_element.FileOrFolderName = file_name
                 else:
                     target_element.Update(file_name)
-        elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:                   # Color Chooser
+        elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:  # Color Chooser
             qcolor = QColorDialog.getColor()
             rgb_color = qcolor.getRgb()
-            color= '#' + ''.join('%02x'% i for i in rgb_color[:3])
+            color = '#' + ''.join('%02x' % i for i in rgb_color[:3])
             if self.Target == (None, None):
                 self.FileOrFolderName = color
             else:
                 target_element.Update(color)
-        elif self.BType == BUTTON_TYPE_CLOSES_WIN:                      # Closes Window
+        elif self.BType == BUTTON_TYPE_CLOSES_WIN:  # Closes Window
             # first, get the results table built
             # modify the Results table in the parent FlexForm object
             if self.Key is not None:
@@ -1328,7 +1748,7 @@ class Button(Element):
             if self.ParentForm.NonBlocking:
                 Window._DecrementOpenCount()
             self.ParentForm._Close()
-        elif self.BType == BUTTON_TYPE_READ_FORM:                       # Read Button
+        elif self.BType == BUTTON_TYPE_READ_FORM:  # Read Button
             # first, get the results table built
             # modify the Results table in the parent FlexForm object
             # if self.Key is not None:
@@ -1341,7 +1761,9 @@ class Button(Element):
             element_callback_quit_mainloop(self)
             self.ParentForm._Close()
             Window._DecrementOpenCount()
-        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
+        elif (
+            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
+        ):  # this is a return type button so GET RESULTS and destroy window
             should_submit_window = False
 
         if should_submit_window:
@@ -1350,8 +1772,18 @@ class Button(Element):
             self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
         return
 
-
-    def Update(self, text=None, button_color=(None, None), disabled=None, image_data=None, image_filename=None, font=None, visible=None, image_subsample=None, image_size=(None,None)):
+    def Update(
+        self,
+        text=None,
+        button_color=(None, None),
+        disabled=None,
+        image_data=None,
+        image_filename=None,
+        font=None,
+        visible=None,
+        image_subsample=None,
+        image_size=(None, None),
+    ):
         if text is not None:
             self.Widget.set_text(str(text))
         fg, bg = button_color
@@ -1370,12 +1802,12 @@ class Button(Element):
 
         super().Update(self.Widget, background_color=bg, text_color=fg, disabled=disabled, font=font, visible=visible)
 
-
     def GetText(self):
         return self.Widget.get_text()
 
     get_text = GetText
     update = Update
+
 
 # -------------------------  Button lazy functions  ------------------------- #
 B = Button
@@ -1386,20 +1818,28 @@ Butt = Button
 def convert_tkinter_filetypes_to_wx(filetypes):
     wx_filetypes = ''
     for item in filetypes:
-        filetype = item[0] + ' (' + item[1] + ')|'+ item[1]
+        filetype = item[0] + ' (' + item[1] + ')|' + item[1]
         wx_filetypes += filetype
     return wx_filetypes
-
-
-
 
 
 # ---------------------------------------------------------------------- #
 #                           ProgreessBar                                 #
 # ---------------------------------------------------------------------- #
 class ProgressBar(Element):
-    def __init__(self, max_value, orientation=None, size=(None, None), auto_size_text=None, bar_color=(None, None),
-                 style=None, border_width=None, relief=None, key=None, pad=None):
+    def __init__(
+        self,
+        max_value,
+        orientation=None,
+        size=(None, None),
+        auto_size_text=None,
+        bar_color=(None, None),
+        style=None,
+        border_width=None,
+        relief=None,
+        key=None,
+        pad=None,
+    ):
         '''
         ProgressBar Element
         :param max_value:
@@ -1441,12 +1881,24 @@ class ProgressBar(Element):
 
     update_bar = UpdateBar
 
+
 # ---------------------------------------------------------------------- #
 #                           Image                                        #
 # ---------------------------------------------------------------------- #
 class Image(Element):
-    def __init__(self, filename=None, data=None, background_color=None, size=(None, None), pad=None, key=None,
-                 tooltip=None, right_click_menu=None, visible=True, enable_events=False):
+    def __init__(
+        self,
+        filename=None,
+        data=None,
+        background_color=None,
+        size=(None, None),
+        pad=None,
+        key=None,
+        tooltip=None,
+        right_click_menu=None,
+        visible=True,
+        enable_events=False,
+    ):
         '''
         Image Element
         :param filename:
@@ -1457,21 +1909,28 @@ class Image(Element):
         :param key:
         :param tooltip:
         '''
-        self.Filename = filename if filename else None # note that Remi expects a / at the front of resource files
+        self.Filename = filename if filename else None  # note that Remi expects a / at the front of resource files
         self.Data = data
         self.tktext_label = None
         self.BackgroundColor = background_color
         self.Disabled = False
         self.EnableEvents = enable_events
-        sz = (0,0) if size == (None, None) else size
-        self.Widget = None          #type: SuperImage
+        sz = (0, 0) if size == (None, None) else size
+        self.Widget = None  # type: SuperImage
         # if data is None and filename is None:                 # it is OK to have no image specified when intially creating
         #     print('* Warning... no image specified in Image Element! *')
-        super().__init__(ELEM_TYPE_IMAGE, size=sz, background_color=background_color, pad=pad, key=key,
-                         tooltip=tooltip, visible=visible)
+        super().__init__(
+            ELEM_TYPE_IMAGE,
+            size=sz,
+            background_color=background_color,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+        )
         return
 
-    def Update(self, filename=None, data=None, size=(None,None), visible=None):
+    def Update(self, filename=None, data=None, size=(None, None), visible=None):
         if data is not None:
             self.Widget.load(data)
             # decoded = base64.b64decode(data)
@@ -1484,10 +1943,9 @@ class Image(Element):
         # if size != (None, None):
         #     self.Widget.style['height'] = '{}px'.format(size[1])
         #     self.Widget.style['width'] = '{}px'.format(size[0])
-        super().Update(self.Widget,  visible=visible)
+        super().Update(self.Widget, visible=visible)
 
     update = Update
-
 
 
 # class SuperImageOld(remi.gui.Image):
@@ -1539,22 +1997,23 @@ class SuperImage(remi.gui.Image):
         self.imagedata = None
         self.mimetype = None
         self.encoding = None
-        if not image: return
+        if not image:
+            return
         self.load(image)
 
     def load(self, file_path_name):
         if type(file_path_name) is bytes:
             try:
-                #here a base64 image is received
+                # here a base64 image is received
                 self.imagedata = base64.b64decode(file_path_name, validate=True)
                 self.attributes['src'] = '/%s/get_image_data?update_index=%s' % (id(self), str(time.time()))
             except binascii.Error:
-                #here an image data is received (opencv image)
+                # here an image data is received (opencv image)
                 self.imagedata = file_path_name
                 self.refresh()
             self.refresh()
         else:
-            #here a filename is received
+            # here a filename is received
             self.attributes['src'] = remi.gui.load_resource(file_path_name)
             """print(f'***** Loading file = {file_path_name}')
             self.mimetype, self.encoding = mimetypes.guess_type(file_path_name)
@@ -1566,7 +2025,8 @@ class SuperImage(remi.gui.Image):
         i = int(time.time() * 1e6)
         # self.app_instance.execute_javascript("""
         if Window.App is not None:
-            Window.App.execute_javascript("""
+            Window.App.execute_javascript(
+                """
                 var url = '/%(id)s/get_image_data?update_index=%(frame_index)s';
                 var xhr = new XMLHttpRequest();
                 xhr.open('GET', url, true);
@@ -1577,7 +2037,9 @@ class SuperImage(remi.gui.Image):
                     document.getElementById('%(id)s').src = imageUrl;
                 }
                 xhr.send();
-                """ % {'id': id(self), 'frame_index':i})
+                """
+                % {'id': id(self), 'frame_index': i}
+            )
 
     def get_image_data(self, update_index):
         headers = {'Content-type': self.mimetype if self.mimetype else 'application/octet-stream'}
@@ -1588,8 +2050,22 @@ class SuperImage(remi.gui.Image):
 #                           Graph                                        #
 # ---------------------------------------------------------------------- #
 class Graph(Element):
-    def __init__(self, canvas_size, graph_bottom_left, graph_top_right, background_color=None, pad=None,
-                 change_submits=False, drag_submits=False, size_px=(None,None), enable_events=False, key=None, visible=True, disabled=False, tooltip=None):
+    def __init__(
+        self,
+        canvas_size,
+        graph_bottom_left,
+        graph_top_right,
+        background_color=None,
+        pad=None,
+        change_submits=False,
+        drag_submits=False,
+        size_px=(None, None),
+        enable_events=False,
+        key=None,
+        visible=True,
+        disabled=False,
+        tooltip=None,
+    ):
         '''
         Graph Element
         :param canvas_size:
@@ -1608,9 +2084,18 @@ class Graph(Element):
         self.ClickPosition = (None, None)
         self.MouseButtonDown = False
         self.Disabled = disabled
-        self.Widget = None                  # type: remi.gui.Svg
-        self.SvgGroup = None                # type: remi.gui.SvgSubcontainer
-        super().__init__(ELEM_TYPE_GRAPH, size=canvas_size, size_px=size_px, visible=visible, background_color=background_color, pad=pad,  tooltip=tooltip, key=key)
+        self.Widget = None  # type: remi.gui.Svg
+        self.SvgGroup = None  # type: remi.gui.SvgSubcontainer
+        super().__init__(
+            ELEM_TYPE_GRAPH,
+            size=canvas_size,
+            size_px=size_px,
+            visible=visible,
+            background_color=background_color,
+            pad=pad,
+            tooltip=tooltip,
+            key=key,
+        )
         return
 
     def _convert_xy_to_canvas_xy(self, x_in, y_in):
@@ -1641,9 +2126,15 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        line = remi.gui.SvgLine(converted_point_from[0], converted_point_from[1], converted_point_to[0], converted_point_to[1])
+        line = remi.gui.SvgLine(
+            converted_point_from[0], converted_point_from[1], converted_point_to[0], converted_point_to[1]
+        )
         line.set_stroke(width, color)
-        self.SvgGroup.append([line,])
+        self.SvgGroup.append(
+            [
+                line,
+            ]
+        )
         return line
 
     def DrawPoint(self, point, size=2, color='black'):
@@ -1657,9 +2148,12 @@ class Graph(Element):
         rpoint = remi.gui.SvgCircle(converted_point[0], converted_point[1], size)
         rpoint.set_stroke(size, color)
         rpoint.set_fill(color)
-        self.SvgGroup.append([rpoint,])
+        self.SvgGroup.append(
+            [
+                rpoint,
+            ]
+        )
         return rpoint
-
 
     def DrawCircle(self, center_location, radius, fill_color=None, line_color='black'):
         if center_location == (None, None):
@@ -1672,9 +2166,12 @@ class Graph(Element):
         rpoint = remi.gui.SvgCircle(converted_point[0], converted_point[1], radius=radius)
         rpoint.set_fill(fill_color)
         rpoint.set_stroke(color=line_color)
-        self.SvgGroup.append([rpoint,])
+        self.SvgGroup.append(
+            [
+                rpoint,
+            ]
+        )
         return rpoint
-
 
     def DrawOval(self, top_left, bottom_right, fill_color=None, line_color=None):
         converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
@@ -1684,7 +2181,6 @@ class Graph(Element):
             print('Call Window.Finalize() prior to this operation')
             return None
         return
-
 
     # def DrawArc(self, top_left, bottom_right, extent, start_angle, style=None, arc_color='black'):
     #     converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
@@ -1704,16 +2200,23 @@ class Graph(Element):
             print('Call Window.Finalize() prior to this operation')
             return None
 
-        rpoint = remi.gui.SvgRectangle(converted_top_left[0], converted_top_left[1], abs(converted_bottom_right[0]-converted_top_left[0]), abs(converted_top_left[1] - converted_bottom_right[1]))
+        rpoint = remi.gui.SvgRectangle(
+            converted_top_left[0],
+            converted_top_left[1],
+            abs(converted_bottom_right[0] - converted_top_left[0]),
+            abs(converted_top_left[1] - converted_bottom_right[1]),
+        )
         rpoint.set_stroke(width=1, color=line_color)
         if fill_color is not None:
             rpoint.set_fill(fill_color)
         else:
             rpoint.set_fill('transparent')
-        self.SvgGroup.append([rpoint,])
+        self.SvgGroup.append(
+            [
+                rpoint,
+            ]
+        )
         return rpoint
-
-
 
     def DrawText(self, text, location, color='black', font=None, angle=0):
         text = str(text)
@@ -1726,10 +2229,13 @@ class Graph(Element):
             return None
 
         rpoint = remi.gui.SvgText(converted_point[0], converted_point[1], text)
-        self.SvgGroup.append([rpoint,])
+        self.SvgGroup.append(
+            [
+                rpoint,
+            ]
+        )
         # self.SvgGroup.redraw()
         return rpoint
-
 
     def DrawImage(self, data=None, image_source=None, location=(None, None), size=(100, 100)):
         if location == (None, None):
@@ -1746,17 +2252,21 @@ class Graph(Element):
 
         if type(image_source) is bytes or len(image_source) > 200:
             # rpoint.set_image("data:image/svg;base64,%s"%image_source)
-            rpoint.image_data = 'data:image/svg;base64,%s'%image_source
+            rpoint.image_data = 'data:image/svg;base64,%s' % image_source
         else:
             mimetype, encoding = mimetypes.guess_type(image_source)
             with open(image_source, 'rb') as f:
                 data = f.read()
             b64 = base64.b64encode(data)
             b64_str = b64.decode('utf-8')
-            image_string = 'data:image/svg;base64,%s'%b64_str
+            image_string = 'data:image/svg;base64,%s' % b64_str
             # rpoint.set_image(image_string)
             rpoint.image_data = image_string
-        self.SvgGroup.append([rpoint,])
+        self.SvgGroup.append(
+            [
+                rpoint,
+            ]
+        )
         rpoint.redraw()
         self.SvgGroup.redraw()
         return rpoint
@@ -1793,9 +2303,8 @@ class Graph(Element):
         print(self.SvgGroup.attributes)
         cur_x = float(self.SvgGroup.attributes['x'])
         cur_y = float(self.SvgGroup.attributes['y'])
-        self.SvgGroup.set_position(cur_x - x_direction,cur_y - y_direction)
+        self.SvgGroup.set_position(cur_x - x_direction, cur_y - y_direction)
         self.SvgGroup.redraw()
-
 
     def Relocate(self, x, y):
         shift_converted = self._convert_xy_to_canvas_xy(x, y)
@@ -1807,9 +2316,8 @@ class Graph(Element):
         self.SvgGroup.set_position(shift_converted[0], shift_converted[1])
         self.SvgGroup.redraw()
 
-
     def MoveFigure(self, figure, x_direction, y_direction):
-        figure = figure     # type: remi.gui.SvgCircle
+        figure = figure  # type: remi.gui.SvgCircle
         zero_converted = self._convert_xy_to_canvas_xy(0, 0)
         shift_converted = self._convert_xy_to_canvas_xy(x_direction, y_direction)
         shift_amount = (shift_converted[0] - zero_converted[0], shift_converted[1] - zero_converted[1])
@@ -1821,17 +2329,17 @@ class Graph(Element):
         try:
             cur_x = float(figure.attributes['x'])
             cur_y = float(figure.attributes['y'])
-            figure.set_position(cur_x - x_direction,cur_y - y_direction)
+            figure.set_position(cur_x - x_direction, cur_y - y_direction)
         except:
             cur_x1 = float(figure.attributes['x1'])
             cur_x2 = float(figure.attributes['x2'])
             cur_y1 = float(figure.attributes['y1'])
             cur_y2 = float(figure.attributes['y2'])
-            figure.set_coords(cur_x1-x_direction, cur_y1-y_direction, cur_x2-x_direction, cur_y2-x_direction)
+            figure.set_coords(cur_x1 - x_direction, cur_y1 - y_direction, cur_x2 - x_direction, cur_y2 - x_direction)
         figure.redraw()
 
     def RelocateFigure(self, figure, x, y):
-        figure = figure     #type: remi.gui.SvgCircle
+        figure = figure  # type: remi.gui.SvgCircle
         zero_converted = self._convert_xy_to_canvas_xy(0, 0)
         shift_converted = self._convert_xy_to_canvas_xy(x, y)
         shift_amount = (shift_converted[0] - zero_converted[0], shift_converted[1] - zero_converted[1])
@@ -1843,9 +2351,8 @@ class Graph(Element):
         figure.set_position(shift_converted[0], shift_converted[1])
         figure.redraw()
 
-
     def DeleteFigure(self, figure):
-        figure = figure     # type: remi.gui.SvgCircle
+        figure = figure  # type: remi.gui.SvgCircle
         if figure is None:
             print('*** WARNING - Your figure is None. It most likely means your did not Finalize your Window ***')
             print('Call Window.Finalize() prior to all graph operations')
@@ -1864,12 +2371,11 @@ class Graph(Element):
         self.BottomLeft = graph_bottom_left
         self.TopRight = graph_top_right
 
-
-    def _MouseDownCallback(self, widget, x,y, *args):
+    def _MouseDownCallback(self, widget, x, y, *args):
         # print(f'Mouse down {x,y}')
         self.MouseButtonDown = True
 
-    def _MouseUpCallback(self, widget, x,y, *args):
+    def _MouseUpCallback(self, widget, x, y, *args):
         self.ClickPosition = self._convert_canvas_xy_to_xy(int(x), int(y))
         self.MouseButtonDown = False
         if self.ChangeSubmits:
@@ -1878,22 +2384,20 @@ class Graph(Element):
             self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
 
     # def ClickCallback(self, emitter, x, y):
-    def ClickCallback(self, widget:remi.gui.Svg, *args):
+    def ClickCallback(self, widget: remi.gui.Svg, *args):
         return
         self.ClickPosition = (None, None)
         self.ParentForm.LastButtonClicked = self.Key if self.Key is not None else ''
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
 
     def _DragCallback(self, emitter, x, y):
-        if not self.MouseButtonDown:        # only return drag events when mouse is down
+        if not self.MouseButtonDown:  # only return drag events when mouse is down
             return
         # print(f'In Drag Callback')
         self.ClickPosition = self._convert_canvas_xy_to_xy(x, y)
         # print(f'Position {self.ClickPosition}')
         self.ParentForm.LastButtonClicked = self.Key if self.Key is not None else ''
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
-
-
 
     click_callback = ClickCallback
     delete_figure = DeleteFigure
@@ -1918,13 +2422,28 @@ class Graph(Element):
 
 # First the REMI implementation of a frame
 
-class CLASSframe( remi.gui.VBox ):
+
+class CLASSframe(remi.gui.VBox):
     def __init__(self, title, *args, **kwargs):
-        super( CLASSframe, self ).__init__(*args, **kwargs)
-        self.style.update({'overflow':'visible','border-width':'1px','border-style':'solid','border-color':'#7d7d7d'})
+        super(CLASSframe, self).__init__(*args, **kwargs)
+        self.style.update(
+            {'overflow': 'visible', 'border-width': '1px', 'border-style': 'solid', 'border-color': '#7d7d7d'}
+        )
         self.frame_label = remi.gui.Label('frame label')
-        self.frame_label.style.update({'position':'relative','overflow':'auto','background-color':'#ffffff','border-width':'1px','border-style':'solid','top':'-7px','width':'0px','height':'0px','left':'10px'})
-        self.append(self.frame_label,'frame_label')
+        self.frame_label.style.update(
+            {
+                'position': 'relative',
+                'overflow': 'auto',
+                'background-color': '#ffffff',
+                'border-width': '1px',
+                'border-style': 'solid',
+                'top': '-7px',
+                'width': '0px',
+                'height': '0px',
+                'left': '10px',
+            }
+        )
+        self.append(self.frame_label, 'frame_label')
         self.set_title(title)
 
     def set_title(self, title):
@@ -1932,9 +2451,22 @@ class CLASSframe( remi.gui.VBox ):
 
 
 class Frame(Element):
-    def __init__(self, title, layout, title_color=None, background_color=None, title_location=None,
-                 relief=DEFAULT_FRAME_RELIEF, element_justification='left', size=(None, None), font=None, pad=None, border_width=None, key=None,
-                 tooltip=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        background_color=None,
+        title_location=None,
+        relief=DEFAULT_FRAME_RELIEF,
+        element_justification='left',
+        size=(None, None),
+        font=None,
+        pad=None,
+        border_width=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Frame Element
         :param title:
@@ -1966,18 +2498,24 @@ class Frame(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self.Justification = 'left'
         self.ElementJustification = element_justification
-        self.Widget = None          # type: CLASSframe
-
-
+        self.Widget = None  # type: CLASSframe
 
         self.Layout(layout)
 
-        super().__init__(ELEM_TYPE_FRAME, background_color=background_color, text_color=title_color, size=size,
-                         font=font, pad=pad, key=key, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_FRAME,
+            background_color=background_color,
+            text_color=title_color,
+            size=size,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
         return
 
     def AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2029,7 +2567,20 @@ VSep = VerticalSeparator
 #                           Tab                                          #
 # ---------------------------------------------------------------------- #
 class Tab(Element):
-    def __init__(self, title, layout, title_color=None, background_color=None, font=None, pad=None, disabled=False, element_justification='left', border_width=None, key=None, tooltip=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        background_color=None,
+        font=None,
+        pad=None,
+        disabled=False,
+        element_justification='left',
+        border_width=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Tab Element
         :param title:
@@ -2059,15 +2610,22 @@ class Tab(Element):
         self.ElementJustification = element_justification
         self.TabID = None
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
-        self.Widget = None          # type: remi.gui.HBox
+        self.Widget = None  # type: remi.gui.HBox
         self._Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB, background_color=background_color, text_color=title_color, font=font, pad=pad,
-                         key=key, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_TAB,
+            background_color=background_color,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
         return
 
     def _AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2107,8 +2665,23 @@ class Tab(Element):
 #                           TabGroup                                     #
 # ---------------------------------------------------------------------- #
 class TabGroup(Element):
-    def __init__(self, layout, tab_location=None, title_color=None, selected_title_color=None, background_color=None,
-                 font=None, change_submits=False, enable_events=False,pad=None, border_width=None, theme=None, key=None, tooltip=None, visible=True):
+    def __init__(
+        self,
+        layout,
+        tab_location=None,
+        title_color=None,
+        selected_title_color=None,
+        background_color=None,
+        font=None,
+        change_submits=False,
+        enable_events=False,
+        pad=None,
+        border_width=None,
+        theme=None,
+        key=None,
+        tooltip=None,
+        visible=True,
+    ):
         '''
         TabGroup Element
         :param layout:
@@ -2133,7 +2706,7 @@ class TabGroup(Element):
         self.SelectedTitleColor = selected_title_color
         self.Rows = []
         self.TKNotebook = None
-        self.Widget = None      # type: remi.gui.TabBox
+        self.Widget = None  # type: remi.gui.TabBox
         self.Justification = 'left'
         self.TabCount = 0
         self.BorderWidth = border_width
@@ -2145,12 +2718,19 @@ class TabGroup(Element):
         self.Disabled = False
         self._Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB_GROUP, background_color=background_color, text_color=title_color, font=font,
-                         pad=pad, key=key, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_TAB_GROUP,
+            background_color=background_color,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
         return
 
     def _AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2188,9 +2768,28 @@ class TabGroup(Element):
 #                           Slider                                       #
 # ---------------------------------------------------------------------- #
 class Slider(Element):
-    def __init__(self, range=(None, None), default_value=None, resolution=None, tick_interval=None, orientation=None,
-                 border_width=None, relief=None, change_submits=False, enable_events=False, disabled=False, size=(None, None), font=None,
-                 background_color=None, text_color=None, key=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        range=(None, None),
+        default_value=None,
+        resolution=None,
+        tick_interval=None,
+        orientation=None,
+        border_width=None,
+        relief=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        size=(None, None),
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         """
 
         :param range:
@@ -2220,11 +2819,21 @@ class Slider(Element):
         if temp_size == (None, None):
             temp_size = (200, 20) if self.Orientation.startswith('h') else (200, 20)
         elif size[0] is not None and size[0] < 100:
-            temp_size = size[0]*10, size[1]*3
-        self.Widget = None      # type: remi.gui.Slider
+            temp_size = size[0] * 10, size[1] * 3
+        self.Widget = None  # type: remi.gui.Slider
 
-        super().__init__(ELEM_TYPE_INPUT_SLIDER, size=temp_size, font=font, background_color=background_color,
-                         text_color=text_color, key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_SLIDER,
+            size=temp_size,
+            font=font,
+            background_color=background_color,
+            text_color=text_color,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
     def Update(self, value=None, range=(None, None), disabled=None, visible=None):
@@ -2236,18 +2845,29 @@ class Slider(Element):
             self.Widget.attributes['max'] = '{}'.format(range[1])
         super().Update(self.Widget, disabled=disabled, visible=visible)
 
-    def _SliderCallback(self, widget:remi.Widget, value):
+    def _SliderCallback(self, widget: remi.Widget, value):
         self.ParentForm.LastButtonClicked = self.Key if self.Key is not None else ''
         self.ParentForm.MessageQueue.put(self.ParentForm.LastButtonClicked)
 
     update = Update
+
 
 #
 # ---------------------------------------------------------------------- #
 #                           Column                                       #
 # ---------------------------------------------------------------------- #
 class Column(Element):
-    def __init__(self, layout, background_color=None, size=(None, None), pad=None, scrollable=False, vertical_scroll_only=False, element_justification='left', key=None):
+    def __init__(
+        self,
+        layout,
+        background_color=None,
+        size=(None, None),
+        pad=None,
+        scrollable=False,
+        vertical_scroll_only=False,
+        element_justification='left',
+        key=None,
+    ):
         '''
         Column Element
         :param layout:
@@ -2280,7 +2900,7 @@ class Column(Element):
         return
 
     def AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2315,7 +2935,18 @@ Col = Column
 #                           Menu                                       #
 # ---------------------------------------------------------------------- #
 class Menu(Element):
-    def __init__(self, menu_definition, background_color=COLOR_SYSTEM_DEFAULT, text_color=None, size=(None, None), tearoff=False, pad=None, key=None, disabled=False, font=None):
+    def __init__(
+        self,
+        menu_definition,
+        background_color=COLOR_SYSTEM_DEFAULT,
+        text_color=None,
+        size=(None, None),
+        tearoff=False,
+        pad=None,
+        key=None,
+        disabled=False,
+        font=None,
+    ):
         '''
         Menu Element
         :param menu_definition:
@@ -2329,17 +2960,23 @@ class Menu(Element):
         self.MenuDefinition = menu_definition
         self.TKMenu = None
         self.Tearoff = tearoff
-        self.Widget = None          # type: remi.gui.MenuBar
+        self.Widget = None  # type: remi.gui.MenuBar
         self.MenuItemChosen = None
         self.Disabled = disabled
 
-        super().__init__(ELEM_TYPE_MENUBAR, background_color=back_color, text_color=text_color, size=size, pad=pad, key=key, font=font)
+        super().__init__(
+            ELEM_TYPE_MENUBAR,
+            background_color=back_color,
+            text_color=text_color,
+            size=size,
+            pad=pad,
+            key=key,
+            font=font,
+        )
         return
 
-
-
-    def _ChangedCallbackMenu(self,  widget, *user_data):
-        widget = widget     # type: remi.gui.MenuItem
+    def _ChangedCallbackMenu(self, widget, *user_data):
+        widget = widget  # type: remi.gui.MenuItem
         chosen = user_data[0]
         self.MenuItemChosen = chosen
         self.ParentForm.LastButtonClicked = chosen
@@ -2350,9 +2987,40 @@ class Menu(Element):
 #                           Table                                        #
 # ---------------------------------------------------------------------- #
 class Table(Element):
-    def __init__(self, values, headings=None, visible_column_map=None, col_widths=None, def_col_width=10,
-                 auto_size_columns=True, max_col_width=20, select_mode=None, display_row_numbers=False, row_header_text='Row', starting_row_num=0, num_rows=None, row_height=None, font=None, justification='right', text_color=None, background_color=None, alternating_row_color=None, row_colors=None, vertical_scroll_only=True, disabled=False,
-                 size=(None, None), change_submits=False, enable_events=False, bind_return_key=False, pad=None, key=None, tooltip=None, right_click_menu=None, visible=True, size_px=(None, None)):
+    def __init__(
+        self,
+        values,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        display_row_numbers=False,
+        row_header_text='Row',
+        starting_row_num=0,
+        num_rows=None,
+        row_height=None,
+        font=None,
+        justification='right',
+        text_color=None,
+        background_color=None,
+        alternating_row_color=None,
+        row_colors=None,
+        vertical_scroll_only=True,
+        disabled=False,
+        size=(None, None),
+        change_submits=False,
+        enable_events=False,
+        bind_return_key=False,
+        pad=None,
+        key=None,
+        tooltip=None,
+        right_click_menu=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Table
         :param values:
@@ -2402,17 +3070,27 @@ class Table(Element):
         self.SelectedRows = []
         self.ChangeSubmits = change_submits or enable_events
         self.BindReturnKey = bind_return_key
-        self.StartingRowNumber = starting_row_num        # When displaying row numbers, where to start
+        self.StartingRowNumber = starting_row_num  # When displaying row numbers, where to start
         self.RowHeaderText = row_header_text
         self.RightClickMenu = right_click_menu
         self.RowColors = row_colors
         self.Disabled = disabled
         self.SelectedItem = None
         self.SelectedRow = None
-        self.Widget = None                      # type: remi.Table
+        self.Widget = None  # type: remi.Table
 
-        super().__init__(ELEM_TYPE_TABLE, text_color=text_color, background_color=background_color, font=font,
-                         size=size, pad=pad, key=key, tooltip=tooltip, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_TABLE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            size=size,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
     def Update(self, values=None):
@@ -2434,7 +3112,6 @@ class Table(Element):
             self.Values = values
             self.SelectedRows = []
 
-
     def _on_table_row_click(self, table, row, item):
         # self.SelectedRow = row          # type: remi.gui.TableRow
         self.SelectedItem = item.get_text()
@@ -2455,17 +3132,32 @@ class Table(Element):
             self.ParentForm.LastButtonClicked = ''
 
 
-
-
 # ---------------------------------------------------------------------- #
 #                           Tree                                         #
 # ---------------------------------------------------------------------- #
 class Tree(Element):
-    def __init__(self, data=None, headings=None, visible_column_map=None, col_widths=None, col0_width=10,
-                 def_col_width=10, auto_size_columns=True, max_col_width=20, select_mode=None, show_expanded=False,
-                 change_submits=False, font=None,
-                 justification='right', text_color=None, background_color=None, num_rows=None, pad=None, key=None,
-                 tooltip=None):
+    def __init__(
+        self,
+        data=None,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        col0_width=10,
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        show_expanded=False,
+        change_submits=False,
+        font=None,
+        justification='right',
+        text_color=None,
+        background_color=None,
+        num_rows=None,
+        pad=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Tree Element
         :param headings:
@@ -2505,15 +3197,22 @@ class Tree(Element):
 
         print('*** Tree Element not yet supported ***')
 
-        super().__init__(ELEM_TYPE_TREE, text_color=text_color, background_color=background_color, font=font, pad=pad,
-                         key=key, tooltip=tooltip)
-
+        super().__init__(
+            ELEM_TYPE_TREE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
 
     def add_treeview_data(self, node):
         # print(f'Inserting {node.key} under parent {node.parent}')
         if node.key != '':
-            self.TKTreeview.insert(node.parent, 'end', node.key, text=node.text, values=node.values,
-                                   open=self.ShowExpanded)
+            self.TKTreeview.insert(
+                node.parent, 'end', node.key, text=node.text, values=node.values, open=self.ShowExpanded
+            )
         for node in node.children:
             self.add_treeview_data(node)
 
@@ -2571,10 +3270,12 @@ class TreeData(object):
 
     def _NodeStr(self, node, level):
         return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text)] +
-            [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
+            [str(node.key) + ' : ' + str(node.text)]
+            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
+        )
 
     insert = Insert
+
 
 # ---------------------------------------------------------------------- #
 #                           Error Element                                #
@@ -2591,11 +3292,13 @@ class ErrorElement(Element):
         return
 
     def Update(self, *args, **kwargs):
-        PopupError('Keyword error in Update',
-                   'You need to stop this madness and check your spelling',
-                   'Bad key = {}'.format(self.Key),
-                   'Your bad line of code may resemble this:',
-                   'window.FindElement("{}")'.format(self.Key))
+        PopupError(
+            'Keyword error in Update',
+            'You need to stop this madness and check your spelling',
+            'Bad key = {}'.format(self.Key),
+            'Your bad line of code may resemble this:',
+            'window.FindElement("{}")'.format(self.Key),
+        )
         return self
 
     def Get(self):
@@ -2620,18 +3323,51 @@ class Window:
     stdout_string_io = None
     stdout_location = None
     port_number = 6900
-    active_windows = [ ]        # type:  [Window]
-    App = None                  # type: remi.App
+    active_windows = []  # type:  [Window]
+    App = None  # type: remi.App
 
-    def __init__(self, title, layout=None, default_element_size=DEFAULT_ELEMENT_SIZE, default_button_element_size=(None, None),
-                 auto_size_text=None, auto_size_buttons=None, location=(None, None), size=(None, None),
-                 element_padding=None, button_color=None, font=None,
-                 progress_bar_color=(None, None), background_color=None, border_depth=None, auto_close=False,
-                 auto_close_duration=None, icon=DEFAULT_BASE64_ICON, force_toplevel=False,
-                 alpha_channel=1, return_keyboard_events=False, return_key_down_events=False, use_default_focus=True, text_justification=None,
-                 no_titlebar=False, grab_anywhere=False, keep_on_top=False, resizable=True, disable_close=False,margins=(None, None), element_justification='left',
-                 disable_minimize=False, background_image=None, finalize=False,
-                 web_debug=False, web_ip='0.0.0.0', web_port=0, web_start_browser=True, web_update_interval=.0000001, web_multiple_instance=False ):
+    def __init__(
+        self,
+        title,
+        layout=None,
+        default_element_size=DEFAULT_ELEMENT_SIZE,
+        default_button_element_size=(None, None),
+        auto_size_text=None,
+        auto_size_buttons=None,
+        location=(None, None),
+        size=(None, None),
+        element_padding=None,
+        button_color=None,
+        font=None,
+        progress_bar_color=(None, None),
+        background_color=None,
+        border_depth=None,
+        auto_close=False,
+        auto_close_duration=None,
+        icon=DEFAULT_BASE64_ICON,
+        force_toplevel=False,
+        alpha_channel=1,
+        return_keyboard_events=False,
+        return_key_down_events=False,
+        use_default_focus=True,
+        text_justification=None,
+        no_titlebar=False,
+        grab_anywhere=False,
+        keep_on_top=False,
+        resizable=True,
+        disable_close=False,
+        margins=(None, None),
+        element_justification='left',
+        disable_minimize=False,
+        background_image=None,
+        finalize=False,
+        web_debug=False,
+        web_ip='0.0.0.0',
+        web_port=0,
+        web_start_browser=True,
+        web_update_interval=0.0000001,
+        web_multiple_instance=False,
+    ):
         '''
 
         :param title:
@@ -2667,9 +3403,11 @@ class Window:
         self.Title = title
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = convert_tkinter_size_to_Wx(default_element_size)
-        self.DefaultButtonElementSize = convert_tkinter_size_to_Wx(
-            default_button_element_size) if default_button_element_size != (
-            None, None) else DEFAULT_BUTTON_ELEMENT_SIZE
+        self.DefaultButtonElementSize = (
+            convert_tkinter_size_to_Wx(default_button_element_size)
+            if default_button_element_size != (None, None)
+            else DEFAULT_BUTTON_ELEMENT_SIZE
+        )
         self.Location = location
         self.ButtonColor = button_color if button_color else DEFAULT_BUTTON_COLOR
         self.BackgroundColor = background_color if background_color else DEFAULT_BACKGROUND_COLOR
@@ -2722,12 +3460,12 @@ class Window:
         self.BackgroundImage = background_image
         self.XFound = False
         self.DisableMinimize = disable_minimize
-        self.OutputElementForStdOut = None      # type: Output
+        self.OutputElementForStdOut = None  # type: Output
         self.Justification = 'left'
         self.ElementJustification = element_justification
         self.IgnoreClose = False
         self.thread_id = None
-        self.App = None         # type: Window.MyApp
+        self.App = None  # type: Window.MyApp
         self.web_debug = web_debug
         self.web_ip = web_ip
         self.web_port = web_port
@@ -2735,7 +3473,7 @@ class Window:
         self.web_update_interval = web_update_interval
         self.web_multiple_instance = web_multiple_instance
         self.MessageQueue = Queue()
-        self.master_widget = None       # type: remi.gui.VBox
+        self.master_widget = None  # type: remi.gui.VBox
         self.UniqueKeyCounter = 0
 
         if layout is not None:
@@ -2755,7 +3493,7 @@ class Window:
 
     # ------------------------- Add ONE Row to Form ------------------------- #
     def AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2779,7 +3517,8 @@ class Window:
 
     def LayoutAndRead(self, rows, non_blocking=False):
         raise DeprecationWarning(
-            'LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()')
+            'LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()'
+        )
         # self.AddRows(rows)
         # self.Show(non_blocking=non_blocking)
         # return self.ReturnValues
@@ -2818,9 +3557,6 @@ class Window:
         # -=-=-=-=-=-=-=-=- RUN the GUI -=-=-=-=-=-=-=-=- ##
         StartupTK(self)
 
-
-
-
     def Read(self, timeout=None, timeout_key=TIMEOUT_KEY, close=False):
         """
         THE biggest deal method in the Window class! This is how you get all of your data from your Window.
@@ -2838,8 +3574,6 @@ class Window:
             self.close()
 
         return results
-
-
 
     def _read(self, timeout=None, timeout_key=TIMEOUT_KEY):
         # if timeout == 0:  # timeout of zero runs the old readnonblocking
@@ -2883,9 +3617,9 @@ class Window:
         self.CurrentlyRunningMainloop = True
         if timeout is not None:
             try:
-                self.LastButtonClicked = self.MessageQueue.get(timeout=(timeout if timeout else .001)/1000)
+                self.LastButtonClicked = self.MessageQueue.get(timeout=(timeout if timeout else 0.001) / 1000)
                 # print(f'Got event {self.LastButtonClicked}')
-            except:             # timeout
+            except:  # timeout
                 self.LastButtonClicked = timeout_key
         else:
             self.LastButtonClicked = self.MessageQueue.get()
@@ -2904,13 +3638,13 @@ class Window:
         # if Window.stdout_is_rerouted:
         #     sys.stdout = Window.stdout_location
         # if self.RootNeedsDestroying:
-            # self.LastButtonClicked = None
-            # self.App.Close()
-            # try:
-            #     self.MasterFrame.Close()
-            # except:
-            #     pass
-            # Window._DecrementOpenCount()
+        # self.LastButtonClicked = None
+        # self.App.Close()
+        # try:
+        #     self.MasterFrame.Close()
+        # except:
+        #     pass
+        # Window._DecrementOpenCount()
         # if form was closed with X
         # if self.LastButtonClicked is None and self.LastKeyboardEvent is None and self.ReturnValues[0] is None:
         #     Window._DecrementOpenCount()
@@ -2927,8 +3661,8 @@ class Window:
         #     elif not self.XFound and self.ReturnValues[
         #         0] is None:  # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
         #         print("*** Faking timeout ***")
-                # self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
-            # return self.ReturnValues
+        # self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
+        # return self.ReturnValues
 
     def _ReadNonBlocking(self):
         if self.TKrootDestroyed:
@@ -2953,7 +3687,6 @@ class Window:
         # while self.App.HasPendingEvents():
         #     self.App.ProcessPendingEvents()
         return BuildResults(self, False, self)
-
 
     # ------------------------- SetIcon - set the window's fav icon ------------------------- #
     def SetIcon(self, icon=None, pngbase64=None):
@@ -3010,15 +3743,14 @@ class Window:
             self.App.ExitMainLoop()
 
     def on_key_down(self, emitter, key, keycode, ctrl, shift, alt):
-        self.LastButtonClicked = 'DOWN'+key
+        self.LastButtonClicked = 'DOWN' + key
         self.MessageQueue.put(self.LastButtonClicked)
-        self.KeyInfoDict =  { 'key':key, 'keycode':keycode, 'ctrl': ctrl, 'shift':shift, 'alt':alt }
+        self.KeyInfoDict = {'key': key, 'keycode': keycode, 'ctrl': ctrl, 'shift': shift, 'alt': alt}
 
     def on_key_up(self, emitter, key, keycode, ctrl, shift, alt):
         self.LastButtonClicked = key
         self.MessageQueue.put(self.LastButtonClicked)
-        self.KeyInfoDict =  { 'key':key, 'keycode':keycode, 'ctrl': ctrl, 'shift':shift, 'alt':alt }
-
+        self.KeyInfoDict = {'key': key, 'keycode': keycode, 'ctrl': ctrl, 'shift': shift, 'alt': alt}
 
     def callback_keyboard_char(self, event):
         self.LastButtonClicked = None
@@ -3071,10 +3803,12 @@ class Window:
         if element is None:
             if not silent_on_error:
                 print('*** WARNING = FindElement did not find the key. Please check your key\'s spelling ***')
-                PopupError('Keyword error in FindElement Call',
-                           'Bad key = {}'.format(key),
-                           'Your bad line of code may resemble this:',
-                           'window.FindElement("{}")'.format(key))
+                PopupError(
+                    'Keyword error in FindElement Call',
+                    'Bad key = {}'.format(key),
+                    'Your bad line of code may resemble this:',
+                    'window.FindElement("{}")'.format(key),
+                )
                 return ErrorElement(key=key)
             else:
                 return False
@@ -3084,7 +3818,7 @@ class Window:
 
     def _BuildKeyDict(self):
         dict = {}
-        self.AllKeysDict = self._BuildKeyDictForWindow(self,self, dict)
+        self.AllKeysDict = self._BuildKeyDictForWindow(self, self, dict)
         # print(f'keys built = {self.AllKeysDict}')
 
     def _BuildKeyDictForWindow(self, top_window, window, key_dict):
@@ -3098,23 +3832,42 @@ class Window:
                     key_dict = self._BuildKeyDictForWindow(top_window, element, key_dict)
                 if element.Type == ELEM_TYPE_TAB:
                     key_dict = self._BuildKeyDictForWindow(top_window, element, key_dict)
-                if element.Key is None:   # if no key has been assigned.... create one for input elements
+                if element.Key is None:  # if no key has been assigned.... create one for input elements
                     if element.Type == ELEM_TYPE_BUTTON:
                         element.Key = element.ButtonText
-                    if element.Type in (ELEM_TYPE_MENUBAR, ELEM_TYPE_BUTTONMENU, ELEM_TYPE_CANVAS,
-                                        ELEM_TYPE_INPUT_SLIDER, ELEM_TYPE_GRAPH, ELEM_TYPE_IMAGE,
-                                        ELEM_TYPE_INPUT_CHECKBOX, ELEM_TYPE_INPUT_LISTBOX, ELEM_TYPE_INPUT_COMBO,
-                                        ELEM_TYPE_INPUT_MULTILINE, ELEM_TYPE_INPUT_OPTION_MENU, ELEM_TYPE_INPUT_SPIN,
-                                        ELEM_TYPE_TABLE, ELEM_TYPE_TREE,
-                                        ELEM_TYPE_INPUT_TEXT):
+                    if element.Type in (
+                        ELEM_TYPE_MENUBAR,
+                        ELEM_TYPE_BUTTONMENU,
+                        ELEM_TYPE_CANVAS,
+                        ELEM_TYPE_INPUT_SLIDER,
+                        ELEM_TYPE_GRAPH,
+                        ELEM_TYPE_IMAGE,
+                        ELEM_TYPE_INPUT_CHECKBOX,
+                        ELEM_TYPE_INPUT_LISTBOX,
+                        ELEM_TYPE_INPUT_COMBO,
+                        ELEM_TYPE_INPUT_MULTILINE,
+                        ELEM_TYPE_INPUT_OPTION_MENU,
+                        ELEM_TYPE_INPUT_SPIN,
+                        ELEM_TYPE_TABLE,
+                        ELEM_TYPE_TREE,
+                        ELEM_TYPE_INPUT_TEXT,
+                    ):
                         element.Key = top_window.DictionaryKeyCounter
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        print('*** Duplicate key found in your layout {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None
+                        (
+                            print('*** Duplicate key found in your layout {} ***'.format(element.Key))
+                            if element.Type != ELEM_TYPE_BUTTON
+                            else None
+                        )
                         element.Key = element.Key + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
-                        print('*** Replaced new key with {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None
+                        (
+                            print('*** Replaced new key with {} ***'.format(element.Key))
+                            if element.Type != ELEM_TYPE_BUTTON
+                            else None
+                        )
                     key_dict[element.Key] = element
         return key_dict
 
@@ -3138,8 +3891,8 @@ class Window:
         except:
             print('*** Error loading form to disk ***')
 
-    def GetScreenDimensions(self):      # TODO - Not sure what to return so (0,0) for now
-        size = (0,0)
+    def GetScreenDimensions(self):  # TODO - Not sure what to return so (0,0) for now
+        size = (0, 0)
         return size
 
     def Move(self, x, y):
@@ -3162,9 +3915,9 @@ class Window:
 
     def Close(self):
         if len(Window.active_windows) != 0:
-            del(Window.active_windows[-1])          # delete current window from active windows
+            del Window.active_windows[-1]  # delete current window from active windows
             if len(Window.active_windows) != 0:
-                window = Window.active_windows[-1]      # get prior window to change to
+                window = Window.active_windows[-1]  # get prior window to change to
                 Window.App.set_root_widget(window.master_widget)
             else:
                 self.App.close()
@@ -3193,7 +3946,7 @@ class Window:
 
     def UnHide(self):
         if self._Hidden:
-            del(self.master_widget.attributes['hidden'])
+            del self.master_widget.attributes['hidden']
             self._Hidden = False
 
     def Disappear(self):
@@ -3226,7 +3979,6 @@ class Window:
     def CurrentLocation(self):
         location = self.MasterFrame.GetPosition()
         return location
-
 
     @property
     def Size(self):
@@ -3271,8 +4023,6 @@ class Window:
         """
         return self.Read(*args, **kwargs)
 
-
-
     add_row = AddRow
     add_rows = AddRows
     alpha_channel = AlphaChannel
@@ -3310,10 +4060,6 @@ class Window:
     un_hide = UnHide
     visibility_changed = VisibilityChanged
 
-
-
-
-
     def remi_thread(self):
         # print('Remi Thread started')
         logging.getLogger('remi').setLevel(logging.CRITICAL)
@@ -3331,14 +4077,17 @@ class Window:
         # s.start()
         Window.port_number += 1
         try:
-            remi.start(self.MyApp,
-                       title=self.Title,
-                       debug=self.web_debug,
-                       address=self.web_ip,
-                       port=self.web_port,
-                       multiple_instance=self.web_multiple_instance,
-                       start_browser=self.web_start_browser,
-                       update_interval=self.web_update_interval, userdata=(self,))
+            remi.start(
+                self.MyApp,
+                title=self.Title,
+                debug=self.web_debug,
+                address=self.web_ip,
+                port=self.web_port,
+                multiple_instance=self.web_multiple_instance,
+                start_browser=self.web_start_browser,
+                update_interval=self.web_update_interval,
+                userdata=(self,),
+            )
 
         except:
             print('*** ERROR Caught inside Remi ***')
@@ -3348,27 +4097,41 @@ class Window:
         # remi.start(self.MyApp, standalone=True, debug=True, userdata=(self,) )            # Can't do this because of a threading problem
         print('Returned from Remi Start command... now sending None event')
 
-        self.MessageQueue.put(None)     # if returned from start call, then the window has been destroyed and a None event should be generated
+        self.MessageQueue.put(
+            None
+        )  # if returned from start call, then the window has been destroyed and a None event should be generated
 
     class MyApp(remi.App):
-        def __init__(self,*args, userdata2=None):
+        def __init__(self, *args, userdata2=None):
             # self.window = window    # type:  Window
             # print(args[-1])
             if userdata2 is None:
                 userdata = args[-1].userdata
-                self.window = userdata[0]       # type: Window
+                self.window = userdata[0]  # type: Window
             else:
-                self.window = userdata2         # type: Window
+                self.window = userdata2  # type: Window
             self.master_widget = None
             # print("new App instance %s" % str(id(self)))
             # self.window.App = self
-            #Window.App = self
+            # Window.App = self
             self.lines_shown = []
 
             if userdata2 is None:
                 # res_path = os.path.dirname(os.path.abspath(__file__))
                 # print('res path', res_path)
-                super(Window.MyApp, self).__init__(*args,  static_file_path={'C':'c:','c':'c:','D':'d:', 'd':'d:', 'E':'e:', 'e':'e:', 'dot':'.', '.':'.'})
+                super(Window.MyApp, self).__init__(
+                    *args,
+                    static_file_path={
+                        'C': 'c:',
+                        'c': 'c:',
+                        'D': 'd:',
+                        'd': 'd:',
+                        'E': 'e:',
+                        'e': 'e:',
+                        'dot': '.',
+                        '.': '.',
+                    }
+                )
 
         def _instance(self):
             remi.App._instance(self)
@@ -3416,12 +4179,11 @@ class Window:
             self.window.master_widget = self.master_widget
             # if self.window.WindowIcon:
             #     print('placing icon')
-                # self.page.children['head'].set_icon_file("/res:logo.png")
-                # self.page.children['head'].set_icon_data( base64_data=self.window.WindowIcon, mimetype="image/png" )
+            # self.page.children['head'].set_icon_file("/res:logo.png")
+            # self.page.children['head'].set_icon_data( base64_data=self.window.WindowIcon, mimetype="image/png" )
 
-            self.window.MessageQueue.put('Layout complete')     # signal the main code that the layout is all done
-            return self.master_widget          # returning the root widget
-
+            self.window.MessageQueue.put('Layout complete')  # signal the main code that the layout is all done
+            return self.master_widget  # returning the root widget
 
         def on_window_close(self):
             # here you can handle the unload
@@ -3432,14 +4194,14 @@ class Window:
             # self.window.MessageQueue.put(None)
             print('server stopped')
 
+
 FlexForm = Window
-
-
 
 
 # =========================================================================== #
 # Stops the mainloop and sets the event information                           #
 # =========================================================================== #
+
 
 def element_callback_quit_mainloop(element):
     if element.Key is not None:
@@ -3468,13 +4230,15 @@ def convert_tkinter_size_to_Wx(size):
     :return: size in pixels, pixels
     """
     qtsize = size
-    if size[1] is not None and size[1] < DEFAULT_PIXEL_TO_CHARS_CUTOFF:        # change from character based size to pixels (roughly)
-        qtsize = size[0]*DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1]*DEFAULT_PIXELS_TO_CHARS_SCALING[1]
+    if (
+        size[1] is not None and size[1] < DEFAULT_PIXEL_TO_CHARS_CUTOFF
+    ):  # change from character based size to pixels (roughly)
+        qtsize = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
     return qtsize
 
 
 def base64_to_style_image(base64_image):
-    x ="url('data:image/png;base64,"
+    x = "url('data:image/png;base64,"
     x += str(base64_image)
     x += "')"
     # print(x)
@@ -3506,8 +4270,6 @@ def font_parse_string(font):
     return family, point_size, style
 
 
-
-
 # ################################################################################
 # ################################################################################
 #  END OF ELEMENT DEFINITIONS
@@ -3521,213 +4283,744 @@ def font_parse_string(font):
 
 
 # -------------------------  FOLDER BROWSE Element lazy function  ------------------------- #
-def FolderBrowse(button_text='Browse', target=(ThisRow, -1), initial_folder=None, tooltip=None, size=(None, None),
-                 auto_size_button=None, button_color=None, disabled=False, change_submits=False, font=None, pad=None,
-                 key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FOLDER, target=target,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  disabled=disabled, button_color=button_color, change_submits=change_submits, font=font, pad=pad,
-                  key=key)
+def FolderBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FOLDER,
+        target=target,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        change_submits=change_submits,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileBrowse(button_text='Browse', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), initial_folder=None,
-               tooltip=None, size=(None, None), auto_size_button=None, button_color=None, change_submits=False,
-               font=None, disabled=False,
-               pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  change_submits=change_submits, disabled=disabled, button_color=button_color, font=font, pad=pad,
-                  key=key)
+def FileBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    disabled=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        change_submits=change_submits,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  FILES BROWSE Element (Multiple file selection) lazy function  ------------------------- #
-def FilesBrowse(button_text='Browse', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), disabled=False,
-                initial_folder=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                change_submits=False,
-                font=None, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILES, target=target, file_types=file_types,
-                  initial_folder=initial_folder, change_submits=change_submits, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button,
-                  disabled=disabled, button_color=button_color, font=font, pad=pad, key=key)
+def FilesBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    disabled=False,
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILES,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        change_submits=change_submits,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileSaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), initial_folder=None,
-               disabled=False, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-               change_submits=False, font=None,
-               pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits,
-                  font=font, pad=pad, key=key)
+def FileSaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    initial_folder=None,
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  SAVE AS Element lazy function  ------------------------- #
-def SaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), initial_folder=None,
-           disabled=False, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-           change_submits=False, font=None,
-           pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits,
-                  font=font, pad=pad, key=key)
+def SaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    initial_folder=None,
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  SAVE BUTTON Element lazy function  ------------------------- #
-def Save(button_text='Save', size=(None, None), auto_size_button=None, button_color=None, bind_return_key=True,
-         disabled=False, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Save(
+    button_text='Save',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    bind_return_key=True,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  SUBMIT BUTTON Element lazy function  ------------------------- #
-def Submit(button_text='Submit', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Submit(
+    button_text='Submit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  OPEN BUTTON Element lazy function  ------------------------- #
-def Open(button_text='Open', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-         bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Open(
+    button_text='Open',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  OK BUTTON Element lazy function  ------------------------- #
-def OK(button_text='OK', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def OK(
+    button_text='OK',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  YES BUTTON Element lazy function  ------------------------- #
-def Ok(button_text='Ok', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Ok(
+    button_text='Ok',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  CANCEL BUTTON Element lazy function  ------------------------- #
-def Cancel(button_text='Cancel', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           tooltip=None, font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Cancel(
+    button_text='Cancel',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  QUIT BUTTON Element lazy function  ------------------------- #
-def Quit(button_text='Quit', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Quit(
+    button_text='Quit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Exit BUTTON Element lazy function  ------------------------- #
-def Exit(button_text='Exit', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
-
+def Exit(
+    button_text='Exit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Up arrow BUTTON Element lazy function  ------------------------- #
-def Up(button_text='▲', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Up(
+    button_text='▲',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
+
 
 # -------------------------  Down arrow BUTTON Element lazy function  ------------------------- #
-def Down(button_text='▼', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Down(
+    button_text='▼',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
+
 
 # -------------------------  Left arrow BUTTON Element lazy function  ------------------------- #
-def Left(button_text='◄', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Left(
+    button_text='◄',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Right arrow BUTTON Element lazy function  ------------------------- #
-def Right(button_text='►', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
-
+def Right(
+    button_text='►',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  YES BUTTON Element lazy function  ------------------------- #
-def Yes(button_text='Yes', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Yes(
+    button_text='Yes',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  NO BUTTON Element lazy function  ------------------------- #
-def No(button_text='No', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-       font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def No(
+    button_text='No',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  NO BUTTON Element lazy function  ------------------------- #
-def Help(button_text='Help', size=(None, None), auto_size_button=None, button_color=None, disabled=False, font=None,
-         tooltip=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Help(
+    button_text='Help',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    tooltip=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  GENERIC BUTTON Element lazy function  ------------------------- #
-def SimpleButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                 border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                 font=None, bind_return_key=False, disabled=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def SimpleButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  CLOSE BUTTON Element lazy function  ------------------------- #
-def CloseButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-                bind_return_key=False, disabled=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def CloseButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 CButton = CloseButton
 
 
 # -------------------------  GENERIC BUTTON Element lazy function  ------------------------- #
-def ReadButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-               border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-               bind_return_key=False, disabled=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def ReadButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 ReadFormButton = ReadButton
@@ -3735,56 +5028,176 @@ RButton = ReadFormButton
 
 
 # -------------------------  Realtime BUTTON Element lazy function  ------------------------- #
-def RealtimeButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                   border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                   font=None, disabled=False, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_REALTIME, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def RealtimeButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_REALTIME,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Dummy BUTTON Element lazy function  ------------------------- #
-def DummyButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-                disabled=False, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN_ONLY, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  button_color=button_color, font=font, disabled=disabled, bind_return_key=bind_return_key, focus=focus,
-                  pad=pad, key=key)
+def DummyButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN_ONLY,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def CalendarButton(button_text, target=(None, None), close_when_date_chosen=True, default_date_m_d_y=(None, None, None),
-                   image_filename=None, image_data=None, image_size=(None, None),
-                   image_subsample=None, tooltip=None, border_width=None, size=(None, None), auto_size_button=None,
-                   button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None,
-                   key=None):
-    button = Button(button_text=button_text, button_type=BUTTON_TYPE_CALENDAR_CHOOSER, target=target,
-                    image_filename=image_filename, image_data=image_data, image_size=image_size,
-                    image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size,
-                    auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                    bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def CalendarButton(
+    button_text,
+    target=(None, None),
+    close_when_date_chosen=True,
+    default_date_m_d_y=(None, None, None),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    button = Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CALENDAR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
     button.CalendarCloseWhenChosen = close_when_date_chosen
     button.DefaultDate_M_D_Y = default_date_m_d_y
     return button
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def ColorChooserButton(button_text, target=(None, None), image_filename=None, image_data=None, image_size=(None, None),
-                       image_subsample=None, tooltip=None, border_width=None, size=(None, None), auto_size_button=None,
-                       button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None,
-                       key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_COLOR_CHOOSER, target=target,
-                  image_filename=image_filename, image_data=image_data, image_size=image_size,
-                  image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def ColorChooserButton(
+    button_text,
+    target=(None, None),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_COLOR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 #####################################  -----  RESULTS   ------ ##################################################
+
 
 def AddToReturnDictionary(form, element, value):
     form.ReturnValuesDictionary[element.Key] = value
@@ -3897,12 +5310,16 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
 
             if not initialize_only:
                 if element.Type == ELEM_TYPE_INPUT_TEXT:
-                    element = element       # type: InputText
+                    element = element  # type: InputText
                     value = element.Widget.get_value()
-                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
+                    if (
+                        not top_level_form.NonBlocking
+                        and not element.do_not_clear
+                        and not top_level_form.ReturnKeyboardEvents
+                    ):
                         element.Widget.set_value('')
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
-                    element = element       # type: Checkbox
+                    element = element  # type: Checkbox
                     value = element.Widget.get_value()
                 elif element.Type == ELEM_TYPE_INPUT_RADIO:
                     # RadVar = element.TKIntVar.get()
@@ -3932,17 +5349,19 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 elif element.Type == ELEM_TYPE_INPUT_LISTBOX:
                     element = element  # type: Listbox
                     value = element.Widget.get_value()
-                    value = [value,]
+                    value = [
+                        value,
+                    ]
                     # items = element.TKListbox.curselection()
                     # value = [element.Values[int(item)] for item in items]
                 elif element.Type == ELEM_TYPE_INPUT_SPIN:
-                    element = element       # type: Spin
+                    element = element  # type: Spin
                     value = element.Widget.get_value()
                 elif element.Type == ELEM_TYPE_INPUT_SLIDER:
-                    element = element       # type: Slider
+                    element = element  # type: Slider
                     value = element.Widget.get_value()
                 elif element.Type == ELEM_TYPE_INPUT_MULTILINE:
-                    element = element # type: Multiline
+                    element = element  # type: Multiline
                     if element.WriteOnly:
                         continue
                     value = element.Widget.get_value()
@@ -3955,8 +5374,10 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                     except:
                         value = None
                 elif element.Type == ELEM_TYPE_TABLE:
-                    element = element   # type:Table
-                    value = [element.SelectedRow,]
+                    element = element  # type:Table
+                    value = [
+                        element.SelectedRow,
+                    ]
                 elif element.Type == ELEM_TYPE_TREE:
                     value = element.SelectedRows
                 elif element.Type == ELEM_TYPE_GRAPH:
@@ -3967,26 +5388,43 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 value = None
 
             # if an input type element, update the results
-            if element.Type != ELEM_TYPE_BUTTON and \
-                    element.Type != ELEM_TYPE_TEXT and \
-                    element.Type != ELEM_TYPE_IMAGE and \
-                    element.Type != ELEM_TYPE_OUTPUT and \
-                    element.Type != ELEM_TYPE_PROGRESS_BAR and \
-                    element.Type != ELEM_TYPE_COLUMN and \
-                    element.Type != ELEM_TYPE_FRAME \
-                    and element.Type != ELEM_TYPE_TAB:
+            if (
+                element.Type != ELEM_TYPE_BUTTON
+                and element.Type != ELEM_TYPE_TEXT
+                and element.Type != ELEM_TYPE_IMAGE
+                and element.Type != ELEM_TYPE_OUTPUT
+                and element.Type != ELEM_TYPE_PROGRESS_BAR
+                and element.Type != ELEM_TYPE_COLUMN
+                and element.Type != ELEM_TYPE_FRAME
+                and element.Type != ELEM_TYPE_TAB
+            ):
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
-            elif (element.Type == ELEM_TYPE_BUTTON and
-                  element.BType == BUTTON_TYPE_CALENDAR_CHOOSER and
-                  element.Target == (None, None)) or \
-                    (element.Type == ELEM_TYPE_BUTTON and
-                     element.BType == BUTTON_TYPE_COLOR_CHOOSER and
-                     element.Target == (None, None)) or \
-                    (element.Type == ELEM_TYPE_BUTTON
-                     and element.Key is not None and
-                     (element.BType in (BUTTON_TYPE_SAVEAS_FILE, BUTTON_TYPE_BROWSE_FILE, BUTTON_TYPE_BROWSE_FILES,
-                                        BUTTON_TYPE_BROWSE_FOLDER))):
+            elif (
+                (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER
+                    and element.Target == (None, None)
+                )
+                or (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.BType == BUTTON_TYPE_COLOR_CHOOSER
+                    and element.Target == (None, None)
+                )
+                or (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.Key is not None
+                    and (
+                        element.BType
+                        in (
+                            BUTTON_TYPE_SAVEAS_FILE,
+                            BUTTON_TYPE_BROWSE_FILE,
+                            BUTTON_TYPE_BROWSE_FILES,
+                            BUTTON_TYPE_BROWSE_FOLDER,
+                        )
+                    )
+                )
+            ):
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
 
@@ -4117,25 +5555,33 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False)
             pos = sub_menu_info.find('&')
             if pos != -1:
                 if pos == 0 or sub_menu_info[pos - 1] != '\\':
-                    sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1:]
+                    sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1 :]
             if sub_menu_info == '---':
                 # top_menu.add('separator')
                 pass
             else:
                 try:
-                    item_without_key = sub_menu_info[:sub_menu_info.index(MENU_KEY_SEPARATOR)]
+                    item_without_key = sub_menu_info[: sub_menu_info.index(MENU_KEY_SEPARATOR)]
                 except:
                     item_without_key = sub_menu_info
                 if item_without_key[0] == MENU_DISABLED_CHARACTER:
-                    menu_item =  remi.gui.MenuItem(item_without_key[1:], width=100, height=30)
+                    menu_item = remi.gui.MenuItem(item_without_key[1:], width=100, height=30)
                     menu_item.set_enabled(False)
-                    top_menu.append([menu_item,])
+                    top_menu.append(
+                        [
+                            menu_item,
+                        ]
+                    )
 
                     # TODO add callback here!
                     # TODO disable entry
                 else:
-                    menu_item =  remi.gui.MenuItem(item_without_key, width=100, height=30)
-                    top_menu.append([menu_item,])
+                    menu_item = remi.gui.MenuItem(item_without_key, width=100, height=30)
+                    top_menu.append(
+                        [
+                            menu_item,
+                        ]
+                    )
                 # menu_item.set_on_click_listener(element._ChangedCallbackMenu, sub_menu_info)
                 menu_item.onclick.connect(element._ChangedCallbackMenu, sub_menu_info)
     else:
@@ -4147,16 +5593,22 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False)
                     pos = sub_menu_info[i].find('&')
                     if pos != -1:
                         if pos == 0 or sub_menu_info[i][pos - 1] != '\\':
-                            sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1:]
+                            sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1 :]
                     if sub_menu_info[i][0] == MENU_DISABLED_CHARACTER:
-                        new_menu = remi.gui.MenuItem(sub_menu_info[i][len(MENU_DISABLED_CHARACTER):], width=100, height=30)
+                        new_menu = remi.gui.MenuItem(
+                            sub_menu_info[i][len(MENU_DISABLED_CHARACTER) :], width=100, height=30
+                        )
                         new_menu.set_enabled(False)
 
                         # TODO Disable Entry
                     else:
                         new_menu = remi.gui.MenuItem(sub_menu_info[i], width=100, height=30)
 
-                    top_menu.append([new_menu,])
+                    top_menu.append(
+                        [
+                            new_menu,
+                        ]
+                    )
                     return_val = new_menu
                     AddMenuItem(new_menu, sub_menu_info[i + 1], element, is_sub_menu=True)
                     i += 1  # skip the next one
@@ -4166,6 +5618,7 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False)
                 AddMenuItem(top_menu, item, element)
             i += 1
     return return_val
+
 
 """
           :::::::::       ::::::::::         :::   :::       :::::::::::
@@ -4179,8 +5632,6 @@ def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False)
 # ------------------------------------------------------------------------------------------------------------ #
 # ===================================== REMI CODE STARTS HERE ================================================ #
 # ------------------------------------------------------------------------------------------------------------ #
-
-
 
 
 def PackFormIntoFrame(form, containing_frame, toplevel_form):
@@ -4216,7 +5667,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
         if element.TextColor not in (None, COLOR_SYSTEM_DEFAULT):
             widget.style['color'] = element.TextColor
         widget.style['font-size'] = '{}px'.format(font_info[1])
-        if element_size[0]:     # if size is zero, don't set any sizes
+        if element_size[0]:  # if size is zero, don't set any sizes
             size = convert_tkinter_size_to_Wx(element_size)
             widget.style['height'] = '{}px'.format(size[1])
             widget.style['width'] = '{}px'.format(size[0])
@@ -4249,11 +5700,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
         elif form.ElementJustification.startswith('r'):
             # tk_row_frame.style['justify-content'] = 'flex-end'
             tk_row_frame.style['margin-left'] = 'auto'
-        else:       # everything else is left justified
+        else:  # everything else is left justified
             # tk_row_frame.style['justify-content'] = 'flex-flexstart'
             tk_row_frame.style['margin-right'] = 'auto'
 
-        if form.BackgroundColor not in(None, COLOR_SYSTEM_DEFAULT):
+        if form.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
             tk_row_frame.style['background-color'] = form.BackgroundColor
 
         for col_num, element in enumerate(flex_row):
@@ -4276,9 +5727,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             text_color = element.TextColor
             # Determine Element size
             element_size = element.Size
-            if (element_size == (None, None) and element_type != ELEM_TYPE_BUTTON):  # user did not specify a size
+            if element_size == (None, None) and element_type != ELEM_TYPE_BUTTON:  # user did not specify a size
                 element_size = toplevel_form.DefaultElementSize
-            elif (element_size == (None, None) and element_type == ELEM_TYPE_BUTTON):
+            elif element_size == (None, None) and element_type == ELEM_TYPE_BUTTON:
                 element_size = toplevel_form.DefaultButtonElementSize
             else:
                 auto_size_text = False  # if user has specified a size then it shouldn't autosize
@@ -4296,7 +5747,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
             # -------------------------  COLUMN element  ------------------------- #
             if element_type == ELEM_TYPE_COLUMN:
-                element = element   # type: Column
+                element = element  # type: Column
                 element.Widget = column_widget = remi.gui.VBox()
                 if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                     column_widget.style['background-color'] = element.BackgroundColor
@@ -4305,11 +5756,11 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
             # -------------------------  TEXT element  ------------------------- #
             elif element_type == ELEM_TYPE_TEXT:
-                element = element   # type: Text
+                element = element  # type: Text
                 element.Widget = remi.gui.Label(element.DisplayText)
                 do_font_and_color(element.Widget)
                 if auto_size_text and element.Size == (None, None):
-                    del(element.Widget.style['width'])
+                    del element.Widget.style['width']
                 if element.Justification:
                     if element.Justification.startswith('c'):
                         element.Widget.style['text-align'] = 'center'
@@ -4326,10 +5777,16 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.Widget = remi.gui.Button(element.ButtonText, width=size[0], height=size[1], margin='10px')
                 element.Widget.onclick.connect(element._ButtonCallBack)
                 do_font_and_color(element.Widget)
-                if element.AutoSizeButton or (toplevel_form.AutoSizeButtons and element.AutoSizeButton is not False) and element.Size == (None, None):
-                    del (element.Widget.style['width'])
+                if (
+                    element.AutoSizeButton
+                    or (toplevel_form.AutoSizeButtons and element.AutoSizeButton is not False)
+                    and element.Size == (None, None)
+                ):
+                    del element.Widget.style['width']
                 if element.ImageFilename:
-                    element.ImageWidget = SuperImage(element.ImageFilename if element.ImageFilename is not None else element.ImageData)
+                    element.ImageWidget = SuperImage(
+                        element.ImageFilename if element.ImageFilename is not None else element.ImageData
+                    )
                     element.Widget.append(element.ImageWidget)
                 tk_row_frame.append(element.Widget)
 
@@ -4583,7 +6040,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             #                                           border_width=element.BorderWidth, relief=element.Relief,
             #                                           style=element.BarStyle, key=element.Key)
             #     element.TKProgressBar.TKProgressBarForReal.pack(side=tk.LEFT, padx=element.Pad[0], pady=element.Pad[1])
-                # -------------------------  INPUT RADIO BUTTON element  ------------------------- #
+            # -------------------------  INPUT RADIO BUTTON element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_RADIO:
                 pass
                 # width = 0 if auto_size_text else element_size[0]
@@ -4647,7 +6104,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 #                                     timeout=DEFAULT_TOOLTIP_TIME)
                 # -------------------------  OUTPUT element  ------------------------- #
             elif element_type == ELEM_TYPE_OUTPUT:
-                element=element  # type: Output
+                element = element  # type: Output
                 element.Widget = remi.gui.TextInput(single_line=False)
                 element.Disabled = True
                 do_font_and_color(element.Widget)
@@ -4732,8 +6189,12 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
             elif element_type == ELEM_TYPE_GRAPH:
                 element = element  # type: Graph
                 element.Widget = remi.gui.Svg(width=element.CanvasSize[0], height=element.CanvasSize[1])
-                element.SvgGroup = remi.gui.SvgSubcontainer(0,0, '100%', '100%')
-                element.Widget.append([element.SvgGroup,])
+                element.SvgGroup = remi.gui.SvgSubcontainer(0, 0, '100%', '100%')
+                element.Widget.append(
+                    [
+                        element.SvgGroup,
+                    ]
+                )
                 do_font_and_color(element.Widget)
                 if element.ChangeSubmits:
                     element.Widget.onmouseup.connect(element._MouseUpCallback)
@@ -4766,9 +6227,9 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 #     element._TKCanvas2.bind('<Motion>', element.MotionCallBack)
             # -------------------------  MENUBAR element  ------------------------- #
             elif element_type == ELEM_TYPE_MENUBAR:
-                element = element       # type: Menu
+                element = element  # type: Menu
                 menu = remi.gui.Menu(width='100%', height=str(element_size[1]))
-                element_size = (0,0)    # makes the menu span across the top
+                element_size = (0, 0)  # makes the menu span across the top
                 do_font_and_color(menu)
 
                 menu_def = element.MenuDefinition
@@ -4778,14 +6239,18 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                     # print(pos)
                     if pos != -1:
                         if pos == 0 or menu_entry[0][pos - 1] != '\\':
-                            menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + 1:]
+                            menu_entry[0] = menu_entry[0][:pos] + menu_entry[0][pos + 1 :]
                     if menu_entry[0][0] == MENU_DISABLED_CHARACTER:
                         item = remi.gui.MenuItem(menu_entry[0][1:], width=100, height=element_size[1])
                         item.set_enabled(False)
                     else:
                         item = remi.gui.MenuItem(menu_entry[0], width=100, height=element_size[1])
                     do_font_and_color(item)
-                    menu.append([item,])
+                    menu.append(
+                        [
+                            item,
+                        ]
+                    )
                     if len(menu_entry) > 1:
                         AddMenuItem(item, menu_entry[1], element)
 
@@ -4797,7 +6262,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
 
             # -------------------------  Frame element  ------------------------- #
             elif element_type == ELEM_TYPE_FRAME:
-                element = element   # type: Frame
+                element = element  # type: Frame
                 # element.Widget = column_widget = remi.gui.VBox()
                 element.Widget = column_widget = CLASSframe(element.Title)
                 if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
@@ -4838,7 +6303,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 #     element.TooltipObject = ToolTip(labeled_frame, text=element.Tooltip, timeout=DEFAULT_TOOLTIP_TIME)
             # -------------------------  Tab element  ------------------------- #
             elif element_type == ELEM_TYPE_TAB:
-                element = element           # type: Tab
+                element = element  # type: Tab
                 element.Widget = remi.gui.VBox()
                 if element.Justification.startswith('c'):
                     # print('CENTERING')
@@ -4884,10 +6349,10 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 #                                     timeout=DEFAULT_TOOLTIP_TIME)
             # -------------------------  TabGroup element  ------------------------- #
             elif element_type == ELEM_TYPE_TAB_GROUP:
-                element = element           # type: TabGroup
+                element = element  # type: TabGroup
                 element.Widget = remi.gui.TabBox()
                 # do_font_and_color(element.Widget)
-                PackFormIntoFrame(element ,element.Widget, toplevel_form)
+                PackFormIntoFrame(element, element.Widget, toplevel_form)
                 tk_row_frame.append(element.Widget)
 
                 # custom_style = str(element.Key) + 'customtab.TNotebook'
@@ -4935,9 +6400,19 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 # -------------------------  SLIDER element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_SLIDER:
                 element = element  # type: Slider
-                orient = remi.gui.Container.LAYOUT_HORIZONTAL if element.Orientation.lower().startswith('h') else remi.gui.Container.LAYOUT_VERTICAL
+                orient = (
+                    remi.gui.Container.LAYOUT_HORIZONTAL
+                    if element.Orientation.lower().startswith('h')
+                    else remi.gui.Container.LAYOUT_VERTICAL
+                )
                 # print(f'slider orient = {orient}')
-                element.Widget = remi.gui.Slider(layout_orientation=orient, default_value=element.DefaultValue, min=element.Range[0], max=element.Range[1],step=element.Resolution)
+                element.Widget = remi.gui.Slider(
+                    layout_orientation=orient,
+                    default_value=element.DefaultValue,
+                    min=element.Range[0],
+                    max=element.Range[1],
+                    step=element.Resolution,
+                )
                 if element.DefaultValue:
                     element.Widget.set_value(element.DefaultValue)
                 # if element.Orientation.startswith('v'):
@@ -4948,16 +6423,18 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
                 element.Widget.style['orientation'] = 'vertical'
                 element.Widget.attributes['orientation'] = 'vertical'
                 # print(f'slider = {element.Widget.style, element.Widget.attributes}')
-                tk_row_frame.append(element.Widget)                # slider_length = element_size[0] * CharWidthInPixels()
+                tk_row_frame.append(element.Widget)  # slider_length = element_size[0] * CharWidthInPixels()
 
             # -------------------------  TABLE element  ------------------------- #
             elif element_type == ELEM_TYPE_TABLE:
-                element = element       # type: Table
+                element = element  # type: Table
                 new_table = []
-                for row_num, row in enumerate(element.Values):             # convert entire table to strings
-                    new_row= [str(item) for item in row]
+                for row_num, row in enumerate(element.Values):  # convert entire table to strings
+                    new_row = [str(item) for item in row]
                     if element.DisplayRowNumbers:
-                        new_row = [element.RowHeaderText if row_num == 0 else str(row_num+element.StartingRowNumber) ,] + new_row
+                        new_row = [
+                            element.RowHeaderText if row_num == 0 else str(row_num + element.StartingRowNumber),
+                        ] + new_row
                     new_table.append(new_row)
                 element.Widget = remi.gui.Table.new_from_list(new_table)
                 do_font_and_color(element.Widget)
@@ -5223,7 +6700,7 @@ def PackFormIntoFrame(form, containing_frame, toplevel_form):
     return
 
 
-def setup_remi_window(app:Window.MyApp, window:Window):
+def setup_remi_window(app: Window.MyApp, window: Window):
     master_widget = remi.gui.VBox()
     master_widget.style['justify-content'] = 'flex-start'
     master_widget.style['align-items'] = 'baseline'
@@ -5235,7 +6712,6 @@ def setup_remi_window(app:Window.MyApp, window:Window):
         print('* ERROR PACKING FORM *')
         print(traceback.format_exc())
 
-
     if window.BackgroundImage:
         master_widget.style['background-image'] = "url('{}')".format('/' + window.BackgroundImage)
         # print(f'background info',self.master_widget.attributes['background-image'] )
@@ -5243,8 +6719,11 @@ def setup_remi_window(app:Window.MyApp, window:Window):
     if not window.DisableClose:
         # add the following 3 lines to your app and the on_window_close method to make the console close automatically
         tag = remi.gui.Tag(_type='script')
-        tag.add_child('javascript', """window.onunload=function(e){sendCallback('%s','%s');return "close?";};""" % (
-            str(id(app)), 'on_window_close'))
+        tag.add_child(
+            'javascript',
+            """window.onunload=function(e){sendCallback('%s','%s');return "close?";};"""
+            % (str(id(app)), 'on_window_close'),
+        )
         master_widget.add_child('onunloadevent', tag)
 
     if window.ReturnKeyboardEvents:
@@ -5252,28 +6731,26 @@ def setup_remi_window(app:Window.MyApp, window:Window):
     if window.ReturnKeyDownEvents:
         app.page.children['body'].onkeydown.connect(window.on_key_down)
 
-
     # if window.WindowIcon:
     #     if type(window.WindowIcon) is bytes or len(window.WindowIcon) > 200:
     #         app.page.children['head'].set_icon_data( base64_data=str(window.WindowIcon), mimetype="image/gif" )
     #     else:
     #         app.page.children['head'].set_icon_file("/res:{}".format(window.WindowIcon))
     #         pass
-            # mimetype, encoding = mimetypes.guess_type(image_source)
-            # with open(image_source, 'rb') as f:
-            #     data = f.read()
-            # b64 = base64.b64encode(data)
-            # b64_str = b64.decode("utf-8")
-            # image_string = "data:image/svg;base64,%s"%b64_str
-            # rpoint.set_image(image_string)
-
+    # mimetype, encoding = mimetypes.guess_type(image_source)
+    # with open(image_source, 'rb') as f:
+    #     data = f.read()
+    # b64 = base64.b64encode(data)
+    # b64_str = b64.decode("utf-8")
+    # image_string = "data:image/svg;base64,%s"%b64_str
+    # rpoint.set_image(image_string)
 
     return master_widget
 
-# ----====----====----====----====----==== STARTUP TK ====----====----====----====----====----#
-def StartupTK(window:Window):
-    global _my_windows
 
+# ----====----====----====----====----==== STARTUP TK ====----====----====----====----====----#
+def StartupTK(window: Window):
+    global _my_windows
 
     # print('Starting TK open Windows = {}'.format(ow))
 
@@ -5297,7 +6774,7 @@ def StartupTK(window:Window):
         window.thread_id = threading.Thread(target=window.remi_thread, daemon=True)
         window.thread_id.daemon = True
         window.thread_id.start()
-        item = window.MessageQueue.get()        # Get the layout complete message
+        item = window.MessageQueue.get()  # Get the layout complete message
         Window.active_windows.append(window)
         Window.App = window.App
     else:
@@ -5315,6 +6792,7 @@ def StartupTK(window:Window):
         Window.App.set_root_widget(master_widget)
 
     return
+
 
 # ==============================_GetNumLinesNeeded ==#
 # Helper function for determining how to wrap text   #
@@ -5334,8 +6812,17 @@ def _GetNumLinesNeeded(text, max_line_width):
 
 # ==============================  PROGRESS METER ========================================== #
 
+
 def ConvertArgsToSingleString(*args):
-    max_line_total, width_used, total_lines, = 0, 0, 0
+    (
+        max_line_total,
+        width_used,
+        total_lines,
+    ) = (
+        0,
+        0,
+        0,
+    )
     single_line_message = ''
     # loop through args and built a SINGLE string from them
     for message in args:
@@ -5353,8 +6840,17 @@ def ConvertArgsToSingleString(*args):
 
 # ============================== ProgressMeter  =====#
 # ===================================================#
-def _ProgressMeter(title, max_value, *args, orientation=None, bar_color=(None, None), button_color=None,
-                   size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
+def _ProgressMeter(
+    title,
+    max_value,
+    *args,
+    orientation=None,
+    bar_color=(None, None),
+    button_color=None,
+    size=DEFAULT_PROGRESS_BAR_SIZE,
+    border_width=None,
+    grab_anywhere=False
+):
     '''
     Create and show a form on tbe caller's behalf.
     :param title:
@@ -5369,8 +6865,14 @@ def _ProgressMeter(title, max_value, *args, orientation=None, bar_color=(None, N
     '''
     local_orientation = DEFAULT_METER_ORIENTATION if orientation is None else orientation
     local_border_width = DEFAULT_PROGRESS_BAR_BORDER_WIDTH if border_width is None else border_width
-    bar2 = ProgressBar(max_value, orientation=local_orientation, size=size, bar_color=bar_color,
-                       border_width=local_border_width, relief=DEFAULT_PROGRESS_BAR_RELIEF)
+    bar2 = ProgressBar(
+        max_value,
+        orientation=local_orientation,
+        size=size,
+        bar_color=bar_color,
+        border_width=local_border_width,
+        relief=DEFAULT_PROGRESS_BAR_RELIEF,
+    )
     form = Window(title, auto_size_text=True, grab_anywhere=grab_anywhere)
 
     # Form using a horizontal bar
@@ -5407,8 +6909,10 @@ def _ProgressMeterUpdate(bar, value, text_elem, *args):
     :return: True if not cancelled, OK....False if Error
     '''
     global _my_windows
-    if bar == None: return False
-    if bar.BarExpired: return False
+    if bar == None:
+        return False
+    if bar.BarExpired:
+        return False
     message, w, h = ConvertArgsToSingleString(*args)
     text_elem.Update(message)
     # bar.TextToDisplay = message
@@ -5440,7 +6944,7 @@ def _ProgressMeterUpdate(bar, value, text_elem, *args):
 
 # ============================== EASY PROGRESS METER ========================================== #
 # class to hold the easy meter info (a global variable essentialy)
-class EasyProgressMeterDataClass():
+class EasyProgressMeterDataClass:
     def __init__(self, title='', current_value=1, max_value=10, start_time=None, stat_messages=()):
         self.Title = title
         self.CurrentValue = current_value
@@ -5477,13 +6981,23 @@ class EasyProgressMeterDataClass():
             '',
             '{} Elapsed Time'.format(time_delta_short),
             '{} Time Remaining'.format(time_remaining_short),
-            '{} Estimated Total Time'.format(total_time_short)]
+            '{} Estimated Total Time'.format(total_time_short),
+        ]
         return
 
 
 # ============================== EasyProgressMeter  =====#
-def EasyProgressMeter(title, current_value, max_value, *args, orientation=None, bar_color=(None, None),
-                      button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None):
+def EasyProgressMeter(
+    title,
+    current_value,
+    max_value,
+    *args,
+    orientation=None,
+    bar_color=(None, None),
+    button_color=None,
+    size=DEFAULT_PROGRESS_BAR_SIZE,
+    border_width=None
+):
     '''
     A ONE-LINE progress meter. Add to your code where ever you need a meter. No need for a second
     function call before your loop. You've got enough code to write!
@@ -5506,20 +7020,25 @@ def EasyProgressMeter(title, current_value, max_value, *args, orientation=None, 
     # if no meter currently running
     if EasyProgressMeter.Data.MeterID is None:  # Starting a new meter
         print(
-            'Please change your call of EasyProgressMeter to use OneLineProgressMeter. EasyProgressMeter will be removed soon')
+            'Please change your call of EasyProgressMeter to use OneLineProgressMeter. EasyProgressMeter will be removed soon'
+        )
         if int(current_value) >= int(max_value):
             return False
-        del (EasyProgressMeter.Data)
+        del EasyProgressMeter.Data
         EasyProgressMeter.Data = EasyProgressMeterDataClass(title, 1, int(max_value), datetime.datetime.utcnow(), [])
         EasyProgressMeter.Data.ComputeProgressStats()
         message = '\n'.join([line for line in EasyProgressMeter.Data.StatMessages])
-        EasyProgressMeter.Data.MeterID, EasyProgressMeter.Data.MeterText = _ProgressMeter(title, int(max_value),
-                                                                                          message, *args,
-                                                                                          orientation=orientation,
-                                                                                          bar_color=bar_color,
-                                                                                          size=size,
-                                                                                          button_color=button_color,
-                                                                                          border_width=local_border_width)
+        EasyProgressMeter.Data.MeterID, EasyProgressMeter.Data.MeterText = _ProgressMeter(
+            title,
+            int(max_value),
+            message,
+            *args,
+            orientation=orientation,
+            bar_color=bar_color,
+            size=size,
+            button_color=button_color,
+            border_width=local_border_width
+        )
         EasyProgressMeter.Data.ParentForm = EasyProgressMeter.Data.MeterID.ParentForm
         return True
     # if exactly the same values as before, then ignore.
@@ -5528,7 +7047,7 @@ def EasyProgressMeter(title, current_value, max_value, *args, orientation=None, 
     if EasyProgressMeter.Data.MaxValue != int(max_value):
         EasyProgressMeter.Data.MeterID = None
         EasyProgressMeter.Data.ParentForm = None
-        del (EasyProgressMeter.Data)
+        del EasyProgressMeter.Data
         EasyProgressMeter.Data = EasyProgressMeterDataClass()  # setup a new progress meter
         return True  # HAVE to return TRUE or else the new meter will thing IT is failing when it hasn't
     EasyProgressMeter.Data.CurrentValue = int(current_value)
@@ -5539,25 +7058,30 @@ def EasyProgressMeter(title, current_value, max_value, *args, orientation=None, 
         message = message + str(line) + '\n'
     message = '\n'.join(EasyProgressMeter.Data.StatMessages)
     args = args + (message,)
-    rc = _ProgressMeterUpdate(EasyProgressMeter.Data.MeterID, current_value,
-                              EasyProgressMeter.Data.MeterText, *args)
+    rc = _ProgressMeterUpdate(EasyProgressMeter.Data.MeterID, current_value, EasyProgressMeter.Data.MeterText, *args)
     # if counter >= max then the progress meter is all done. Indicate none running
     if current_value >= EasyProgressMeter.Data.MaxValue or not rc:
         EasyProgressMeter.Data.MeterID = None
-        del (EasyProgressMeter.Data)
+        del EasyProgressMeter.Data
         EasyProgressMeter.Data = EasyProgressMeterDataClass()  # setup a new progress meter
         return False  # even though at the end, return True so don't cause error with the app
     return rc  # return whatever the update told us
 
 
 def EasyProgressMeterCancel(title, *args):
-    EasyProgressMeter.EasyProgressMeterData = getattr(EasyProgressMeter, 'EasyProgressMeterData',
-                                                      EasyProgressMeterDataClass())
+    EasyProgressMeter.EasyProgressMeterData = getattr(
+        EasyProgressMeter, 'EasyProgressMeterData', EasyProgressMeterDataClass()
+    )
     if EasyProgressMeter.EasyProgressMeterData.MeterID is not None:
         # tell the normal meter update that we're at max value which will close the meter
-        rc = EasyProgressMeter(title, EasyProgressMeter.EasyProgressMeterData.MaxValue,
-                               EasyProgressMeter.EasyProgressMeterData.MaxValue, ' *** CANCELLING ***',
-                               'Caller requested a cancel', *args)
+        rc = EasyProgressMeter(
+            title,
+            EasyProgressMeter.EasyProgressMeterData.MaxValue,
+            EasyProgressMeter.EasyProgressMeterData.MaxValue,
+            ' *** CANCELLING ***',
+            'Caller requested a cancel',
+            *args
+        )
         return rc
     return True
 
@@ -5567,8 +7091,19 @@ _one_line_progress_meters = {}
 
 
 # ============================== OneLineProgressMeter  =====#
-def OneLineProgressMeter(title, current_value, max_value, key='OK for 1 meter', *args, orientation=None, bar_color=(None, None),
-                         button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
+def OneLineProgressMeter(
+    title,
+    current_value,
+    max_value,
+    key='OK for 1 meter',
+    *args,
+    orientation=None,
+    bar_color=(None, None),
+    button_color=None,
+    size=DEFAULT_PROGRESS_BAR_SIZE,
+    border_width=None,
+    grab_anywhere=False
+):
     global _one_line_progress_meters
 
     local_border_width = DEFAULT_PROGRESS_BAR_BORDER_WIDTH if border_width is not None else border_width
@@ -5581,11 +7116,18 @@ def OneLineProgressMeter(title, current_value, max_value, key='OK for 1 meter', 
         _one_line_progress_meters[key] = meter_data
         meter_data.ComputeProgressStats()
         message = '\n'.join([line for line in meter_data.StatMessages])
-        meter_data.MeterID, meter_data.MeterText = _ProgressMeter(title, int(max_value), message, *args,
-                                                                  orientation=orientation, bar_color=bar_color,
-                                                                  size=size, button_color=button_color,
-                                                                  border_width=local_border_width,
-                                                                  grab_anywhere=grab_anywhere)
+        meter_data.MeterID, meter_data.MeterText = _ProgressMeter(
+            title,
+            int(max_value),
+            message,
+            *args,
+            orientation=orientation,
+            bar_color=bar_color,
+            size=size,
+            button_color=button_color,
+            border_width=local_border_width,
+            grab_anywhere=grab_anywhere
+        )
         meter_data.ParentForm = meter_data.MeterID.ParentForm
         return True
 
@@ -5600,8 +7142,7 @@ def OneLineProgressMeter(title, current_value, max_value, key='OK for 1 meter', 
         message = message + str(line) + '\n'
     message = '\n'.join(meter_data.StatMessages)
     args = args + (message,)
-    rc = _ProgressMeterUpdate(meter_data.MeterID, current_value,
-                              meter_data.MeterText, *args)
+    rc = _ProgressMeterUpdate(meter_data.MeterID, current_value, meter_data.MeterText, *args)
     # if counter >= max then the progress meter is all done. Indicate none running
     if current_value >= meter_data.MaxValue or not rc:
         del _one_line_progress_meters[key]
@@ -5639,21 +7180,33 @@ def GetComplimentaryHex(color):
 _easy_print_data = None  # global variable... I'm cheating
 
 
-class DebugWin():
-    def __init__(self, size=(None, None), location=(None, None), font=None, no_titlebar=False, no_button=False,
-                 grab_anywhere=False, keep_on_top=False):
+class DebugWin:
+    def __init__(
+        self,
+        size=(None, None),
+        location=(None, None),
+        font=None,
+        no_titlebar=False,
+        no_button=False,
+        grab_anywhere=False,
+        keep_on_top=False,
+    ):
         # Show a form that's a running counter
         win_size = size if size != (None, None) else DEFAULT_DEBUG_WINDOW_SIZE
-        self.window = Window('Debug Window', no_titlebar=no_titlebar, auto_size_text=True, location=location,
-                             font=font or ('Courier New', 10), grab_anywhere=grab_anywhere, keep_on_top=keep_on_top)
+        self.window = Window(
+            'Debug Window',
+            no_titlebar=no_titlebar,
+            auto_size_text=True,
+            location=location,
+            font=font or ('Courier New', 10),
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+        )
         self.output_element = Output(size=win_size)
         if no_button:
             self.layout = [[self.output_element]]
         else:
-            self.layout = [
-                [self.output_element],
-                [DummyButton('Quit')]
-            ]
+            self.layout = [[self.output_element], [DummyButton('Quit')]]
         self.window.AddRows(self.layout)
         self.window.Read(timeout=0)  # Show a non-blocking form, returns immediately
         return
@@ -5685,13 +7238,30 @@ def PrintClose():
     EasyPrintClose()
 
 
-def EasyPrint(*args, size=(None, None), end=None, sep=None, location=(None, None), font=None, no_titlebar=False,
-              no_button=False, grab_anywhere=False, keep_on_top=False):
+def EasyPrint(
+    *args,
+    size=(None, None),
+    end=None,
+    sep=None,
+    location=(None, None),
+    font=None,
+    no_titlebar=False,
+    no_button=False,
+    grab_anywhere=False,
+    keep_on_top=False
+):
     global _easy_print_data
 
     if _easy_print_data is None:
-        _easy_print_data = DebugWin(size=size, location=location, font=font, no_titlebar=no_titlebar,
-                                    no_button=no_button, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top)
+        _easy_print_data = DebugWin(
+            size=size,
+            location=location,
+            font=font,
+            no_titlebar=no_titlebar,
+            no_button=no_button,
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+        )
     _easy_print_data.Print(*args, end=end, sep=sep)
 
 
@@ -5722,6 +7292,7 @@ def EasyPrintClose():
 CPRINT_DESTINATION_WINDOW = None
 CPRINT_DESTINATION_MULTILINE_ELMENT_KEY = None
 
+
 def cprint_set_output_destination(window, multiline_key):
     """
     Sets up the color print (cprint) output destination
@@ -5739,9 +7310,20 @@ def cprint_set_output_destination(window, multiline_key):
     CPRINT_DESTINATION_MULTILINE_ELMENT_KEY = multiline_key
 
 
-
 # def cprint(*args, **kwargs):
-def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=None, b=None, colors=None, c=None, window=None, key=None):
+def cprint(
+    *args,
+    end=None,
+    sep=' ',
+    text_color=None,
+    t=None,
+    background_color=None,
+    b=None,
+    colors=None,
+    c=None,
+    window=None,
+    key=None
+):
     """
     Color print to a multiline element in a window of your choice.
     Must have EITHER called cprint_set_output_destination prior to making this call so that the
@@ -5800,9 +7382,11 @@ def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=N
     destination_window = window or CPRINT_DESTINATION_WINDOW
 
     if (destination_window is None and window is None) or (destination_key is None and key is None):
-        print('** Warning ** Attempting to perform a cprint without a valid window & key',
-              'Will instead print on Console',
-              'You can specify window and key in this cprint call, or set ahead of time using cprint_set_output_destination')
+        print(
+            '** Warning ** Attempting to perform a cprint without a valid window & key',
+            'Will instead print on Console',
+            'You can specify window and key in this cprint call, or set ahead of time using cprint_set_output_destination',
+        )
         print(*args)
         return
 
@@ -5819,24 +7403,25 @@ def cprint(*args, end=None, sep=' ', text_color=None, t=None, background_color=N
     except Exception as e:
         print('* cprint warning * you messed up with color formatting', e)
 
-    mline = destination_window.find_element(destination_key, silent_on_error=True)      # type: Multiline
+    mline = destination_window.find_element(destination_key, silent_on_error=True)  # type: Multiline
     try:
         # mline = destination_window[destination_key]     # type: Multiline
         if end is None:
             mline.print(*args, text_color=kw_text_color, background_color=kw_background_color, end='', sep=sep)
             mline.print('')
         else:
-            mline.print(*args,text_color=kw_text_color, background_color=kw_background_color, end=end, sep=sep)
+            mline.print(*args, text_color=kw_text_color, background_color=kw_background_color, end=end, sep=sep)
     except Exception as e:
         print('** cprint error trying to print to the multiline. Printing to console instead **', e)
         print(*args, end=end, sep=sep)
 
 
-
 # ------------------------------------------------------------------------------------------------ #
 # A print-like call that can be used to output to a multiline element as if it's an Output element #
 # ------------------------------------------------------------------------------------------------ #
-def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True):
+def _print_to_element(
+    multiline_element, *args, end=None, sep=None, text_color=None, background_color=None, autoscroll=True
+):
     """
     Print like Python normally prints except route the output to a multline element and also add colors if desired
 
@@ -5862,23 +7447,31 @@ def _print_to_element(multiline_element, *args, end=None, sep=None, text_color=N
     num_args = len(args)
     for i, arg in enumerate(args):
         outstring += str(arg)
-        if i != num_args-1:
+        if i != num_args - 1:
             outstring += sep_str
     outstring += end_str
 
-    multiline_element.update(outstring, append=True, text_color=text_color, background_color=background_color, autoscroll=autoscroll)
-
+    multiline_element.update(
+        outstring, append=True, text_color=text_color, background_color=background_color, autoscroll=autoscroll
+    )
 
 
 # ========================  Scrolled Text Box   =====#
 # ===================================================#
-def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None,
-                  size=(None, None)):
-    if not args: return
+def PopupScrolled(
+    *args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None, size=(None, None)
+):
+    if not args:
+        return
     width, height = size
     width = width if width else MESSAGE_BOX_LINE_WIDTH
-    form = Window(args[0], auto_size_text=True, button_color=button_color, auto_close=auto_close,
-                  auto_close_duration=auto_close_duration)
+    form = Window(
+        args[0],
+        auto_size_text=True,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+    )
     max_line_total, max_line_width, total_lines, height_computed = 0, 0, 0, 0
     complete_output = ''
     for message in args:
@@ -5893,7 +7486,9 @@ def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto
         height_computed += lines_needed
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    height_computed = (
+        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    )
     if height:
         height_computed = height
     form.AddRow(Multiline(complete_output, size=(max_line_width, height_computed)))
@@ -5931,18 +7526,40 @@ def SetGlobalIcon(icon):
 # ============================== SetOptions =========#
 # Sets the icon to be used by default                #
 # ===================================================#
-def SetOptions(icon=None, button_color=None, element_size=(None, None), button_element_size=(None, None),
-               margins=(None, None),
-               element_padding=(None, None), auto_size_text=None, auto_size_buttons=None, font=None, border_width=None,
-               slider_border_width=None, slider_relief=None, slider_orientation=None,
-               autoclose_time=None, message_box_line_width=None,
-               progress_meter_border_depth=None, progress_meter_style=None,
-               progress_meter_relief=None, progress_meter_color=None, progress_meter_size=None,
-               text_justification=None, background_color=None, element_background_color=None,
-               text_element_background_color=None, input_elements_background_color=None, input_text_color=None,
-               scrollbar_color=None, text_color=None, element_text_color=None, debug_win_size=(None, None),
-               window_location=(None, None),
-               tooltip_time=None):
+def SetOptions(
+    icon=None,
+    button_color=None,
+    element_size=(None, None),
+    button_element_size=(None, None),
+    margins=(None, None),
+    element_padding=(None, None),
+    auto_size_text=None,
+    auto_size_buttons=None,
+    font=None,
+    border_width=None,
+    slider_border_width=None,
+    slider_relief=None,
+    slider_orientation=None,
+    autoclose_time=None,
+    message_box_line_width=None,
+    progress_meter_border_depth=None,
+    progress_meter_style=None,
+    progress_meter_relief=None,
+    progress_meter_color=None,
+    progress_meter_size=None,
+    text_justification=None,
+    background_color=None,
+    element_background_color=None,
+    text_element_background_color=None,
+    input_elements_background_color=None,
+    input_text_color=None,
+    scrollbar_color=None,
+    text_color=None,
+    element_text_color=None,
+    debug_win_size=(None, None),
+    window_location=(None, None),
+    tooltip_time=None,
+):
     global DEFAULT_ELEMENT_SIZE
     global DEFAULT_BUTTON_ELEMENT_SIZE
     global DEFAULT_MARGINS  # Margins for each LEFT/RIGHT margin is first term
@@ -6080,7 +7697,6 @@ def SetOptions(icon=None, button_color=None, element_size=(None, None), button_e
     return True
 
 
-
 # ----------------------------------------------------------------- #
 
 # .########.##.....##.########.##.....##.########..######.
@@ -6099,994 +7715,1834 @@ def SetOptions(icon=None, button_color=None, element_size=(None, None), button_e
 # Predefined settings that will change the colors and styles #
 # of the elements.                                           #
 ##############################################################
-LOOK_AND_FEEL_TABLE = {'SystemDefault':
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'SystemDefaultForReal':
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': COLOR_SYSTEM_DEFAULT,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'SystemDefault1':
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': COLOR_SYSTEM_DEFAULT,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'Material1': {'BACKGROUND': '#E3F2FD',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#86A8FF',
-                                     'TEXT_INPUT': '#000000',
-                                     'SCROLL': '#86A8FF',
-                                     'BUTTON': ('#FFFFFF', '#5079D3'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'Material2': {'BACKGROUND': '#FAFAFA',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#004EA1',
-                                     'TEXT_INPUT': '#FFFFFF',
-                                     'SCROLL': '#5EA7FF',
-                                     'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'Reddit': {'BACKGROUND': '#ffffff',
-                                  'TEXT': '#1a1a1b',
-                                  'INPUT': '#dae0e6',
-                                  'TEXT_INPUT': '#222222',
-                                  'SCROLL': '#a5a4a4',
-                                  'BUTTON': ('#FFFFFF', '#0079d3'),
-                                  'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                  'BORDER': 1,
-                                  'SLIDER_DEPTH': 0,
-                                  'PROGRESS_DEPTH': 0,
-                                  'ACCENT1': '#ff5414',
-                                  'ACCENT2': '#33a8ff',
-                                  'ACCENT3': '#dbf0ff'},
-
-                       'Topanga': {'BACKGROUND': '#282923',
-                                   'TEXT': '#E7DB74',
-                                   'INPUT': '#393a32',
-                                   'TEXT_INPUT': '#E7C855',
-                                   'SCROLL': '#E7C855',
-                                   'BUTTON': ('#E7C855', '#284B5A'),
-                                   'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                   'BORDER': 1,
-                                   'SLIDER_DEPTH': 0,
-                                   'PROGRESS_DEPTH': 0,
-                                   'ACCENT1': '#c15226',
-                                   'ACCENT2': '#7a4d5f',
-                                   'ACCENT3': '#889743'},
-
-                       'GreenTan': {'BACKGROUND': '#9FB8AD',
-                                    'TEXT': COLOR_SYSTEM_DEFAULT,
-                                    'INPUT': '#F7F3EC', 'TEXT_INPUT': '#000000',
-                                    'SCROLL': '#F7F3EC',
-                                    'BUTTON': ('#FFFFFF', '#475841'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'Dark': {'BACKGROUND': '#404040',
-                                'TEXT': '#FFFFFF',
-                                'INPUT': '#4D4D4D',
-                                'TEXT_INPUT': '#FFFFFF',
-                                'SCROLL': '#707070',
-                                'BUTTON': ('#FFFFFF', '#004F00'),
-                                'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                'BORDER': 1,
-                                'SLIDER_DEPTH': 0,
-                                'PROGRESS_DEPTH': 0},
-
-                       'LightGreen': {'BACKGROUND': '#B7CECE',
-                                      'TEXT': '#000000',
-                                      'INPUT': '#FDFFF7',
-                                      'TEXT_INPUT': '#000000',
-                                      'SCROLL': '#FDFFF7',
-                                      'BUTTON': ('#FFFFFF', '#658268'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'ACCENT1': '#76506d',
-                                      'ACCENT2': '#5148f1',
-                                      'ACCENT3': '#0a1c84',
-                                      'PROGRESS_DEPTH': 0},
-
-                       'Dark2': {'BACKGROUND': '#404040',
-                                 'TEXT': '#FFFFFF',
-                                 'INPUT': '#FFFFFF',
-                                 'TEXT_INPUT': '#000000',
-                                 'SCROLL': '#707070',
-                                 'BUTTON': ('#FFFFFF', '#004F00'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'Black': {'BACKGROUND': '#000000',
-                                 'TEXT': '#FFFFFF',
-                                 'INPUT': '#4D4D4D',
-                                 'TEXT_INPUT': '#FFFFFF',
-                                 'SCROLL': '#707070',
-                                 'BUTTON': ('#000000', '#FFFFFF'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'Tan': {'BACKGROUND': '#fdf6e3',
-                               'TEXT': '#268bd1',
-                               'INPUT': '#eee8d5',
-                               'TEXT_INPUT': '#6c71c3',
-                               'SCROLL': '#eee8d5',
-                               'BUTTON': ('#FFFFFF', '#063542'),
-                               'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                               'BORDER': 1,
-                               'SLIDER_DEPTH': 0,
-                               'PROGRESS_DEPTH': 0},
-
-                       'TanBlue': {'BACKGROUND': '#e5dece',
-                                   'TEXT': '#063289',
-                                   'INPUT': '#f9f8f4',
-                                   'TEXT_INPUT': '#242834',
-                                   'SCROLL': '#eee8d5',
-                                   'BUTTON': ('#FFFFFF', '#063289'),
-                                   'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                   'BORDER': 1,
-                                   'SLIDER_DEPTH': 0,
-                                   'PROGRESS_DEPTH': 0},
-
-                       'DarkTanBlue': {'BACKGROUND': '#242834',
-                                       'TEXT': '#dfe6f8',
-                                       'INPUT': '#97755c',
-                                       'TEXT_INPUT': '#FFFFFF',
-                                       'SCROLL': '#a9afbb',
-                                       'BUTTON': ('#FFFFFF', '#063289'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkAmber': {'BACKGROUND': '#2c2825',
-                                     'TEXT': '#fdcb52',
-                                     'INPUT': '#705e52',
-                                     'TEXT_INPUT': '#fdcb52',
-                                     'SCROLL': '#705e52',
-                                     'BUTTON': ('#000000', '#fdcb52'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue': {'BACKGROUND': '#1a2835',
-                                    'TEXT': '#d1ecff',
-                                    'INPUT': '#335267',
-                                    'TEXT_INPUT': '#acc2d0',
-                                    'SCROLL': '#1b6497',
-                                    'BUTTON': ('#000000', '#fafaf8'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'Reds': {'BACKGROUND': '#280001',
-                                'TEXT': '#FFFFFF',
-                                'INPUT': '#d8d584',
-                                'TEXT_INPUT': '#000000',
-                                'SCROLL': '#763e00',
-                                'BUTTON': ('#000000', '#daad28'),
-                                'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                'BORDER': 1,
-                                'SLIDER_DEPTH': 0,
-                                'PROGRESS_DEPTH': 0},
-
-                       'Green': {'BACKGROUND': '#82a459',
-                                 'TEXT': '#000000',
-                                 'INPUT': '#d8d584',
-                                 'TEXT_INPUT': '#000000',
-                                 'SCROLL': '#e3ecf3',
-                                 'BUTTON': ('#FFFFFF', '#517239'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'BluePurple': {'BACKGROUND': '#A5CADD',
-                                      'TEXT': '#6E266E',
-                                      'INPUT': '#E0F5FF',
-                                      'TEXT_INPUT': '#000000',
-                                      'SCROLL': '#E0F5FF',
-                                      'BUTTON': ('#FFFFFF', '#303952'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'Purple': {'BACKGROUND': '#B0AAC2',
-                                  'TEXT': '#000000',
-                                  'INPUT': '#F2EFE8',
-                                  'SCROLL': '#F2EFE8',
-                                  'TEXT_INPUT': '#000000',
-                                  'BUTTON': ('#000000', '#C2D4D8'),
-                                  'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                  'BORDER': 1,
-                                  'SLIDER_DEPTH': 0,
-                                  'PROGRESS_DEPTH': 0},
-
-                       'BlueMono': {'BACKGROUND': '#AAB6D3',
-                                    'TEXT': '#000000',
-                                    'INPUT': '#F1F4FC',
-                                    'SCROLL': '#F1F4FC',
-                                    'TEXT_INPUT': '#000000',
-                                    'BUTTON': ('#FFFFFF', '#7186C7'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1,
-                                    'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'GreenMono': {'BACKGROUND': '#A8C1B4',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#DDE0DE',
-                                     'SCROLL': '#E3E3E3',
-                                     'TEXT_INPUT': '#000000',
-                                     'BUTTON': ('#FFFFFF', '#6D9F85'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'BrownBlue': {'BACKGROUND': '#64778d',
-                                     'TEXT': '#FFFFFF',
-                                     'INPUT': '#f0f3f7',
-                                     'SCROLL': '#A6B2BE',
-                                     'TEXT_INPUT': '#000000',
-                                     'BUTTON': ('#FFFFFF', '#283b5b'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'BrightColors': {'BACKGROUND': '#b4ffb4',
-                                        'TEXT': '#000000',
-                                        'INPUT': '#ffff64',
-                                        'SCROLL': '#ffb482',
-                                        'TEXT_INPUT': '#000000',
-                                        'BUTTON': ('#000000', '#ffa0dc'),
-                                        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                        'BORDER': 1,
-                                        'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0},
-
-                       'NeutralBlue': {'BACKGROUND': '#92aa9d',
-                                       'TEXT': '#000000',
-                                       'INPUT': '#fcfff6',
-                                       'SCROLL': '#fcfff6',
-                                       'TEXT_INPUT': '#000000',
-                                       'BUTTON': ('#000000', '#d0dbbd'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'Kayak': {'BACKGROUND': '#a7ad7f',
-                                 'TEXT': '#000000',
-                                 'INPUT': '#e6d3a8',
-                                 'SCROLL': '#e6d3a8',
-                                 'TEXT_INPUT': '#000000',
-                                 'BUTTON': ('#FFFFFF', '#5d907d'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'SandyBeach': {'BACKGROUND': '#efeccb',
-                                      'TEXT': '#012f2f',
-                                      'INPUT': '#e6d3a8',
-                                      'SCROLL': '#e6d3a8',
-                                      'TEXT_INPUT': '#012f2f',
-                                      'BUTTON': ('#FFFFFF', '#046380'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'TealMono': {'BACKGROUND': '#a8cfdd',
-                                    'TEXT': '#000000',
-                                    'INPUT': '#dfedf2',
-                                    'SCROLL': '#dfedf2',
-                                    'TEXT_INPUT': '#000000',
-                                    'BUTTON': ('#FFFFFF', '#183440'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1,
-                                    'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-                       ################################## Renamed Original Themes ##################################
-                       'Default':  # plain gray but blue buttons
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'Default1':  # everything is gray
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': COLOR_SYSTEM_DEFAULT,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'DefaultNoMoreNagging':  # a duplicate of "Default" for users that are tired of the nag screen
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'LightBlue': {'BACKGROUND': '#E3F2FD',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#86A8FF',
-                                     'TEXT_INPUT': '#000000',
-                                     'SCROLL': '#86A8FF',
-                                     'BUTTON': ('#FFFFFF', '#5079D3'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'LightGrey': {'BACKGROUND': '#FAFAFA',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#004EA1',
-                                     'TEXT_INPUT': '#FFFFFF',
-                                     'SCROLL': '#5EA7FF',
-                                     'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'LightGrey1': {'BACKGROUND': '#ffffff',
-                                      'TEXT': '#1a1a1b',
-                                      'INPUT': '#dae0e6',
-                                      'TEXT_INPUT': '#222222',
-                                      'SCROLL': '#a5a4a4',
-                                      'BUTTON': ('#FFFFFF', '#0079d3'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0,
-                                      'ACCENT1': '#ff5414',
-                                      'ACCENT2': '#33a8ff',
-                                      'ACCENT3': '#dbf0ff'},
-
-                       'DarkBrown': {'BACKGROUND': '#282923',
-                                     'TEXT': '#E7DB74',
-                                     'INPUT': '#393a32',
-                                     'TEXT_INPUT': '#E7C855',
-                                     'SCROLL': '#E7C855',
-                                     'BUTTON': ('#E7C855', '#284B5A'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#c15226',
-                                     'ACCENT2': '#7a4d5f',
-                                     'ACCENT3': '#889743'},
-
-                       'LightGreen1': {'BACKGROUND': '#9FB8AD',
-                                       'TEXT': COLOR_SYSTEM_DEFAULT,
-                                       'INPUT': '#F7F3EC', 'TEXT_INPUT': '#000000',
-                                       'SCROLL': '#F7F3EC',
-                                       'BUTTON': ('#FFFFFF', '#475841'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkGrey': {'BACKGROUND': '#404040',
-                                    'TEXT': '#FFFFFF',
-                                    'INPUT': '#4D4D4D',
-                                    'TEXT_INPUT': '#FFFFFF',
-                                    'SCROLL': '#707070',
-                                    'BUTTON': ('#FFFFFF', '#004F00'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1,
-                                    'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'LightGreen2': {'BACKGROUND': '#B7CECE',
-                                       'TEXT': '#000000',
-                                       'INPUT': '#FDFFF7',
-                                       'TEXT_INPUT': '#000000',
-                                       'SCROLL': '#FDFFF7',
-                                       'BUTTON': ('#FFFFFF', '#658268'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'ACCENT1': '#76506d',
-                                       'ACCENT2': '#5148f1',
-                                       'ACCENT3': '#0a1c84',
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkGrey1': {'BACKGROUND': '#404040',
-                                     'TEXT': '#FFFFFF',
-                                     'INPUT': '#FFFFFF',
-                                     'TEXT_INPUT': '#000000',
-                                     'SCROLL': '#707070',
-                                     'BUTTON': ('#FFFFFF', '#004F00'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBlack': {'BACKGROUND': '#000000',
-                                     'TEXT': '#FFFFFF',
-                                     'INPUT': '#4D4D4D',
-                                     'TEXT_INPUT': '#FFFFFF',
-                                     'SCROLL': '#707070',
-                                     'BUTTON': ('#000000', '#FFFFFF'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'LightBrown': {'BACKGROUND': '#fdf6e3',
-                                      'TEXT': '#268bd1',
-                                      'INPUT': '#eee8d5',
-                                      'TEXT_INPUT': '#6c71c3',
-                                      'SCROLL': '#eee8d5',
-                                      'BUTTON': ('#FFFFFF', '#063542'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'LightBrown1': {'BACKGROUND': '#e5dece',
-                                       'TEXT': '#063289',
-                                       'INPUT': '#f9f8f4',
-                                       'TEXT_INPUT': '#242834',
-                                       'SCROLL': '#eee8d5',
-                                       'BUTTON': ('#FFFFFF', '#063289'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue1': {'BACKGROUND': '#242834',
-                                     'TEXT': '#dfe6f8',
-                                     'INPUT': '#97755c',
-                                     'TEXT_INPUT': '#FFFFFF',
-                                     'SCROLL': '#a9afbb',
-                                     'BUTTON': ('#FFFFFF', '#063289'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBrown1': {'BACKGROUND': '#2c2825',
-                                      'TEXT': '#fdcb52',
-                                      'INPUT': '#705e52',
-                                      'TEXT_INPUT': '#fdcb52',
-                                      'SCROLL': '#705e52',
-                                      'BUTTON': ('#000000', '#fdcb52'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue2': {'BACKGROUND': '#1a2835',
-                                     'TEXT': '#d1ecff',
-                                     'INPUT': '#335267',
-                                     'TEXT_INPUT': '#acc2d0',
-                                     'SCROLL': '#1b6497',
-                                     'BUTTON': ('#000000', '#fafaf8'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBrown2': {'BACKGROUND': '#280001',
-                                      'TEXT': '#FFFFFF',
-                                      'INPUT': '#d8d584',
-                                      'TEXT_INPUT': '#000000',
-                                      'SCROLL': '#763e00',
-                                      'BUTTON': ('#000000', '#daad28'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'DarkGreen': {'BACKGROUND': '#82a459',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#d8d584',
-                                     'TEXT_INPUT': '#000000',
-                                     'SCROLL': '#e3ecf3',
-                                     'BUTTON': ('#FFFFFF', '#517239'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'LightBlue1': {'BACKGROUND': '#A5CADD',
-                                      'TEXT': '#6E266E',
-                                      'INPUT': '#E0F5FF',
-                                      'TEXT_INPUT': '#000000',
-                                      'SCROLL': '#E0F5FF',
-                                      'BUTTON': ('#FFFFFF', '#303952'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'LightPurple': {'BACKGROUND': '#B0AAC2',
-                                       'TEXT': '#000000',
-                                       'INPUT': '#F2EFE8',
-                                       'SCROLL': '#F2EFE8',
-                                       'TEXT_INPUT': '#000000',
-                                       'BUTTON': ('#000000', '#C2D4D8'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBlue2': {'BACKGROUND': '#AAB6D3',
-                                      'TEXT': '#000000',
-                                      'INPUT': '#F1F4FC',
-                                      'SCROLL': '#F1F4FC',
-                                      'TEXT_INPUT': '#000000',
-                                      'BUTTON': ('#FFFFFF', '#7186C7'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'LightGreen3': {'BACKGROUND': '#A8C1B4',
-                                       'TEXT': '#000000',
-                                       'INPUT': '#DDE0DE',
-                                       'SCROLL': '#E3E3E3',
-                                       'TEXT_INPUT': '#000000',
-                                       'BUTTON': ('#FFFFFF', '#6D9F85'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue3': {'BACKGROUND': '#64778d',
-                                     'TEXT': '#FFFFFF',
-                                     'INPUT': '#f0f3f7',
-                                     'SCROLL': '#A6B2BE',
-                                     'TEXT_INPUT': '#000000',
-                                     'BUTTON': ('#FFFFFF', '#283b5b'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'LightGreen4': {'BACKGROUND': '#b4ffb4',
-                                       'TEXT': '#000000',
-                                       'INPUT': '#ffff64',
-                                       'SCROLL': '#ffb482',
-                                       'TEXT_INPUT': '#000000',
-                                       'BUTTON': ('#000000', '#ffa0dc'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightGreen5': {'BACKGROUND': '#92aa9d',
-                                       'TEXT': '#000000',
-                                       'INPUT': '#fcfff6',
-                                       'SCROLL': '#fcfff6',
-                                       'TEXT_INPUT': '#000000',
-                                       'BUTTON': ('#000000', '#d0dbbd'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBrown2': {'BACKGROUND': '#a7ad7f',
-                                       'TEXT': '#000000',
-                                       'INPUT': '#e6d3a8',
-                                       'SCROLL': '#e6d3a8',
-                                       'TEXT_INPUT': '#000000',
-                                       'BUTTON': ('#FFFFFF', '#5d907d'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBrown3': {'BACKGROUND': '#efeccb',
-                                       'TEXT': '#012f2f',
-                                       'INPUT': '#e6d3a8',
-                                       'SCROLL': '#e6d3a8',
-                                       'TEXT_INPUT': '#012f2f',
-                                       'BUTTON': ('#FFFFFF', '#046380'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBlue3': {'BACKGROUND': '#a8cfdd',
-                                      'TEXT': '#000000',
-                                      'INPUT': '#dfedf2',
-                                      'SCROLL': '#dfedf2',
-                                      'TEXT_INPUT': '#000000',
-                                      'BUTTON': ('#FFFFFF', '#183440'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       ################################## End Renamed Original Themes ##################################
-
-                       #
-                       'LightBrown4': {'BACKGROUND': '#d7c79e', 'TEXT': '#a35638', 'INPUT': '#9dab86', 'TEXT_INPUT': '#000000', 'SCROLL': '#a35638',
-                                       'BUTTON': ('#FFFFFF', '#a35638'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'], },
-                       'DarkTeal': {'BACKGROUND': '#003f5c', 'TEXT': '#fb5b5a', 'INPUT': '#bc4873', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#bc4873',
-                                    'BUTTON': ('#FFFFFF', '#fb5b5a'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                    'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'], },
-                       'DarkPurple': {'BACKGROUND': '#472b62', 'TEXT': '#fb5b5a', 'INPUT': '#bc4873', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#bc4873',
-                                      'BUTTON': ('#FFFFFF', '#472b62'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'], },
-                       'LightGreen6': {'BACKGROUND': '#eafbea', 'TEXT': '#1f6650', 'INPUT': '#6f9a8d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#1f6650',
-                                       'BUTTON': ('#FFFFFF', '#1f6650'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'], },
-                       'DarkGrey2': {'BACKGROUND': '#2b2b28', 'TEXT': '#f8f8f8', 'INPUT': '#f1d6ab', 'TEXT_INPUT': '#000000', 'SCROLL': '#f1d6ab',
-                                     'BUTTON': ('#2b2b28', '#e3b04b'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'], },
-                       'LightBrown6': {'BACKGROUND': '#f9b282', 'TEXT': '#8f4426', 'INPUT': '#de6b35', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#8f4426',
-                                       'BUTTON': ('#FFFFFF', '#8f4426'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'], },
-                       'DarkTeal1': {'BACKGROUND': '#396362', 'TEXT': '#ffe7d1', 'INPUT': '#f6c89f', 'TEXT_INPUT': '#000000', 'SCROLL': '#f6c89f',
-                                     'BUTTON': ('#ffe7d1', '#4b8e8d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'], },
-                       'LightBrown7': {'BACKGROUND': '#f6c89f', 'TEXT': '#396362', 'INPUT': '#4b8e8d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#396362',
-                                       'BUTTON': ('#FFFFFF', '#396362'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'], },
-                       'DarkPurple1': {'BACKGROUND': '#0c093c', 'TEXT': '#fad6d6', 'INPUT': '#eea5f6', 'TEXT_INPUT': '#000000', 'SCROLL': '#eea5f6',
-                                       'BUTTON': ('#FFFFFF', '#df42d1'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'], },
-                       'DarkGrey3': {'BACKGROUND': '#211717', 'TEXT': '#dfddc7', 'INPUT': '#f58b54', 'TEXT_INPUT': '#000000', 'SCROLL': '#f58b54',
-                                     'BUTTON': ('#dfddc7', '#a34a28'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'], },
-                       'LightBrown8': {'BACKGROUND': '#dfddc7', 'TEXT': '#211717', 'INPUT': '#a34a28', 'TEXT_INPUT': '#dfddc7', 'SCROLL': '#211717',
-                                       'BUTTON': ('#dfddc7', '#a34a28'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'], },
-                       'DarkBlue4': {'BACKGROUND': '#494ca2', 'TEXT': '#e3e7f1', 'INPUT': '#c6cbef', 'TEXT_INPUT': '#000000', 'SCROLL': '#c6cbef',
-                                     'BUTTON': ('#FFFFFF', '#8186d5'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'], },
-                       'LightBlue4': {'BACKGROUND': '#5c94bd', 'TEXT': '#470938', 'INPUT': '#1a3e59', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#470938',
-                                      'BUTTON': ('#FFFFFF', '#470938'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'], },
-                       'DarkTeal2': {'BACKGROUND': '#394a6d', 'TEXT': '#c0ffb3', 'INPUT': '#52de97', 'TEXT_INPUT': '#000000', 'SCROLL': '#52de97',
-                                     'BUTTON': ('#c0ffb3', '#394a6d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'], },
-                       'DarkTeal3': {'BACKGROUND': '#3c9d9b', 'TEXT': '#c0ffb3', 'INPUT': '#52de97', 'TEXT_INPUT': '#000000', 'SCROLL': '#52de97',
-                                     'BUTTON': ('#c0ffb3', '#394a6d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'], },
-                       'DarkPurple5': {'BACKGROUND': '#730068', 'TEXT': '#f6f078', 'INPUT': '#01d28e', 'TEXT_INPUT': '#000000', 'SCROLL': '#01d28e',
-                                       'BUTTON': ('#f6f078', '#730068'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'], },
-                       'DarkPurple2': {'BACKGROUND': '#202060', 'TEXT': '#b030b0', 'INPUT': '#602080', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#602080',
-                                       'BUTTON': ('#FFFFFF', '#202040'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'], },
-                       'DarkBlue5': {'BACKGROUND': '#000272', 'TEXT': '#ff6363', 'INPUT': '#a32f80', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#a32f80',
-                                     'BUTTON': ('#FFFFFF', '#341677'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'], },
-                       'LightGrey2': {'BACKGROUND': '#f6f6f6', 'TEXT': '#420000', 'INPUT': '#d4d7dd', 'TEXT_INPUT': '#420000', 'SCROLL': '#420000',
-                                      'BUTTON': ('#420000', '#d4d7dd'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'], },
-                       'LightGrey3': {'BACKGROUND': '#eae9e9', 'TEXT': '#420000', 'INPUT': '#d4d7dd', 'TEXT_INPUT': '#420000', 'SCROLL': '#420000',
-                                      'BUTTON': ('#420000', '#d4d7dd'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'], },
-                       'DarkBlue6': {'BACKGROUND': '#01024e', 'TEXT': '#ff6464', 'INPUT': '#8b4367', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#8b4367',
-                                     'BUTTON': ('#FFFFFF', '#543864'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'], },
-                       'DarkBlue7': {'BACKGROUND': '#241663', 'TEXT': '#eae7af', 'INPUT': '#a72693', 'TEXT_INPUT': '#eae7af', 'SCROLL': '#a72693',
-                                     'BUTTON': ('#eae7af', '#160f30'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'], },
-                       'LightBrown9': {'BACKGROUND': '#f6d365', 'TEXT': '#3a1f5d', 'INPUT': '#c83660', 'TEXT_INPUT': '#f6d365', 'SCROLL': '#3a1f5d',
-                                       'BUTTON': ('#f6d365', '#c83660'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'], },
-                       'DarkPurple3': {'BACKGROUND': '#6e2142', 'TEXT': '#ffd692', 'INPUT': '#e16363', 'TEXT_INPUT': '#ffd692', 'SCROLL': '#e16363',
-                                       'BUTTON': ('#ffd692', '#943855'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'], },
-                       'LightBrown10': {'BACKGROUND': '#ffd692', 'TEXT': '#6e2142', 'INPUT': '#943855', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#6e2142',
-                                        'BUTTON': ('#FFFFFF', '#6e2142'),
-                                        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'], },
-                       'DarkPurple4': {'BACKGROUND': '#200f21', 'TEXT': '#f638dc', 'INPUT': '#5a3d5c', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#5a3d5c',
-                                       'BUTTON': ('#FFFFFF', '#382039'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'], },
-                       'LightBlue5': {'BACKGROUND': '#b2fcff', 'TEXT': '#3e64ff', 'INPUT': '#5edfff', 'TEXT_INPUT': '#000000', 'SCROLL': '#3e64ff',
-                                      'BUTTON': ('#FFFFFF', '#3e64ff'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'], },
-                       'DarkTeal4': {'BACKGROUND': '#464159', 'TEXT': '#c7f0db', 'INPUT': '#8bbabb', 'TEXT_INPUT': '#000000', 'SCROLL': '#8bbabb',
-                                     'BUTTON': ('#FFFFFF', '#6c7b95'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-                       'LightTeal': {'BACKGROUND': '#c7f0db', 'TEXT': '#464159', 'INPUT': '#6c7b95', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#464159',
-                                     'BUTTON': ('#FFFFFF', '#464159'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-                       'DarkTeal5': {'BACKGROUND': '#8bbabb', 'TEXT': '#464159', 'INPUT': '#6c7b95', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#464159',
-                                     'BUTTON': ('#c7f0db', '#6c7b95'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-                       'LightGrey4': {'BACKGROUND': '#faf5ef', 'TEXT': '#672f2f', 'INPUT': '#99b19c', 'TEXT_INPUT': '#672f2f', 'SCROLL': '#672f2f',
-                                      'BUTTON': ('#672f2f', '#99b19c'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-                       'LightGreen7': {'BACKGROUND': '#99b19c', 'TEXT': '#faf5ef', 'INPUT': '#d7d1c9', 'TEXT_INPUT': '#000000', 'SCROLL': '#d7d1c9',
-                                       'BUTTON': ('#FFFFFF', '#99b19c'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-                       'LightGrey5': {'BACKGROUND': '#d7d1c9', 'TEXT': '#672f2f', 'INPUT': '#99b19c', 'TEXT_INPUT': '#672f2f', 'SCROLL': '#672f2f',
-                                      'BUTTON': ('#FFFFFF', '#672f2f'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-                       'DarkBrown3': {'BACKGROUND': '#a0855b', 'TEXT': '#f9f6f2', 'INPUT': '#f1d6ab', 'TEXT_INPUT': '#000000', 'SCROLL': '#f1d6ab',
-                                      'BUTTON': ('#FFFFFF', '#38470b'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'], },
-                       'LightBrown11': {'BACKGROUND': '#f1d6ab', 'TEXT': '#38470b', 'INPUT': '#a0855b', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#38470b',
-                                        'BUTTON': ('#f9f6f2', '#a0855b'),
-                                        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'], },
-                       'DarkRed': {'BACKGROUND': '#83142c', 'TEXT': '#f9d276', 'INPUT': '#ad1d45', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#ad1d45',
-                                   'BUTTON': ('#f9d276', '#ad1d45'),
-                                   'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                   'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'], },
-                       'DarkTeal6': {'BACKGROUND': '#204969', 'TEXT': '#fff7f7', 'INPUT': '#dadada', 'TEXT_INPUT': '#000000', 'SCROLL': '#dadada',
-                                     'BUTTON': ('#000000', '#fff7f7'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'], },
-                       'DarkBrown4': {'BACKGROUND': '#252525', 'TEXT': '#ff0000', 'INPUT': '#af0404', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#af0404',
-                                      'BUTTON': ('#FFFFFF', '#252525'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'], },
-                       'LightYellow': {'BACKGROUND': '#f4ff61', 'TEXT': '#27aa80', 'INPUT': '#32ff6a', 'TEXT_INPUT': '#000000', 'SCROLL': '#27aa80',
-                                       'BUTTON': ('#f4ff61', '#27aa80'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'], },
-                       'DarkGreen1': {'BACKGROUND': '#2b580c', 'TEXT': '#fdef96', 'INPUT': '#f7b71d', 'TEXT_INPUT': '#000000', 'SCROLL': '#f7b71d',
-                                      'BUTTON': ('#fdef96', '#2b580c'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'], },
-
-                       'LightGreen8': {'BACKGROUND': '#c8dad3', 'TEXT': '#63707e', 'INPUT': '#93b5b3', 'TEXT_INPUT': '#000000', 'SCROLL': '#63707e',
-                                       'BUTTON': ('#FFFFFF', '#63707e'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'], },
-
-                       'DarkTeal7': {'BACKGROUND': '#248ea9', 'TEXT': '#fafdcb', 'INPUT': '#aee7e8', 'TEXT_INPUT': '#000000', 'SCROLL': '#aee7e8',
-                                     'BUTTON': ('#000000', '#fafdcb'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'], },
-                       'DarkBlue8': {'BACKGROUND': '#454d66', 'TEXT': '#d9d872', 'INPUT': '#58b368', 'TEXT_INPUT': '#000000', 'SCROLL': '#58b368',
-                                     'BUTTON': ('#000000', '#009975'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'], },
-                       'DarkBlue9': {'BACKGROUND': '#263859', 'TEXT': '#ff6768', 'INPUT': '#6b778d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#6b778d',
-                                     'BUTTON': ('#ff6768', '#263859'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'], },
-                       'DarkBlue10': {'BACKGROUND': '#0028ff', 'TEXT': '#f1f4df', 'INPUT': '#10eaf0', 'TEXT_INPUT': '#000000', 'SCROLL': '#10eaf0',
-                                      'BUTTON': ('#f1f4df', '#24009c'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'], },
-                       'DarkBlue11': {'BACKGROUND': '#6384b3', 'TEXT': '#e6f0b6', 'INPUT': '#b8e9c0', 'TEXT_INPUT': '#000000', 'SCROLL': '#b8e9c0',
-                                      'BUTTON': ('#e6f0b6', '#684949'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'], },
-
-                       'DarkTeal8': {'BACKGROUND': '#71a0a5', 'TEXT': '#212121', 'INPUT': '#665c84', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#212121',
-                                     'BUTTON': ('#fab95b', '#665c84'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b']},
-                       'DarkRed1': {'BACKGROUND': '#c10000', 'TEXT': '#eeeeee', 'INPUT': '#dedede', 'TEXT_INPUT': '#000000', 'SCROLL': '#dedede',
-                                    'BUTTON': ('#c10000', '#eeeeee'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                    'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'], },
-                       'LightBrown5': {'BACKGROUND': '#fff591', 'TEXT': '#e41749', 'INPUT': '#f5587b', 'TEXT_INPUT': '#000000', 'SCROLL': '#e41749',
-                                       'BUTTON': ('#fff591', '#e41749'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591']},
-                       'LightGreen9': {'BACKGROUND': '#f1edb3', 'TEXT': '#3b503d', 'INPUT': '#4a746e', 'TEXT_INPUT': '#f1edb3', 'SCROLL': '#3b503d',
-                                       'BUTTON': ('#f1edb3', '#3b503d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'], 'DESCRIPTION': ['Green', 'Turquoise', 'Yellow']},
-                       'DarkGreen2': {'BACKGROUND': '#3b503d', 'TEXT': '#f1edb3', 'INPUT': '#c8cf94', 'TEXT_INPUT': '#000000', 'SCROLL': '#c8cf94',
-                                      'BUTTON': ('#f1edb3', '#3b503d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'], 'DESCRIPTION': ['Green', 'Turquoise', 'Yellow']},
-                       'LightGray1': {'BACKGROUND': '#f2f2f2', 'TEXT': '#222831', 'INPUT': '#393e46', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#222831',
-                                      'BUTTON': ('#f2f2f2', '#222831'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],
-                                      'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn']},
-                       'DarkGrey4': {'BACKGROUND': '#52524e', 'TEXT': '#e9e9e5', 'INPUT': '#d4d6c8', 'TEXT_INPUT': '#000000', 'SCROLL': '#d4d6c8',
-                                     'BUTTON': ('#FFFFFF', '#9a9b94'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],
-                                     'DESCRIPTION': ['Grey', 'Pastel', 'Winter']},
-                       'DarkBlue12': {'BACKGROUND': '#324e7b', 'TEXT': '#f8f8f8', 'INPUT': '#86a6df', 'TEXT_INPUT': '#000000', 'SCROLL': '#86a6df',
-                                      'BUTTON': ('#FFFFFF', '#5068a9'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],
-                                      'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter']},
-                       'DarkPurple6': {'BACKGROUND': '#070739', 'TEXT': '#e1e099', 'INPUT': '#c327ab', 'TEXT_INPUT': '#e1e099', 'SCROLL': '#c327ab',
-                                       'BUTTON': ('#e1e099', '#521477'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],
-                                       'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark']},
-                       'DarkBlue13': {'BACKGROUND': '#203562', 'TEXT': '#e3e8f8', 'INPUT': '#c0c5cd', 'TEXT_INPUT': '#000000', 'SCROLL': '#c0c5cd',
-                                      'BUTTON': ('#FFFFFF', '#3e588f'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],
-                                      'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold']},
-                       'DarkBrown5': {'BACKGROUND': '#3c1b1f', 'TEXT': '#f6e1b5', 'INPUT': '#e2bf81', 'TEXT_INPUT': '#000000', 'SCROLL': '#e2bf81',
-                                      'BUTTON': ('#3c1b1f', '#f6e1b5'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],
-                                      'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm']},
-                       'DarkGreen3': {'BACKGROUND': '#062121', 'TEXT': '#eeeeee', 'INPUT': '#e4dcad', 'TEXT_INPUT': '#000000', 'SCROLL': '#e4dcad',
-                                      'BUTTON': ('#eeeeee', '#181810'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
-                                      'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey']},
-                       'DarkBlack1': {'BACKGROUND': '#181810', 'TEXT': '#eeeeee', 'INPUT': '#e4dcad', 'TEXT_INPUT': '#000000', 'SCROLL': '#e4dcad',
-                                      'BUTTON': ('#FFFFFF', '#062121'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
-                                      'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey']},
-                       'DarkGrey5': {'BACKGROUND': '#343434', 'TEXT': '#f3f3f3', 'INPUT': '#e9dcbe', 'TEXT_INPUT': '#000000', 'SCROLL': '#e9dcbe',
-                                     'BUTTON': ('#FFFFFF', '#8e8b82'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'], 'DESCRIPTION': ['Grey', 'Brown']},
-                       'LightBrown12': {'BACKGROUND': '#8e8b82', 'TEXT': '#f3f3f3', 'INPUT': '#e9dcbe', 'TEXT_INPUT': '#000000', 'SCROLL': '#e9dcbe',
-                                        'BUTTON': ('#f3f3f3', '#8e8b82'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'], 'DESCRIPTION': ['Grey', 'Brown']},
-                       'DarkTeal9': {'BACKGROUND': '#13445a', 'TEXT': '#fef4e8', 'INPUT': '#446878', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#446878',
-                                     'BUTTON': ('#fef4e8', '#446878'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],
-                                     'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro']},
-                       'DarkBlue14': {'BACKGROUND': '#21273d', 'TEXT': '#f1f6f8', 'INPUT': '#b9d4f1', 'TEXT_INPUT': '#000000', 'SCROLL': '#b9d4f1',
-                                      'BUTTON': ('#FFFFFF', '#6a759b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
-                                      'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter']},
-                       'LightBlue6': {'BACKGROUND': '#f1f6f8', 'TEXT': '#21273d', 'INPUT': '#6a759b', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#21273d',
-                                      'BUTTON': ('#f1f6f8', '#6a759b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
-                                      'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter']},
-                       'DarkGreen4': {'BACKGROUND': '#044343', 'TEXT': '#e4e4e4', 'INPUT': '#045757', 'TEXT_INPUT': '#e4e4e4', 'SCROLL': '#045757',
-                                      'BUTTON': ('#e4e4e4', '#045757'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],
-                                      'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark']},
-                       'DarkGreen5': {'BACKGROUND': '#1b4b36', 'TEXT': '#e0e7f1', 'INPUT': '#aebd77', 'TEXT_INPUT': '#000000', 'SCROLL': '#aebd77',
-                                      'BUTTON': ('#FFFFFF', '#538f6a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'], 'DESCRIPTION': ['Green', 'Grey']},
-                       'DarkTeal10': {'BACKGROUND': '#0d3446', 'TEXT': '#d8dfe2', 'INPUT': '#71adb5', 'TEXT_INPUT': '#000000', 'SCROLL': '#71adb5',
-                                      'BUTTON': ('#FFFFFF', '#176d81'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],
-                                      'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold']},
-                       'DarkGrey6': {'BACKGROUND': '#3e3e3e', 'TEXT': '#ededed', 'INPUT': '#68868c', 'TEXT_INPUT': '#ededed', 'SCROLL': '#68868c',
-                                     'BUTTON': ('#FFFFFF', '#405559'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
-                                     'DESCRIPTION': ['Grey', 'Turquoise', 'Winter']},
-                       'DarkTeal11': {'BACKGROUND': '#405559', 'TEXT': '#ededed', 'INPUT': '#68868c', 'TEXT_INPUT': '#ededed', 'SCROLL': '#68868c',
-                                      'BUTTON': ('#ededed', '#68868c'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
-                                      'DESCRIPTION': ['Grey', 'Turquoise', 'Winter']},
-                       'LightBlue7': {'BACKGROUND': '#9ed0e0', 'TEXT': '#19483f', 'INPUT': '#5c868e', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#19483f',
-                                      'BUTTON': ('#FFFFFF', '#19483f'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],
-                                      'DESCRIPTION': ['Orange', 'Blue', 'Turquoise']},
-                       'LightGreen10': {'BACKGROUND': '#d8ebb5', 'TEXT': '#205d67', 'INPUT': '#639a67', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#205d67',
-                                        'BUTTON': ('#d8ebb5', '#205d67'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],
-                                        'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage']},
-                       'DarkBlue15': {'BACKGROUND': '#151680', 'TEXT': '#f1fea4', 'INPUT': '#375fc0', 'TEXT_INPUT': '#f1fea4', 'SCROLL': '#375fc0',
-                                      'BUTTON': ('#f1fea4', '#1c44ac'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
-                                      'DESCRIPTION': ['Blue', 'Yellow', 'Cold']},
-                       'DarkBlue16': {'BACKGROUND': '#1c44ac', 'TEXT': '#f1fea4', 'INPUT': '#375fc0', 'TEXT_INPUT': '#f1fea4', 'SCROLL': '#375fc0',
-                                      'BUTTON': ('#f1fea4', '#151680'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
-                                      'DESCRIPTION': ['Blue', 'Yellow', 'Cold']},
-                       'DarkTeal12': {'BACKGROUND': '#004a7c', 'TEXT': '#fafafa', 'INPUT': '#e8f1f5', 'TEXT_INPUT': '#000000', 'SCROLL': '#e8f1f5',
-                                      'BUTTON': ('#fafafa', '#005691'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],
-                                      'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter']},
-                       'LightBrown13': {'BACKGROUND': '#ebf5ee', 'TEXT': '#921224', 'INPUT': '#bdc6b8', 'TEXT_INPUT': '#921224', 'SCROLL': '#921224',
-                                        'BUTTON': ('#FFFFFF', '#921224'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],
-                                        'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding']},
-                       'DarkBlue17': {'BACKGROUND': '#21294c', 'TEXT': '#f9f2d7', 'INPUT': '#f2dea8', 'TEXT_INPUT': '#000000', 'SCROLL': '#f2dea8',
-                                      'BUTTON': ('#f9f2d7', '#141829'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
-                                      'DESCRIPTION': ['#000000', 'Blue', 'Yellow']},
-                       'DarkBrown6': {'BACKGROUND': '#785e4d', 'TEXT': '#f2eee3', 'INPUT': '#baaf92', 'TEXT_INPUT': '#000000', 'SCROLL': '#baaf92',
-                                      'BUTTON': ('#FFFFFF', '#785e4d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],
-                                      'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn']},
-                       'DarkGreen6': {'BACKGROUND': '#5c715e', 'TEXT': '#f2f9f1', 'INPUT': '#ddeedf', 'TEXT_INPUT': '#000000', 'SCROLL': '#ddeedf',
-                                      'BUTTON': ('#f2f9f1', '#5c715e'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],
-                                      'DESCRIPTION': ['Grey', 'Green', 'Vintage']},
-                       'DarkGrey7': {'BACKGROUND': '#4b586e', 'TEXT': '#dddddd', 'INPUT': '#574e6d', 'TEXT_INPUT': '#dddddd', 'SCROLL': '#574e6d',
-                                     'BUTTON': ('#dddddd', '#43405d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],
-                                     'DESCRIPTION': ['Grey', 'Winter', 'Cold']},
-                       'DarkRed2': {'BACKGROUND': '#ab1212', 'TEXT': '#f6e4b5', 'INPUT': '#cd3131', 'TEXT_INPUT': '#f6e4b5', 'SCROLL': '#cd3131',
-                                    'BUTTON': ('#f6e4b5', '#ab1212'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],
-                                    'DESCRIPTION': ['Turquoise', 'Red', 'Yellow']},
-                       'LightGrey6': {'BACKGROUND': '#e3e3e3', 'TEXT': '#233142', 'INPUT': '#455d7a', 'TEXT_INPUT': '#e3e3e3', 'SCROLL': '#233142',
-                                      'BUTTON': ('#e3e3e3', '#455d7a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],
-                                      'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey']},
-                       'HotDogStand': {'BACKGROUND': 'red', 'TEXT': 'yellow', 'INPUT': 'yellow', 'TEXT_INPUT': '#000000', 'SCROLL': 'yellow',
-                                      'BUTTON': ('red', 'yellow'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0,
-                                     },
-                       }
+LOOK_AND_FEEL_TABLE = {
+    'SystemDefault': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefaultForReal': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefault1': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Material1': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Material2': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Reddit': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('#FFFFFF', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'Topanga': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'GreenTan': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('#FFFFFF', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': '#000000',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('#FFFFFF', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark2': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#FFFFFF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Black': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#000000', '#FFFFFF'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Tan': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TanBlue': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkTanBlue': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkAmber': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('#000000', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('#000000', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Reds': {
+        'BACKGROUND': '#280001',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#763e00',
+        'BUTTON': ('#000000', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Green': {
+        'BACKGROUND': '#82a459',
+        'TEXT': '#000000',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('#FFFFFF', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BluePurple': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('#FFFFFF', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Purple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': '#000000',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BlueMono': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': '#000000',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'GreenMono': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': '#000000',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrownBlue': {
+        'BACKGROUND': '#64778d',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrightColors': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': '#000000',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'NeutralBlue': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': '#000000',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Kayak': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': '#000000',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SandyBeach': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('#FFFFFF', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TealMono': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': '#000000',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    ################################## Renamed Original Themes ##################################
+    'Default': {  # plain gray but blue buttons
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Default1': {  # everything is gray
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DefaultNoMoreNagging': {  # a duplicate of "Default" for users that are tired of the nag screen
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey1': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('#FFFFFF', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'DarkBrown': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'LightGreen1': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('#FFFFFF', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen2': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': '#000000',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('#FFFFFF', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey1': {
+        'BACKGROUND': '#404040',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#FFFFFF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#707070',
+        'BUTTON': ('#FFFFFF', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlack': {
+        'BACKGROUND': '#000000',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#707070',
+        'BUTTON': ('#000000', '#FFFFFF'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown1': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue1': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('#FFFFFF', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown1': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('#000000', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue2': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('#000000', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown2': {
+        'BACKGROUND': '#280001',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#763e00',
+        'BUTTON': ('#000000', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGreen': {
+        'BACKGROUND': '#82a459',
+        'TEXT': '#000000',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('#FFFFFF', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue1': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('#FFFFFF', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightPurple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': '#000000',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue2': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': '#000000',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen3': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': '#000000',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue3': {
+        'BACKGROUND': '#64778d',
+        'TEXT': '#FFFFFF',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen4': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': '#000000',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen5': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': '#000000',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#000000', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown2': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': '#000000',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown3': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('#FFFFFF', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue3': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': '#000000',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': '#000000',
+        'BUTTON': ('#FFFFFF', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    ################################## End Renamed Original Themes ##################################
+    #
+    'LightBrown4': {
+        'BACKGROUND': '#d7c79e',
+        'TEXT': '#a35638',
+        'INPUT': '#9dab86',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#a35638',
+        'BUTTON': ('#FFFFFF', '#a35638'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'],
+    },
+    'DarkTeal': {
+        'BACKGROUND': '#003f5c',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('#FFFFFF', '#fb5b5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'DarkPurple': {
+        'BACKGROUND': '#472b62',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('#FFFFFF', '#472b62'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'LightGreen6': {
+        'BACKGROUND': '#eafbea',
+        'TEXT': '#1f6650',
+        'INPUT': '#6f9a8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#1f6650',
+        'BUTTON': ('#FFFFFF', '#1f6650'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'],
+    },
+    'DarkGrey2': {
+        'BACKGROUND': '#2b2b28',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('#2b2b28', '#e3b04b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'],
+    },
+    'LightBrown6': {
+        'BACKGROUND': '#f9b282',
+        'TEXT': '#8f4426',
+        'INPUT': '#de6b35',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8f4426',
+        'BUTTON': ('#FFFFFF', '#8f4426'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'],
+    },
+    'DarkTeal1': {
+        'BACKGROUND': '#396362',
+        'TEXT': '#ffe7d1',
+        'INPUT': '#f6c89f',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f6c89f',
+        'BUTTON': ('#ffe7d1', '#4b8e8d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'LightBrown7': {
+        'BACKGROUND': '#f6c89f',
+        'TEXT': '#396362',
+        'INPUT': '#4b8e8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#396362',
+        'BUTTON': ('#FFFFFF', '#396362'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'DarkPurple1': {
+        'BACKGROUND': '#0c093c',
+        'TEXT': '#fad6d6',
+        'INPUT': '#eea5f6',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#eea5f6',
+        'BUTTON': ('#FFFFFF', '#df42d1'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'],
+    },
+    'DarkGrey3': {
+        'BACKGROUND': '#211717',
+        'TEXT': '#dfddc7',
+        'INPUT': '#f58b54',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f58b54',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'LightBrown8': {
+        'BACKGROUND': '#dfddc7',
+        'TEXT': '#211717',
+        'INPUT': '#a34a28',
+        'TEXT_INPUT': '#dfddc7',
+        'SCROLL': '#211717',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'DarkBlue4': {
+        'BACKGROUND': '#494ca2',
+        'TEXT': '#e3e7f1',
+        'INPUT': '#c6cbef',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c6cbef',
+        'BUTTON': ('#FFFFFF', '#8186d5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'],
+    },
+    'LightBlue4': {
+        'BACKGROUND': '#5c94bd',
+        'TEXT': '#470938',
+        'INPUT': '#1a3e59',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#470938',
+        'BUTTON': ('#FFFFFF', '#470938'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'],
+    },
+    'DarkTeal2': {
+        'BACKGROUND': '#394a6d',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkTeal3': {
+        'BACKGROUND': '#3c9d9b',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkPurple5': {
+        'BACKGROUND': '#730068',
+        'TEXT': '#f6f078',
+        'INPUT': '#01d28e',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#01d28e',
+        'BUTTON': ('#f6f078', '#730068'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'],
+    },
+    'DarkPurple2': {
+        'BACKGROUND': '#202060',
+        'TEXT': '#b030b0',
+        'INPUT': '#602080',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#602080',
+        'BUTTON': ('#FFFFFF', '#202040'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'],
+    },
+    'DarkBlue5': {
+        'BACKGROUND': '#000272',
+        'TEXT': '#ff6363',
+        'INPUT': '#a32f80',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a32f80',
+        'BUTTON': ('#FFFFFF', '#341677'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'],
+    },
+    'LightGrey2': {
+        'BACKGROUND': '#f6f6f6',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'LightGrey3': {
+        'BACKGROUND': '#eae9e9',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'DarkBlue6': {
+        'BACKGROUND': '#01024e',
+        'TEXT': '#ff6464',
+        'INPUT': '#8b4367',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8b4367',
+        'BUTTON': ('#FFFFFF', '#543864'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'],
+    },
+    'DarkBlue7': {
+        'BACKGROUND': '#241663',
+        'TEXT': '#eae7af',
+        'INPUT': '#a72693',
+        'TEXT_INPUT': '#eae7af',
+        'SCROLL': '#a72693',
+        'BUTTON': ('#eae7af', '#160f30'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'],
+    },
+    'LightBrown9': {
+        'BACKGROUND': '#f6d365',
+        'TEXT': '#3a1f5d',
+        'INPUT': '#c83660',
+        'TEXT_INPUT': '#f6d365',
+        'SCROLL': '#3a1f5d',
+        'BUTTON': ('#f6d365', '#c83660'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'],
+    },
+    'DarkPurple3': {
+        'BACKGROUND': '#6e2142',
+        'TEXT': '#ffd692',
+        'INPUT': '#e16363',
+        'TEXT_INPUT': '#ffd692',
+        'SCROLL': '#e16363',
+        'BUTTON': ('#ffd692', '#943855'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'LightBrown10': {
+        'BACKGROUND': '#ffd692',
+        'TEXT': '#6e2142',
+        'INPUT': '#943855',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6e2142',
+        'BUTTON': ('#FFFFFF', '#6e2142'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'DarkPurple4': {
+        'BACKGROUND': '#200f21',
+        'TEXT': '#f638dc',
+        'INPUT': '#5a3d5c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5a3d5c',
+        'BUTTON': ('#FFFFFF', '#382039'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'],
+    },
+    'LightBlue5': {
+        'BACKGROUND': '#b2fcff',
+        'TEXT': '#3e64ff',
+        'INPUT': '#5edfff',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#3e64ff',
+        'BUTTON': ('#FFFFFF', '#3e64ff'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'],
+    },
+    'DarkTeal4': {
+        'BACKGROUND': '#464159',
+        'TEXT': '#c7f0db',
+        'INPUT': '#8bbabb',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#8bbabb',
+        'BUTTON': ('#FFFFFF', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightTeal': {
+        'BACKGROUND': '#c7f0db',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('#FFFFFF', '#464159'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'DarkTeal5': {
+        'BACKGROUND': '#8bbabb',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('#c7f0db', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightGrey4': {
+        'BACKGROUND': '#faf5ef',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('#672f2f', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGreen7': {
+        'BACKGROUND': '#99b19c',
+        'TEXT': '#faf5ef',
+        'INPUT': '#d7d1c9',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d7d1c9',
+        'BUTTON': ('#FFFFFF', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGrey5': {
+        'BACKGROUND': '#d7d1c9',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('#FFFFFF', '#672f2f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'DarkBrown3': {
+        'BACKGROUND': '#a0855b',
+        'TEXT': '#f9f6f2',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('#FFFFFF', '#38470b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'LightBrown11': {
+        'BACKGROUND': '#f1d6ab',
+        'TEXT': '#38470b',
+        'INPUT': '#a0855b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#38470b',
+        'BUTTON': ('#f9f6f2', '#a0855b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'DarkRed': {
+        'BACKGROUND': '#83142c',
+        'TEXT': '#f9d276',
+        'INPUT': '#ad1d45',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#ad1d45',
+        'BUTTON': ('#f9d276', '#ad1d45'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'],
+    },
+    'DarkTeal6': {
+        'BACKGROUND': '#204969',
+        'TEXT': '#fff7f7',
+        'INPUT': '#dadada',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dadada',
+        'BUTTON': ('#000000', '#fff7f7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'],
+    },
+    'DarkBrown4': {
+        'BACKGROUND': '#252525',
+        'TEXT': '#ff0000',
+        'INPUT': '#af0404',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#af0404',
+        'BUTTON': ('#FFFFFF', '#252525'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'],
+    },
+    'LightYellow': {
+        'BACKGROUND': '#f4ff61',
+        'TEXT': '#27aa80',
+        'INPUT': '#32ff6a',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#27aa80',
+        'BUTTON': ('#f4ff61', '#27aa80'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'],
+    },
+    'DarkGreen1': {
+        'BACKGROUND': '#2b580c',
+        'TEXT': '#fdef96',
+        'INPUT': '#f7b71d',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f7b71d',
+        'BUTTON': ('#fdef96', '#2b580c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'],
+    },
+    'LightGreen8': {
+        'BACKGROUND': '#c8dad3',
+        'TEXT': '#63707e',
+        'INPUT': '#93b5b3',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#63707e',
+        'BUTTON': ('#FFFFFF', '#63707e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'],
+    },
+    'DarkTeal7': {
+        'BACKGROUND': '#248ea9',
+        'TEXT': '#fafdcb',
+        'INPUT': '#aee7e8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aee7e8',
+        'BUTTON': ('#000000', '#fafdcb'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'],
+    },
+    'DarkBlue8': {
+        'BACKGROUND': '#454d66',
+        'TEXT': '#d9d872',
+        'INPUT': '#58b368',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#58b368',
+        'BUTTON': ('#000000', '#009975'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'],
+    },
+    'DarkBlue9': {
+        'BACKGROUND': '#263859',
+        'TEXT': '#ff6768',
+        'INPUT': '#6b778d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6b778d',
+        'BUTTON': ('#ff6768', '#263859'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'],
+    },
+    'DarkBlue10': {
+        'BACKGROUND': '#0028ff',
+        'TEXT': '#f1f4df',
+        'INPUT': '#10eaf0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#10eaf0',
+        'BUTTON': ('#f1f4df', '#24009c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'],
+    },
+    'DarkBlue11': {
+        'BACKGROUND': '#6384b3',
+        'TEXT': '#e6f0b6',
+        'INPUT': '#b8e9c0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b8e9c0',
+        'BUTTON': ('#e6f0b6', '#684949'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'],
+    },
+    'DarkTeal8': {
+        'BACKGROUND': '#71a0a5',
+        'TEXT': '#212121',
+        'INPUT': '#665c84',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#212121',
+        'BUTTON': ('#fab95b', '#665c84'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'],
+    },
+    'DarkRed1': {
+        'BACKGROUND': '#c10000',
+        'TEXT': '#eeeeee',
+        'INPUT': '#dedede',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dedede',
+        'BUTTON': ('#c10000', '#eeeeee'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'],
+    },
+    'LightBrown5': {
+        'BACKGROUND': '#fff591',
+        'TEXT': '#e41749',
+        'INPUT': '#f5587b',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e41749',
+        'BUTTON': ('#fff591', '#e41749'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'],
+    },
+    'LightGreen9': {
+        'BACKGROUND': '#f1edb3',
+        'TEXT': '#3b503d',
+        'INPUT': '#4a746e',
+        'TEXT_INPUT': '#f1edb3',
+        'SCROLL': '#3b503d',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'DarkGreen2': {
+        'BACKGROUND': '#3b503d',
+        'TEXT': '#f1edb3',
+        'INPUT': '#c8cf94',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c8cf94',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'LightGray1': {
+        'BACKGROUND': '#f2f2f2',
+        'TEXT': '#222831',
+        'INPUT': '#393e46',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#222831',
+        'BUTTON': ('#f2f2f2', '#222831'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],
+        'DESCRIPTION': ['#000000', 'Grey', 'Orange', 'Grey', 'Autumn'],
+    },
+    'DarkGrey4': {
+        'BACKGROUND': '#52524e',
+        'TEXT': '#e9e9e5',
+        'INPUT': '#d4d6c8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d4d6c8',
+        'BUTTON': ('#FFFFFF', '#9a9b94'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],
+        'DESCRIPTION': ['Grey', 'Pastel', 'Winter'],
+    },
+    'DarkBlue12': {
+        'BACKGROUND': '#324e7b',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#86a6df',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86a6df',
+        'BUTTON': ('#FFFFFF', '#5068a9'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkPurple6': {
+        'BACKGROUND': '#070739',
+        'TEXT': '#e1e099',
+        'INPUT': '#c327ab',
+        'TEXT_INPUT': '#e1e099',
+        'SCROLL': '#c327ab',
+        'BUTTON': ('#e1e099', '#521477'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],
+        'DESCRIPTION': ['#000000', 'Purple', 'Yellow', 'Dark'],
+    },
+    'DarkBlue13': {
+        'BACKGROUND': '#203562',
+        'TEXT': '#e3e8f8',
+        'INPUT': '#c0c5cd',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c0c5cd',
+        'BUTTON': ('#FFFFFF', '#3e588f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'],
+    },
+    'DarkBrown5': {
+        'BACKGROUND': '#3c1b1f',
+        'TEXT': '#f6e1b5',
+        'INPUT': '#e2bf81',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e2bf81',
+        'BUTTON': ('#3c1b1f', '#f6e1b5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],
+        'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'],
+    },
+    'DarkGreen3': {
+        'BACKGROUND': '#062121',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('#eeeeee', '#181810'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
+    },
+    'DarkBlack1': {
+        'BACKGROUND': '#181810',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('#FFFFFF', '#062121'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['#000000', '#000000', 'Brown', 'Grey'],
+    },
+    'DarkGrey5': {
+        'BACKGROUND': '#343434',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#FFFFFF', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'LightBrown12': {
+        'BACKGROUND': '#8e8b82',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#f3f3f3', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'DarkTeal9': {
+        'BACKGROUND': '#13445a',
+        'TEXT': '#fef4e8',
+        'INPUT': '#446878',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#446878',
+        'BUTTON': ('#fef4e8', '#446878'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],
+        'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'],
+    },
+    'DarkBlue14': {
+        'BACKGROUND': '#21273d',
+        'TEXT': '#f1f6f8',
+        'INPUT': '#b9d4f1',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b9d4f1',
+        'BUTTON': ('#FFFFFF', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
+    },
+    'LightBlue6': {
+        'BACKGROUND': '#f1f6f8',
+        'TEXT': '#21273d',
+        'INPUT': '#6a759b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#21273d',
+        'BUTTON': ('#f1f6f8', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', '#000000', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkGreen4': {
+        'BACKGROUND': '#044343',
+        'TEXT': '#e4e4e4',
+        'INPUT': '#045757',
+        'TEXT_INPUT': '#e4e4e4',
+        'SCROLL': '#045757',
+        'BUTTON': ('#e4e4e4', '#045757'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],
+        'DESCRIPTION': ['#000000', 'Turquoise', 'Grey', 'Dark'],
+    },
+    'DarkGreen5': {
+        'BACKGROUND': '#1b4b36',
+        'TEXT': '#e0e7f1',
+        'INPUT': '#aebd77',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aebd77',
+        'BUTTON': ('#FFFFFF', '#538f6a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'],
+        'DESCRIPTION': ['Green', 'Grey'],
+    },
+    'DarkTeal10': {
+        'BACKGROUND': '#0d3446',
+        'TEXT': '#d8dfe2',
+        'INPUT': '#71adb5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#71adb5',
+        'BUTTON': ('#FFFFFF', '#176d81'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'],
+    },
+    'DarkGrey6': {
+        'BACKGROUND': '#3e3e3e',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#FFFFFF', '#405559'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'DarkTeal11': {
+        'BACKGROUND': '#405559',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#ededed', '#68868c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'LightBlue7': {
+        'BACKGROUND': '#9ed0e0',
+        'TEXT': '#19483f',
+        'INPUT': '#5c868e',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#19483f',
+        'BUTTON': ('#FFFFFF', '#19483f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],
+        'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'],
+    },
+    'LightGreen10': {
+        'BACKGROUND': '#d8ebb5',
+        'TEXT': '#205d67',
+        'INPUT': '#639a67',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#205d67',
+        'BUTTON': ('#d8ebb5', '#205d67'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],
+        'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'],
+    },
+    'DarkBlue15': {
+        'BACKGROUND': '#151680',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#1c44ac'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkBlue16': {
+        'BACKGROUND': '#1c44ac',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#151680'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkTeal12': {
+        'BACKGROUND': '#004a7c',
+        'TEXT': '#fafafa',
+        'INPUT': '#e8f1f5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e8f1f5',
+        'BUTTON': ('#fafafa', '#005691'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],
+        'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'],
+    },
+    'LightBrown13': {
+        'BACKGROUND': '#ebf5ee',
+        'TEXT': '#921224',
+        'INPUT': '#bdc6b8',
+        'TEXT_INPUT': '#921224',
+        'SCROLL': '#921224',
+        'BUTTON': ('#FFFFFF', '#921224'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],
+        'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'],
+    },
+    'DarkBlue17': {
+        'BACKGROUND': '#21294c',
+        'TEXT': '#f9f2d7',
+        'INPUT': '#f2dea8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f2dea8',
+        'BUTTON': ('#f9f2d7', '#141829'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
+        'DESCRIPTION': ['#000000', 'Blue', 'Yellow'],
+    },
+    'DarkBrown6': {
+        'BACKGROUND': '#785e4d',
+        'TEXT': '#f2eee3',
+        'INPUT': '#baaf92',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#baaf92',
+        'BUTTON': ('#FFFFFF', '#785e4d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],
+        'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'],
+    },
+    'DarkGreen6': {
+        'BACKGROUND': '#5c715e',
+        'TEXT': '#f2f9f1',
+        'INPUT': '#ddeedf',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#ddeedf',
+        'BUTTON': ('#f2f9f1', '#5c715e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],
+        'DESCRIPTION': ['Grey', 'Green', 'Vintage'],
+    },
+    'DarkGrey7': {
+        'BACKGROUND': '#4b586e',
+        'TEXT': '#dddddd',
+        'INPUT': '#574e6d',
+        'TEXT_INPUT': '#dddddd',
+        'SCROLL': '#574e6d',
+        'BUTTON': ('#dddddd', '#43405d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],
+        'DESCRIPTION': ['Grey', 'Winter', 'Cold'],
+    },
+    'DarkRed2': {
+        'BACKGROUND': '#ab1212',
+        'TEXT': '#f6e4b5',
+        'INPUT': '#cd3131',
+        'TEXT_INPUT': '#f6e4b5',
+        'SCROLL': '#cd3131',
+        'BUTTON': ('#f6e4b5', '#ab1212'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],
+        'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'],
+    },
+    'LightGrey6': {
+        'BACKGROUND': '#e3e3e3',
+        'TEXT': '#233142',
+        'INPUT': '#455d7a',
+        'TEXT_INPUT': '#e3e3e3',
+        'SCROLL': '#233142',
+        'BUTTON': ('#e3e3e3', '#455d7a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],
+        'DESCRIPTION': ['#000000', 'Blue', 'Red', 'Grey'],
+    },
+    'HotDogStand': {
+        'BACKGROUND': 'red',
+        'TEXT': 'yellow',
+        'INPUT': 'yellow',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': 'yellow',
+        'BUTTON': ('red', 'yellow'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+}
 
 
 def ListOfLookAndFeelValues():
@@ -7154,6 +9610,7 @@ def theme_text_element_background_color(color=None):
         set_options(text_element_background_color=color)
     return DEFAULT_TEXT_ELEMENT_BACKGROUND_COLOR
 
+
 def theme_input_background_color(color=None):
     """
     Sets/Returns the input element background color currently in use
@@ -7174,7 +9631,6 @@ def theme_input_text_color(color=None):
     if color is not None:
         set_options(input_text_color=color)
     return DEFAULT_INPUT_TEXT_COLOR
-
 
 
 def theme_button_color(color=None):
@@ -7244,7 +9700,6 @@ def theme_progress_bar_border_width(border_width=None):
     return DEFAULT_PROGRESS_BAR_BORDER_WIDTH
 
 
-
 def theme_element_text_color(color=None):
     """
     Sets/Returns the text color used by elements that have text as part of their display (Tables, Trees and Sliders)
@@ -7288,6 +9743,7 @@ def theme_previewer(columns=12):
     :param columns: (int) number of themes in a single row
     """
     preview_all_look_and_feel_themes(columns)
+
 
 def ChangeLookAndFeel(index, force=False):
     """
@@ -7350,20 +9806,22 @@ def ChangeLookAndFeel(index, force=False):
         else:
             colors['PROGRESS'] = DEFAULT_PROGRESS_BAR_COLOR_OFFICIAL
         # call to change all the colors
-        SetOptions(background_color=colors['BACKGROUND'],
-                   text_element_background_color=colors['BACKGROUND'],
-                   element_background_color=colors['BACKGROUND'],
-                   text_color=colors['TEXT'],
-                   input_elements_background_color=colors['INPUT'],
-                   # button_color=colors['BUTTON'] if not sys.platform.startswith('darwin') else None,
-                   button_color=colors['BUTTON'],
-                   progress_meter_color=colors['PROGRESS'],
-                   border_width=colors['BORDER'],
-                   slider_border_width=colors['SLIDER_DEPTH'],
-                   progress_meter_border_depth=colors['PROGRESS_DEPTH'],
-                   scrollbar_color=(colors['SCROLL']),
-                   element_text_color=colors['TEXT'],
-                   input_text_color=colors['TEXT_INPUT'])
+        SetOptions(
+            background_color=colors['BACKGROUND'],
+            text_element_background_color=colors['BACKGROUND'],
+            element_background_color=colors['BACKGROUND'],
+            text_color=colors['TEXT'],
+            input_elements_background_color=colors['INPUT'],
+            # button_color=colors['BUTTON'] if not sys.platform.startswith('darwin') else None,
+            button_color=colors['BUTTON'],
+            progress_meter_color=colors['PROGRESS'],
+            border_width=colors['BORDER'],
+            slider_border_width=colors['SLIDER_DEPTH'],
+            progress_meter_border_depth=colors['PROGRESS_DEPTH'],
+            scrollbar_color=(colors['SCROLL']),
+            element_text_color=colors['TEXT'],
+            input_text_color=colors['TEXT_INPUT'],
+        )
     except:  # most likely an index out of range
         print('** Warning - Theme value not valid. Change your theme call. **')
         print('valid values are', list_of_look_and_feel_values())
@@ -7377,15 +9835,23 @@ def preview_all_look_and_feel_themes(columns=12):
     """
 
     # Show a "splash" type message so the user doesn't give up waiting
-    popup_quick_message('Hang on for a moment, this will take a bit to create....', background_color='red', text_color='#FFFFFF', auto_close=True, non_blocking=True)
+    popup_quick_message(
+        'Hang on for a moment, this will take a bit to create....',
+        background_color='red',
+        text_color='#FFFFFF',
+        auto_close=True,
+        non_blocking=True,
+    )
 
     web = False
 
     win_bg = 'black'
 
     def sample_layout():
-        return [[Text('Text element'), InputText('Input data here', size=(10, 1))],
-                [Button('Ok'), Button('Cancel'), Slider((1, 10), orientation='h', size=(5, 15))]]
+        return [
+            [Text('Text element'), InputText('Input data here', size=(10, 1))],
+            [Button('Ok'), Button('Cancel'), Slider((1, 10), orientation='h', size=(5, 15))],
+        ]
 
     layout = [[Text('Here is a complete list of themes', font='Default 18', background_color=win_bg)]]
 
@@ -7418,18 +9884,35 @@ sprint = ScrolledTextBox
 def ObjToStringSingleObj(obj):
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    )
 
 
 def ObjToString(obj, extra='    '):
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (extra + (str(item) + ' = ' +
-                  (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(
-                      obj.__dict__[item])))
-         for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join(
+            (
+                extra
+                + (
+                    str(item)
+                    + ' = '
+                    + (
+                        ObjToString(obj.__dict__[item], extra + '    ')
+                        if hasattr(obj.__dict__[item], '__dict__')
+                        else str(obj.__dict__[item])
+                    )
+                )
+                for item in sorted(obj.__dict__)
+            )
+        )
+    )
 
 
 # ------------------------------------------------------------------------------------------------------------------ #
@@ -7439,10 +9922,25 @@ def ObjToString(obj, extra='    '):
 
 # ----------------------------------- The mighty Popup! ------------------------------------------------------------ #
 
-def Popup(*args, button_color=None, background_color=None, text_color=None, button_type=POPUP_BUTTONS_OK,
-          auto_close=False, auto_close_duration=None, custom_text=(None, None), non_blocking=False,
-          icon=DEFAULT_WINDOW_ICON, line_width=None,
-          font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+
+def Popup(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    button_type=POPUP_BUTTONS_OK,
+    auto_close=False,
+    auto_close_duration=None,
+    custom_text=(None, None),
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Popup - Display a popup box with as many parms as you wish to include
     :param args:
@@ -7471,9 +9969,20 @@ def Popup(*args, button_color=None, background_color=None, text_color=None, butt
     else:
         local_line_width = MESSAGE_BOX_LINE_WIDTH
     title = args_to_print[0] if args_to_print[0] is not None else 'None'
-    window = Window(title, auto_size_text=True, background_color=background_color, button_color=button_color,
-                    auto_close=auto_close, auto_close_duration=auto_close_duration, icon=icon, font=font,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    window = Window(
+        title,
+        auto_size_text=True,
+        background_color=background_color,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        icon=icon,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
     max_line_total, total_lines = 0, 0
     for message in args_to_print:
         # fancy code to check if string and convert if not is not need. Just always convert to string :-)
@@ -7490,7 +9999,8 @@ def Popup(*args, button_color=None, background_color=None, text_color=None, butt
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
         window.AddRow(
-            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color))
+            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)
+        )
         total_lines += height
 
     if non_blocking:
@@ -7500,33 +10010,62 @@ def Popup(*args, button_color=None, background_color=None, text_color=None, butt
     # show either an OK or Yes/No depending on paramater
     if custom_text != (None, None):
         if type(custom_text) is not tuple:
-            window.AddRow(PopupButton(custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True,
-                                      bind_return_key=True))
+            window.AddRow(
+                PopupButton(
+                    custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True, bind_return_key=True
+                )
+            )
         elif custom_text[1] is None:
             window.AddRow(
-                PopupButton(custom_text[0], size=(len(custom_text[0]), 1), button_color=button_color, focus=True,
-                            bind_return_key=True))
+                PopupButton(
+                    custom_text[0],
+                    size=(len(custom_text[0]), 1),
+                    button_color=button_color,
+                    focus=True,
+                    bind_return_key=True,
+                )
+            )
         else:
-            window.AddRow(PopupButton(custom_text[0], button_color=button_color, focus=True, bind_return_key=True,
-                                      size=(len(custom_text[0]), 1)),
-                          PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[0]), 1)))
+            window.AddRow(
+                PopupButton(
+                    custom_text[0],
+                    button_color=button_color,
+                    focus=True,
+                    bind_return_key=True,
+                    size=(len(custom_text[0]), 1),
+                ),
+                PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[0]), 1)),
+            )
     elif button_type is POPUP_BUTTONS_YES_NO:
-        window.AddRow(PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3),
-                                  size=(5, 1)), PopupButton('No', button_color=button_color, size=(5, 1)))
+        window.AddRow(
+            PopupButton(
+                'Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3), size=(5, 1)
+            ),
+            PopupButton('No', button_color=button_color, size=(5, 1)),
+        )
     elif button_type is POPUP_BUTTONS_CANCELLED:
         window.AddRow(
-            PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
+            PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3))
+        )
     elif button_type is POPUP_BUTTONS_ERROR:
-        window.AddRow(PopupButton('Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True,
-                                  pad=((20, 0), 3)))
+        window.AddRow(
+            PopupButton(
+                'Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
+            )
+        )
     elif button_type is POPUP_BUTTONS_OK_CANCEL:
-        window.AddRow(PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
-                      PopupButton('Cancel', size=(6, 1), button_color=button_color))
+        window.AddRow(
+            PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
+            PopupButton('Cancel', size=(6, 1), button_color=button_color),
+        )
     elif button_type is POPUP_BUTTONS_NO_BUTTONS:
         pass
     else:
-        window.AddRow(PopupButton('OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True,
-                                  pad=((20, 0), 3)))
+        window.AddRow(
+            PopupButton(
+                'OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
+            )
+        )
 
     if non_blocking:
         button, values = window.Read(timeout=0)
@@ -7546,9 +10085,22 @@ def MsgBox(*args):
 
 
 # --------------------------- PopupNoButtons ---------------------------
-def PopupNoButtons(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-                   auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                   no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupNoButtons(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Show a Popup but without any buttons
     :param args:
@@ -7567,18 +10119,43 @@ def PopupNoButtons(*args, button_color=None, background_color=None, text_color=N
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=POPUP_BUTTONS_NO_BUTTONS,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=POPUP_BUTTONS_NO_BUTTONS,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 # --------------------------- PopupNonBlocking ---------------------------
-def PopupNonBlocking(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                     auto_close=False, auto_close_duration=None, non_blocking=True, icon=DEFAULT_WINDOW_ICON,
-                     line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                     location=(None, None)):
+def PopupNonBlocking(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Show Popup box and immediately return (does not block)
     :param args:
@@ -7598,20 +10175,46 @@ def PopupNonBlocking(*args, button_type=POPUP_BUTTONS_OK, button_color=None, bac
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 PopupNoWait = PopupNonBlocking
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup  ---------------------------
-def PopupQuick(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-               auto_close=True, auto_close_duration=2, non_blocking=True, icon=DEFAULT_WINDOW_ICON, line_width=None,
-               font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupQuick(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=2,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Show Popup box that doesn't block and closes itself
     :param args:
@@ -7631,19 +10234,43 @@ def PopupQuick(*args, button_type=POPUP_BUTTONS_OK, button_color=None, backgroun
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup with no titlebar and no buttons ---------------------------
-def PopupQuickMessage(*args, button_type=POPUP_BUTTONS_NO_BUTTONS, button_color=None, background_color=None,
-                      text_color=None,
-                      auto_close=True, auto_close_duration=2, non_blocking=True, icon=DEFAULT_WINDOW_ICON,
-                      line_width=None,
-                      font=None, no_titlebar=True, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupQuickMessage(
+    *args,
+    button_type=POPUP_BUTTONS_NO_BUTTONS,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=2,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=True,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Show Popup box that doesn't block and closes itself
     :param args:
@@ -7663,17 +10290,42 @@ def PopupQuickMessage(*args, button_type=POPUP_BUTTONS_NO_BUTTONS, button_color=
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 # --------------------------- PopupNoTitlebar ---------------------------
-def PopupNoTitlebar(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                    auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON,
-                    line_width=None, font=None, grab_anywhere=True, keep_on_top=False, location=(None, None)):
+def PopupNoTitlebar(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    grab_anywhere=True,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Display a Popup without a titlebar.   Enables grab anywhere so you can move it
     :param args:
@@ -7692,11 +10344,23 @@ def PopupNoTitlebar(*args, button_type=POPUP_BUTTONS_OK, button_color=None, back
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=True, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=True,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 PopupNoFrame = PopupNoTitlebar
@@ -7705,10 +10369,23 @@ PopupAnnoying = PopupNoTitlebar
 
 
 # --------------------------- PopupAutoClose ---------------------------
-def PopupAutoClose(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                   auto_close=True, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON,
-                   line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                   location=(None, None)):
+def PopupAutoClose(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Popup that closes itself after some time period
     :param args:
@@ -7728,20 +10405,45 @@ def PopupAutoClose(*args, button_type=POPUP_BUTTONS_OK, button_color=None, backg
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 PopupTimed = PopupAutoClose
 
 
 # --------------------------- PopupError ---------------------------
-def PopupError(*args, button_color=DEFAULT_ERROR_BUTTON_COLOR, background_color=None, text_color=None, auto_close=False,
-               auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-               no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupError(
+    *args,
+    button_color=DEFAULT_ERROR_BUTTON_COLOR,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Popup with colored button and 'Error' as button text
     :param args:
@@ -7760,16 +10462,42 @@ def PopupError(*args, button_color=DEFAULT_ERROR_BUTTON_COLOR, background_color=
     :param location:
     :return:
     """
-    Popup(*args, button_type=POPUP_BUTTONS_ERROR, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_type=POPUP_BUTTONS_ERROR,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 # --------------------------- PopupCancel ---------------------------
-def PopupCancel(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-                auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupCancel(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Display Popup with "cancelled" button text
     :param args:
@@ -7788,16 +10516,42 @@ def PopupCancel(*args, button_color=None, background_color=None, text_color=None
     :param location:
     :return:
     """
-    Popup(*args, button_type=POPUP_BUTTONS_CANCELLED, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_type=POPUP_BUTTONS_CANCELLED,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 # --------------------------- PopupOK ---------------------------
-def PopupOK(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-            auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-            no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupOK(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Display Popup with OK button only
     :param args:
@@ -7816,16 +10570,42 @@ def PopupOK(*args, button_color=None, background_color=None, text_color=None, au
     :param location:
     :return:
     """
-    Popup(*args, button_type=POPUP_BUTTONS_OK, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_type=POPUP_BUTTONS_OK,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 # --------------------------- PopupOKCancel ---------------------------
-def PopupOKCancel(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-                  auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                  no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupOKCancel(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Display popup with OK and Cancel buttons
     :param args:
@@ -7844,16 +10624,42 @@ def PopupOKCancel(*args, button_color=None, background_color=None, text_color=No
     :param location:
     :return: OK, Cancel or None
     """
-    return Popup(*args, button_type=POPUP_BUTTONS_OK_CANCEL, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    return Popup(
+        *args,
+        button_type=POPUP_BUTTONS_OK_CANCEL,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 # --------------------------- PopupYesNo ---------------------------
-def PopupYesNo(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-               auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-               no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupYesNo(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None)
+):
     """
     Display Popup with Yes and No buttons
     :param args:
@@ -7872,10 +10678,23 @@ def PopupYesNo(*args, button_color=None, background_color=None, text_color=None,
     :param location:
     :return: Yes, No or None
     """
-    return Popup(*args, button_type=POPUP_BUTTONS_YES_NO, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    return Popup(
+        *args,
+        button_type=POPUP_BUTTONS_YES_NO,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location
+    )
 
 
 ##############################################################################
@@ -7885,9 +10704,22 @@ def PopupYesNo(*args, button_color=None, background_color=None, text_color=None,
 # --------------------------- PopupGetFolder ---------------------------
 
 
-def PopupGetFolder(message, default_path='', no_window=False, size=(None, None), button_color=None,
-                   background_color=None, text_color=None, icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False,
-                   grab_anywhere=False, keep_on_top=False, location=(None, None), initial_folder=None):
+def PopupGetFolder(
+    message,
+    default_path='',
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    initial_folder=None,
+):
     """
     Display popup with text entry field and browse button. Browse for folder
     :param message:
@@ -7921,14 +10753,25 @@ def PopupGetFolder(message, default_path='', no_window=False, size=(None, None),
         root.destroy()
         return folder_name
 
-    layout = [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
-              [InputText(default_text=default_path, size=size, key='_INPUT_'), FolderBrowse(initial_folder=initial_folder)],
-              [Button('Ok', size=(5, 1), bind_return_key=True), Button('Cancel', size=(5, 1))]]
+    layout = [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
+        [InputText(default_text=default_path, size=size, key='_INPUT_'), FolderBrowse(initial_folder=initial_folder)],
+        [Button('Ok', size=(5, 1), bind_return_key=True), Button('Cancel', size=(5, 1))],
+    ]
 
-    window = Window(title=message, layout=layout, icon=icon, auto_size_text=True, button_color=button_color,
-                    background_color=background_color,
-                    font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top,
-                    location=location)
+    window = Window(
+        title=message,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        background_color=background_color,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.Close()
@@ -7941,10 +10784,26 @@ def PopupGetFolder(message, default_path='', no_window=False, size=(None, None),
 
 # --------------------------- PopupGetFile ---------------------------
 
-def PopupGetFile(message, default_path='', default_extension='', save_as=False, file_types=(('ALL Files', '*.*'),),
-                 no_window=False, size=(None, None), button_color=None, background_color=None, text_color=None,
-                 icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                 location=(None, None), initial_folder=None):
+
+def PopupGetFile(
+    message,
+    default_path='',
+    default_extension='',
+    save_as=False,
+    file_types=(('ALL Files', '*.*'),),
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    initial_folder=None,
+):
     """
         Display popup with text entry field and browse button. Browse for file
     :param message:
@@ -7978,24 +10837,41 @@ def PopupGetFile(message, default_path='', default_extension='', save_as=False, 
         except:
             pass
         if save_as:
-            filename = tk.filedialog.asksaveasfilename(filetypes=file_types,
-                                                       defaultextension=default_extension)  # show the 'get file' dialog box
+            filename = tk.filedialog.asksaveasfilename(
+                filetypes=file_types, defaultextension=default_extension
+            )  # show the 'get file' dialog box
         else:
-            filename = tk.filedialog.askopenfilename(filetypes=file_types,
-                                                     defaultextension=default_extension)  # show the 'get file' dialog box
+            filename = tk.filedialog.askopenfilename(
+                filetypes=file_types, defaultextension=default_extension
+            )  # show the 'get file' dialog box
         root.destroy()
         return filename
 
-    browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder) if save_as else FileBrowse(
-        file_types=file_types, initial_folder=initial_folder)
+    browse_button = (
+        SaveAs(file_types=file_types, initial_folder=initial_folder)
+        if save_as
+        else FileBrowse(file_types=file_types, initial_folder=initial_folder)
+    )
 
-    layout = [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
-              [InputText(default_text=default_path, size=size, key='_INPUT_'), browse_button],
-              [Button('Ok', size=(6, 1), bind_return_key=True), Button('Cancel', size=(6, 1))]]
+    layout = [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
+        [InputText(default_text=default_path, size=size, key='_INPUT_'), browse_button],
+        [Button('Ok', size=(6, 1), bind_return_key=True), Button('Cancel', size=(6, 1))],
+    ]
 
-    window = Window(title=message, layout = layout, icon=icon, auto_size_text=True, button_color=button_color, font=font,
-                    background_color=background_color,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    window = Window(
+        title=message,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        font=font,
+        background_color=background_color,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.Close()
@@ -8006,12 +10882,24 @@ def PopupGetFile(message, default_path='', default_extension='', save_as=False, 
         return path
 
 
-
 # --------------------------- PopupGetText ---------------------------
 
-def PopupGetText(message, default_text='', password_char='', size=(None, None), button_color=None,
-                 background_color=None, text_color=None, icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False,
-                 grab_anywhere=False, keep_on_top=False, location=(None, None)):
+
+def PopupGetText(
+    message,
+    default_text='',
+    password_char='',
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display Popup with text entry field
     :param message:
@@ -8030,13 +10918,24 @@ def PopupGetText(message, default_text='', password_char='', size=(None, None), 
     :return: Text entered or None if window was closed
     """
 
-    layout = [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color, font=font)],
-              [InputText(default_text=default_text, size=size, key='_INPUT_', password_char=password_char)],
-              [Button('Ok', size=(5, 1), bind_return_key=True), Button('Cancel', size=(5, 1))]]
+    layout = [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color, font=font)],
+        [InputText(default_text=default_text, size=size, key='_INPUT_', password_char=password_char)],
+        [Button('Ok', size=(5, 1), bind_return_key=True), Button('Cancel', size=(5, 1))],
+    ]
 
-    window = Window(title=message, layout=layout, icon=icon, auto_size_text=True, button_color=button_color, no_titlebar=no_titlebar,
-                    background_color=background_color, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top,
-                    location=location)
+    window = Window(
+        title=message,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        no_titlebar=no_titlebar,
+        background_color=background_color,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.Close()
@@ -8086,12 +10985,10 @@ timer_start = TimerStart
 timer_stop = TimerStop
 sprint = sprint
 
-#------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
+# ------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
 theme(CURRENT_LOOK_AND_FEEL)
 # theme_previewer()
 # -------------------------------- ENTRY POINT IF RUN STANDALONE -------------------------------- #
-
-
 
 
 def main():
@@ -8110,64 +11007,159 @@ def main():
 
     ver = version.split('\n')[0]
 
+    def VerLine(version, description, size=(30, 1)):
+        return [
+            Column(
+                [[T(description, font='Courier 18', text_color='yellow')], [T(version, font='Courier 18', size=size)]]
+            )
+        ]
 
-    def VerLine(version, description, size=(30,1)):
-        return [Column([[T(description, font='Courier 18', text_color='yellow')], [T(version, font='Courier 18', size=size)]])]
+    menu_def = [
+        ['&File', ['&Open', '&Save', 'E&xit', 'Properties']],
+        [
+            '&Edit',
+            [
+                'Paste',
+                [
+                    'Special',
+                    'Normal',
+                ],
+                '!Undo',
+            ],
+        ],
+        [
+            '!&Disabled',
+            [
+                'Paste',
+                [
+                    'Special',
+                    'Normal',
+                ],
+                '!Undo',
+            ],
+        ],
+        ['&Help', '&About...'],
+    ]
 
-
-    menu_def = [['&File', ['&Open', '&Save', 'E&xit', 'Properties']],
-                ['&Edit', ['Paste', ['Special', 'Normal', ], '!Undo'], ],
-                ['!&Disabled', ['Paste', ['Special', 'Normal', ], '!Undo'], ],
-                ['&Help', '&About...'], ]
-
-
-    menu_def = [['File',  ['&Open::mykey', '&Save', 'E&xit', 'Properties']],
-                ['Edit', ['!Paste', ['Special', 'Normal', ], '!Undo'], ],
-                ['!Disabled', ['Has Sub', ['Item1', 'Item2', ], 'No Sub'], ],
-                ['Help', 'About...'], ]
+    menu_def = [
+        ['File', ['&Open::mykey', '&Save', 'E&xit', 'Properties']],
+        [
+            'Edit',
+            [
+                '!Paste',
+                [
+                    'Special',
+                    'Normal',
+                ],
+                '!Undo',
+            ],
+        ],
+        [
+            '!Disabled',
+            [
+                'Has Sub',
+                [
+                    'Item1',
+                    'Item2',
+                ],
+                'No Sub',
+            ],
+        ],
+        ['Help', 'About...'],
+    ]
 
     col1 = [[Text('Column 1 line  1', background_color='red')], [Text('Column 1 line 2')]]
 
     layout = [
-        [Menu(menu_def, key='_MENU_', text_color='yellow', background_color='#475841',  font='Courier 14')],
+        [Menu(menu_def, key='_MENU_', text_color='yellow', background_color='#475841', font='Courier 14')],
         # [T('123435', size=(1,8))],
-        [Text('PySimpleGUIWeb Welcomes You...', tooltip='text', font=('Comic sans ms', 20),size=(40,1), text_color='yellow', enable_events=False, key='_PySimpleGUIWeb_')],
+        [
+            Text(
+                'PySimpleGUIWeb Welcomes You...',
+                tooltip='text',
+                font=('Comic sans ms', 20),
+                size=(40, 1),
+                text_color='yellow',
+                enable_events=False,
+                key='_PySimpleGUIWeb_',
+            )
+        ],
         # [OptionMenu([])],
-        [T('System platform = %s'%sys.platform)],
+        [T('System platform = %s' % sys.platform)],
         [Image(data=DEFAULT_BASE64_ICON, enable_events=False)],
         # [Image(filename=r'C:\Python\PycharmProjects\PSG\logo500.png', key='-IMAGE-')],
         VerLine(ver, 'PySimpleGUI Version'),
         VerLine(os.path.dirname(os.path.abspath(__file__)), 'PySimpleGUI Location'),
-        VerLine(sys.version, 'Python Version', size=(60,2)),
+        VerLine(sys.version, 'Python Version', size=(60, 2)),
         VerLine(pkg_resources.get_distribution('remi').version, 'Remi Version'),
         # [Text('VERSION {}'.format(version), text_color='red', font='Courier 24')],
-        [T('Current Time '), Text('Text', key='_TEXT_', font='Arial 18', text_color='black', size=(30,1)), Column(col1, background_color='red')],
-        [T('Up Time'), Text('Text', key='_TEXT_UPTIME_', font='Arial 18', text_color='black', size=(30,1))],
-        [Input('Single Line Input', do_not_clear=True, enable_events=False, size=(30, 1), text_color='red', key='_IN_')],
+        [
+            T('Current Time '),
+            Text('Text', key='_TEXT_', font='Arial 18', text_color='black', size=(30, 1)),
+            Column(col1, background_color='red'),
+        ],
+        [T('Up Time'), Text('Text', key='_TEXT_UPTIME_', font='Arial 18', text_color='black', size=(30, 1))],
+        [
+            Input(
+                'Single Line Input', do_not_clear=True, enable_events=False, size=(30, 1), text_color='red', key='_IN_'
+            )
+        ],
         [Multiline('Multiline Input', do_not_clear=True, size=(40, 4), enable_events=False, key='_MULTI_IN_')],
         # [Output(size=(60,10))],
-        [MultilineOutput('Multiline Output', size=(80, 8), text_color='blue', font='Courier 12', key='_MULTIOUT_', autoscroll=True)],
-        [Checkbox('Checkbox 1', enable_events=True, key='_CB1_'), Checkbox('Checkbox 2', default=True, key='_CB2_', enable_events=True)],
-        [Combo(values=['Combo 1', 'Combo 2', 'Combo 3'], default_value='Combo 2', key='_COMBO_', enable_events=True,
-               readonly=False, tooltip='Combo box', disabled=False, size=(12, 1))],
-        [Listbox(values=('Listbox 1', 'Listbox 2', 'Listbox 3'), enable_events =True, size=(10, 3), key='_LIST_')],
+        [
+            MultilineOutput(
+                'Multiline Output',
+                size=(80, 8),
+                text_color='blue',
+                font='Courier 12',
+                key='_MULTIOUT_',
+                autoscroll=True,
+            )
+        ],
+        [
+            Checkbox('Checkbox 1', enable_events=True, key='_CB1_'),
+            Checkbox('Checkbox 2', default=True, key='_CB2_', enable_events=True),
+        ],
+        [
+            Combo(
+                values=['Combo 1', 'Combo 2', 'Combo 3'],
+                default_value='Combo 2',
+                key='_COMBO_',
+                enable_events=True,
+                readonly=False,
+                tooltip='Combo box',
+                disabled=False,
+                size=(12, 1),
+            )
+        ],
+        [Listbox(values=('Listbox 1', 'Listbox 2', 'Listbox 3'), enable_events=True, size=(10, 3), key='_LIST_')],
         # [Image(filename=r'C:\Python\PycharmProjects\PSG\logo200.png', enable_events=False)],
         [Slider((1, 100), default_value=80, key='_SLIDER_', visible=True, enable_events=True, orientation='v')],
         [Spin(values=(1, 2, 3), initial_value='2', size=(4, 1), key='_SPIN_', enable_events=True)],
-        [OK(), Button('Hidden', visible=False, key='_HIDDEN_'), Button('Values'), Button('Exit', button_color=('white', 'red')), Button('UnHide'), B('Popup')]
+        [
+            OK(),
+            Button('Hidden', visible=False, key='_HIDDEN_'),
+            Button('Values'),
+            Button('Exit', button_color=('white', 'red')),
+            Button('UnHide'),
+            B('Popup'),
+        ],
     ]
 
-    window = Window('PySimpleGUIWeb Test Harness Window', layout,
-                    font='Arial 18',
-                    icon=DEFAULT_BASE64_ICON,
-                    default_element_size=(12,1),
-                     auto_size_buttons=False)
+    window = Window(
+        'PySimpleGUIWeb Test Harness Window',
+        layout,
+        font='Arial 18',
+        icon=DEFAULT_BASE64_ICON,
+        default_element_size=(12, 1),
+        auto_size_buttons=False,
+    )
 
     start_time = datetime.datetime.now()
     while True:
         event, values = window.Read(timeout=100)
         window.Element('_TEXT_').Update(str(datetime.datetime.now()))
-        window.Element('_TEXT_UPTIME_').Update(str(datetime.datetime.now()-start_time))
+        window.Element('_TEXT_UPTIME_').Update(str(datetime.datetime.now() - start_time))
         print(event, values) if event != TIMEOUT_KEY else None
         if event in (None, 'Exit'):
             break
@@ -8178,7 +11170,7 @@ def main():
             window.Element('_PySimpleGUIWeb_').Widget.style['background-image'] = "url('/my_resources:mine.png')"
 
         elif event == 'Values':
-            window.Element('_MULTIOUT_').Update(str(values)+'\n', append=True)
+            window.Element('_MULTIOUT_').Update(str(values) + '\n', append=True)
             # nav = remi.gui.FileFolderNavigator(False,r'a:\TEMP', True, False)
             # here is returned the Input Dialog widget, and it will be shown
             # fileselectionDialog.show(window.Element('_IN_').Widget)

--- a/FreeSimpleGUIWeb/setup.py
+++ b/FreeSimpleGUIWeb/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/FreeSimpleGUIWx/FreeSimpleGUIWx/FreeSimpleGUIWx.py
+++ b/FreeSimpleGUIWx/FreeSimpleGUIWx/FreeSimpleGUIWx.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
-version = __version__ = (
-    '0.17.1.5 Unreleased\n VSeparator added (spelling error), Radio.reset_group added and removed the clearing all when one cleared, added default key for one_line_progress_meter, auto-add keys to tables & trees, added theme_add_new'
-)
+version = __version__ = '0.17.1.5 Unreleased\n VSeparator added (spelling error), Radio.reset_group added and removed the clearing all when one cleared, added default key for one_line_progress_meter, auto-add keys to tables & trees, added theme_add_new'
 
 port = 'PySimpleGUIWx'
 
@@ -356,13 +354,9 @@ class Element:
                 ELEM_TYPE_TAB,
                 ELEM_TYPE_COLUMN,
             ):
-                self.Size = _convert_tkinter_size_to_Wx(
-                    size, DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT, DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE
-                )
+                self.Size = _convert_tkinter_size_to_Wx(size, DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT, DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE)
             else:
-                self.Size = _convert_tkinter_size_to_Wx(
-                    size, DEFAULT_PIXELS_TO_CHARS_SCALING, DEFAULT_PIXEL_TO_CHARS_CUTOFF
-                )
+                self.Size = _convert_tkinter_size_to_Wx(size, DEFAULT_PIXELS_TO_CHARS_SCALING, DEFAULT_PIXEL_TO_CHARS_CUTOFF)
         self.Type = elem_type
         self.AutoSizeText = auto_size_text
         # self.Pad = DEFAULT_ELEMENT_PADDING if pad is None else pad
@@ -492,9 +486,7 @@ class Element:
     def _WxCallbackKeyboard(self, value):
         element_callback_quit_mainloop(self)
 
-    def Update(
-        self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None
-    ):
+    def Update(self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None):
         if font:
             widget.SetFont(font_to_wx_font(font))
         if text_color not in (None, COLOR_SYSTEM_DEFAULT):
@@ -589,9 +581,7 @@ class InputText(Element):
             size_px=size_px,
         )
 
-    def Update(
-        self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None):
         if disabled is True:
             self.WxTextCtrl.Enable(True)
         elif disabled is False:
@@ -606,9 +596,7 @@ class InputText(Element):
         #     self.ParentForm.VisibilityChanged()
         # elif visible is False:
         #     self.WxTextCtrl.Hide()
-        super().Update(
-            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         return self.WxTextCtrl.GetValue()
@@ -710,9 +698,7 @@ class Combo(Element):
         if readonly is not None:
             self.WxComboBox.SetWindowStyle(wx.CB_READONLY)
 
-        super().Update(
-            self.WxComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.WxComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     update = Update
 
@@ -967,9 +953,7 @@ class Radio(Element):
             self.WxRadioButton.SetValue(True)
         elif value is False:
             self.WxRadioButton.SetValue(False)
-        super().Update(
-            self.WxRadioButton, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.WxRadioButton, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def reset_group(self):
         self.WxRadioButton.SetValue(True)
@@ -1138,9 +1122,7 @@ class Spin(Element):
         if self.ChangeSubmits:
             element_callback_quit_mainloop(self)
 
-    def Update(
-        self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
         if values != None:
             self.Values = values
             self.QT_Spinner.setStrings(values)
@@ -1156,9 +1138,7 @@ class Spin(Element):
             self.QT_Spinner.setDisabled(True)
         elif disabled == False:
             self.QT_Spinner.setDisabled(False)
-        super().Update(
-            self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         return self.WxSpinCtrl.GetValue()
@@ -1238,9 +1218,7 @@ class Multiline(Element):
         )
         return
 
-    def Update(
-        self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
         try:  # added in case the widget has already been deleted for some readon.
             if value is not None and not append:
                 self.WxTextCtrl.SetValue(value)
@@ -1259,9 +1237,7 @@ class Multiline(Element):
         except:
             pass
 
-        super().Update(
-            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     #
     # def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
@@ -1357,9 +1333,7 @@ class MultilineOutput(Element):
         )
         return
 
-    def Update(
-        self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None
-    ):
+    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
         if value is not None and not append:
             self.WxTextCtrl.SetLabel(value)
         elif value is not None and append:
@@ -1374,9 +1348,7 @@ class MultilineOutput(Element):
             self.WxTextCtrl.Enable(True)
         elif disabled is False:
             self.WxTextCtrl.Enable(False)
-        super().Update(
-            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def Get(self):
         self.WxTextCtrl.GetValue()
@@ -1476,9 +1448,7 @@ class Text(Element):
             self.WxStaticText.SetForegroundColour(text_color)
         if font is not None:
             self.WxStaticText.SetFont(font)
-        super().Update(
-            self.WxStaticText, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.WxStaticText, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     update = Update
 
@@ -1563,9 +1533,7 @@ class Output(Element):
     def Update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.WxTextCtrl.AppendText(value)
-        super().Update(
-            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
-        )
+        super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
     def __del__(self):
         try:
@@ -1742,9 +1710,7 @@ class Button(Element):
         elif self.BType == BUTTON_TYPE_BROWSE_FILE:  # Browse File
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(
-                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN
-                )
+                dialog = wx.FileDialog(self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN)
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_OPEN)
             file_name = ''
@@ -1760,9 +1726,7 @@ class Button(Element):
         elif self.BType == BUTTON_TYPE_BROWSE_FILES:  # Browse Files
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(
-                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE
-                )
+                dialog = wx.FileDialog(self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE)
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_MULTIPLE)
             file_names = ''
@@ -1786,9 +1750,7 @@ class Button(Element):
                     style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
                 )
             else:
-                dialog = wx.FileDialog(
-                    self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
-                )
+                dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
             file_name = ''
             if dialog.ShowModal() == wx.ID_OK:
                 file_name = dialog.GetPath()
@@ -1843,9 +1805,7 @@ class Button(Element):
             self.ParentForm.MasterFrame.Close()
             self.ParentForm._Close()
             Window.DecrementOpenCount()
-        elif (
-            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
-        ):  # this is a return type button so GET RESULTS and destroy window
+        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
             should_submit_window = False
 
         if should_submit_window:
@@ -1981,9 +1941,7 @@ class ProgressBar(Element):
 #                           Image                                        #
 # ---------------------------------------------------------------------- #
 class Image(Element):
-    def __init__(
-        self, filename=None, data=None, background_color=None, size=(None, None), pad=None, key=None, tooltip=None
-    ):
+    def __init__(self, filename=None, data=None, background_color=None, size=(None, None), pad=None, key=None, tooltip=None):
         '''
         Image Element
         :param filename:
@@ -2048,9 +2006,7 @@ class Canvas(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self._TKCanvas = canvas
 
-        super().__init__(
-            ELEM_TYPE_CANVAS, background_color=background_color, size=size, pad=pad, key=key, tooltip=tooltip
-        )
+        super().__init__(ELEM_TYPE_CANVAS, background_color=background_color, size=size, pad=pad, key=key, tooltip=tooltip)
         return
 
     @property
@@ -2096,9 +2052,7 @@ class Graph(Element):
         self.DragSubmits = drag_submits
         self.ClickPosition = (None, None)
         self.MouseButtonDown = False
-        super().__init__(
-            ELEM_TYPE_GRAPH, background_color=background_color, size_px=canvas_size, pad=pad, key=key, tooltip=tooltip
-        )
+        super().__init__(ELEM_TYPE_GRAPH, background_color=background_color, size_px=canvas_size, pad=pad, key=key, tooltip=tooltip)
         return
 
     def _convert_xy_to_canvas_xy(self, x_in, y_in):
@@ -2224,9 +2178,7 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        text_id = self._TKCanvas2.create_text(
-            converted_point[0], converted_point[1], text=text, font=font, fill=color, angle=angle
-        )
+        text_id = self._TKCanvas2.create_text(converted_point[0], converted_point[1], text=text, font=font, fill=color, angle=angle)
         return text_id
 
     def Erase(self):
@@ -2781,9 +2733,7 @@ class Column(Element):
         self.ElementJustification = element_justification
         tsize = size_px if size_px != (None, None) else size
 
-        super().__init__(
-            ELEM_TYPE_COLUMN, background_color=background_color, size_px=tsize, pad=pad, key=key, visible=visible
-        )
+        super().__init__(ELEM_TYPE_COLUMN, background_color=background_color, size_px=tsize, pad=pad, key=key, visible=visible)
         return
 
     def _AddRow(self, *args):
@@ -3030,9 +2980,7 @@ class Tree(Element):
     def add_treeview_data(self, node):
         # print(f'Inserting {node.key} under parent {node.parent}')
         if node.key != '':
-            self.TKTreeview.insert(
-                node.parent, 'end', node.key, text=node.text, values=node.values, open=self.ShowExpanded
-            )
+            self.TKTreeview.insert(node.parent, 'end', node.key, text=node.text, values=node.values, open=self.ShowExpanded)
         for node in node.children:
             self.add_treeview_data(node)
 
@@ -3088,10 +3036,7 @@ class TreeData(object):
         return self._NodeStr(self.root_node, 1)
 
     def _NodeStr(self, node, level):
-        return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text)]
-            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
-        )
+        return '\n'.join([str(node.key) + ' : ' + str(node.text)] + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
 
 
 # ---------------------------------------------------------------------- #
@@ -3477,11 +3422,7 @@ class Window:
         self.Title = title
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = _convert_tkinter_size_to_Wx(default_element_size)
-        self.DefaultButtonElementSize = (
-            _convert_tkinter_size_to_Wx(default_button_element_size)
-            if default_button_element_size != (None, None)
-            else _convert_tkinter_size_to_Wx(DEFAULT_BUTTON_ELEMENT_SIZE)
-        )
+        self.DefaultButtonElementSize = _convert_tkinter_size_to_Wx(default_button_element_size) if default_button_element_size != (None, None) else _convert_tkinter_size_to_Wx(DEFAULT_BUTTON_ELEMENT_SIZE)
         self.Location = location
         self.ButtonColor = button_color if button_color else DEFAULT_BUTTON_COLOR
         self.BackgroundColor = background_color if background_color else DEFAULT_BACKGROUND_COLOR
@@ -3489,11 +3430,7 @@ class Window:
         self.Font = font if font else DEFAULT_FONT
         self.RadioDict = {}
         self.BorderDepth = border_depth
-        self.WindowIcon = (
-            Window.user_defined_icon
-            if Window.user_defined_icon is not None
-            else icon if icon is not None else DEFAULT_WINDOW_ICON
-        )
+        self.WindowIcon = Window.user_defined_icon if Window.user_defined_icon is not None else icon if icon is not None else DEFAULT_WINDOW_ICON
         self.AutoClose = auto_close
         self.NonBlocking = False
         self.TKroot = None
@@ -3583,9 +3520,7 @@ class Window:
         return self
 
     def LayoutAndRead(self, rows, non_blocking=False):
-        raise DeprecationWarning(
-            'LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()'
-        )
+        raise DeprecationWarning('LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()')
         # self.AddRows(rows)
         # self.Show(non_blocking=non_blocking)
         # return self.ReturnValues
@@ -3795,13 +3730,9 @@ class Window:
                 self.LastButtonClicked = None
             return results
         else:
-            if (
-                not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None
-            ):  # Special Qt case because returning for no reason so fake timeout
+            if not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None:  # Special Qt case because returning for no reason so fake timeout
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
-            elif (
-                not self.XFound and self.ReturnValues[0] is None
-            ):  # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
+            elif not self.XFound and self.ReturnValues[0] is None:  # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
                 # print("*** Faking timeout ***")
                 self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
             return self.ReturnValues
@@ -3919,18 +3850,10 @@ class Window:
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        (
-                            print('*** Duplicate key found in your layout {} ***'.format(element.Key))
-                            if element.Type != ELEM_TYPE_BUTTON
-                            else None
-                        )
+                        (print('*** Duplicate key found in your layout {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None)
                         element.Key = element.Key + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
-                        (
-                            print('*** Replaced new key with {} ***'.format(element.Key))
-                            if element.Type != ELEM_TYPE_BUTTON
-                            else None
-                        )
+                        (print('*** Replaced new key with {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None)
                     key_dict[element.Key] = element
         return key_dict
 
@@ -4189,9 +4112,7 @@ def quit_mainloop(window):
 # =========================================================================== #
 # Convert from characters to pixels                                           #
 # =========================================================================== #
-def _convert_tkinter_size_to_Wx(
-    size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF
-):
+def _convert_tkinter_size_to_Wx(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF):
     """
     Converts size in characters to size in pixels
     :param size:  size in characters, rows
@@ -4243,9 +4164,7 @@ def preprocess_radio_elements(top_window, window):
         for element in row:
             if element.Type == ELEM_TYPE_INPUT_RADIO:
                 if element.WxRadioButton is None:
-                    element.WxRadioButton = wx.RadioButton(
-                        top_window.MasterPanel, id=wx.ID_ANY, label=element.Text, style=wx.RB_GROUP
-                    )
+                    element.WxRadioButton = wx.RadioButton(top_window.MasterPanel, id=wx.ID_ANY, label=element.Text, style=wx.RB_GROUP)
                     create_wx_radio_buttons(top_window, top_window, element.GroupID)
             if element.Type in (ELEM_TYPE_COLUMN, ELEM_TYPE_FRAME, ELEM_TYPE_TAB_GROUP, ELEM_TYPE_TAB):
                 preprocess_radio_elements(top_window, element)
@@ -5186,11 +5105,7 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
             if not initialize_only:
                 if element.Type == ELEM_TYPE_INPUT_TEXT:
                     value = element.WxTextCtrl.GetValue()
-                    if (
-                        not top_level_form.NonBlocking
-                        and not element.do_not_clear
-                        and not top_level_form.ReturnKeyboardEvents
-                    ):
+                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
                         element.WxTextCtrl.SetValue('')
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
                     value = element.WxCheckbox.GetValue()
@@ -5238,11 +5153,7 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                     except:
                         pass
 
-                    if (
-                        not top_level_form.NonBlocking
-                        and not element.do_not_clear
-                        and not top_level_form.ReturnKeyboardEvents
-                    ):
+                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
                         element.WxTextCtrl.SetValue('')
                 elif element.Type == ELEM_TYPE_TAB_GROUP:
                     try:
@@ -5262,29 +5173,12 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 value = None
 
             # if an input type element, update the results
-            if (
-                element.Type != ELEM_TYPE_BUTTON
-                and element.Type != ELEM_TYPE_TEXT
-                and element.Type != ELEM_TYPE_IMAGE
-                and element.Type != ELEM_TYPE_OUTPUT
-                and element.Type != ELEM_TYPE_PROGRESS_BAR
-                and element.Type != ELEM_TYPE_COLUMN
-                and element.Type != ELEM_TYPE_FRAME
-                and element.Type != ELEM_TYPE_TAB
-            ):
+            if element.Type != ELEM_TYPE_BUTTON and element.Type != ELEM_TYPE_TEXT and element.Type != ELEM_TYPE_IMAGE and element.Type != ELEM_TYPE_OUTPUT and element.Type != ELEM_TYPE_PROGRESS_BAR and element.Type != ELEM_TYPE_COLUMN and element.Type != ELEM_TYPE_FRAME and element.Type != ELEM_TYPE_TAB:
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
             elif (
-                (
-                    element.Type == ELEM_TYPE_BUTTON
-                    and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER
-                    and element.Target == (None, None)
-                )
-                or (
-                    element.Type == ELEM_TYPE_BUTTON
-                    and element.BType == BUTTON_TYPE_COLOR_CHOOSER
-                    and element.Target == (None, None)
-                )
+                (element.Type == ELEM_TYPE_BUTTON and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER and element.Target == (None, None))
+                or (element.Type == ELEM_TYPE_BUTTON and element.BType == BUTTON_TYPE_COLOR_CHOOSER and element.Target == (None, None))
                 or (
                     element.Type == ELEM_TYPE_BUTTON
                     and element.Key is not None
@@ -5761,11 +5655,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                style = (
-                    wx.ALIGN_LEFT
-                    if justification.startswith('l')
-                    else wx.ALIGN_CENTER if justification.startswith('c') else wx.ALIGN_RIGHT
-                )
+                style = wx.ALIGN_LEFT if justification.startswith('l') else wx.ALIGN_CENTER if justification.startswith('c') else wx.ALIGN_RIGHT
                 # print(border_depth, element.BorderWidth)
                 if border_depth:
                     if element.Relief:
@@ -5777,9 +5667,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                             style |= wx.RAISED_BORDER
                         elif element.Relief in (RELIEF_SUNKEN, RELIEF_SUNKEN):
                             style |= wx.SUNKEN_BORDER
-                statictext = element.WxStaticText = wx.StaticText(
-                    toplevel_form.MasterPanel, -1, element.DisplayText, style=style
-                )
+                statictext = element.WxStaticText = wx.StaticText(toplevel_form.MasterPanel, -1, element.DisplayText, style=style)
                 if font:
                     statictext.SetFont(font_to_wx_font(font))
                 if element.TextColor not in (None, COLOR_SYSTEM_DEFAULT):
@@ -5839,9 +5727,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 if auto_size:
                     element.WxButton.SetWindowStyleFlag(element.WxButton.GetWindowStyleFlag() | wx.BU_EXACTFIT)
                 else:
-                    element.WxButton.SetMinSize(
-                        _convert_tkinter_size_to_Wx((width, height), DEFAULT_PIXEL_TO_CHARS_CUTOFF)
-                    )
+                    element.WxButton.SetMinSize(_convert_tkinter_size_to_Wx((width, height), DEFAULT_PIXEL_TO_CHARS_CUTOFF))
                 if element.ButtonColor != (None, None) and element.ButtonColor != DEFAULT_BUTTON_COLOR:
                     bc = element.ButtonColor
                 elif toplevel_form.ButtonColor != (None, None) and toplevel_form.ButtonColor != DEFAULT_BUTTON_COLOR:
@@ -5915,11 +5801,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = (
-                    wx.ALIGN_LEFT
-                    if justification.startswith('l')
-                    else wx.ALIGN_CENTER_HORIZONTAL if justification.startswith('c') else wx.ALIGN_RIGHT
-                )
+                justify = wx.ALIGN_LEFT if justification.startswith('l') else wx.ALIGN_CENTER_HORIZONTAL if justification.startswith('c') else wx.ALIGN_RIGHT
                 if element.PasswordCharacter:
                     justify |= wx.TE_PASSWORD
 
@@ -6165,9 +6047,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 style = wx.GA_HORIZONTAL if element.Orientation.startswith('h') else wx.GA_VERTICAL
                 element_size = element_size[::-1] if element.Orientation.startswith('v') else element_size
                 element_size = wx.Size((element_size[0], element_size[1]))
-                element.WxGauge = gauge = wx.Gauge(
-                    toplevel_form.MasterPanel, wx.ID_ANY, range=element.MaxValue, style=style, size=element_size
-                )
+                element.WxGauge = gauge = wx.Gauge(toplevel_form.MasterPanel, wx.ID_ANY, range=element.MaxValue, style=style, size=element_size)
                 if element.StartValue is not None:
                     gauge.SetValue(element.StartValue)
                 do_font_and_color(element.WxGauge)
@@ -6209,9 +6089,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 full_element_pad = saved_pad
                 ######## Now make a "Spin Button" that has the arrows ########
                 # element.WxSpinCtrl = widget = wx.SpinCtrl(toplevel_form.MasterPanel, style=wx.SP_WRAP|wx.SP_ARROW_KEYS)
-                element.WxSpinCtrl = widget = wx.SpinButton(
-                    toplevel_form.MasterPanel, style=wx.SP_WRAP | wx.SP_ARROW_KEYS
-                )
+                element.WxSpinCtrl = widget = wx.SpinButton(toplevel_form.MasterPanel, style=wx.SP_WRAP | wx.SP_ARROW_KEYS)
                 do_font_and_color(element.WxSpinCtrl)
                 element.WxSpinCtrl.SetRange(0, len(element.Values) - 1)
                 if element.DefaultValue:
@@ -6324,9 +6202,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 # if not element.Visible:
                 #     hsizer.Hide(vsizer, recursive=True)
                 # element.panel = panel = wx.Panel(toplevel_form.MasterFrame)
-                element.WxBoxSizer = vsizer = wx.StaticBoxSizer(
-                    orient=wx.VERTICAL, parent=toplevel_form.MasterFrame.panel, label=element.Title
-                )
+                element.WxBoxSizer = vsizer = wx.StaticBoxSizer(orient=wx.VERTICAL, parent=toplevel_form.MasterFrame.panel, label=element.Title)
                 element.WxHSizer = hsizer
                 PackFormIntoFrame(element, vsizer, toplevel_form)
 
@@ -6612,9 +6488,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 if element.Orientation.lower().startswith('v'):
                     element.WxStaticLine = static_line = wx.StaticLine(toplevel_form.MasterPanel, style=wx.LI_VERTICAL)
                 else:
-                    element.WxStaticLine = static_line = wx.StaticLine(
-                        toplevel_form.MasterPanel, style=wx.LI_HORIZONTAL
-                    )
+                    element.WxStaticLine = static_line = wx.StaticLine(toplevel_form.MasterPanel, style=wx.LI_HORIZONTAL)
 
                 do_font_and_color(element.WxStaticLine)
 
@@ -6759,9 +6633,7 @@ def StartupTK(window: Window):
 
     if window.AutoClose:
         window.timer = wx.Timer(window.App, id=Window.NumOpenWindows)
-        window.App.Bind(
-            wx.EVT_TIMER, lambda frame: window.autoclose_timer_callback(window.MasterFrame), id=Window.NumOpenWindows
-        )
+        window.App.Bind(wx.EVT_TIMER, lambda frame: window.autoclose_timer_callback(window.MasterFrame), id=Window.NumOpenWindows)
         window.timer.Start(milliseconds=window.AutoCloseDuration * 1000, oneShot=wx.TIMER_ONE_SHOT)
     # ------------------------------------ MAINLOOP ------------------------------------
 
@@ -6874,9 +6746,7 @@ class QuickMeter(object):
         layout = []
         if self.orientation.lower().startswith('h'):
             col = []
-            col += [
-                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
-            ]  ### convert all *args into one string that can be updated
+            col += [[T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]]  ### convert all *args into one string that can be updated
             col += [
                 [T('', size=(25, 8), key='_STATS_')],
                 [ProgressBar(max_value=self.max_value, orientation='h', key='_PROG_', size=self.size)],
@@ -6886,9 +6756,7 @@ class QuickMeter(object):
         else:
             col = [[ProgressBar(max_value=self.max_value, orientation='v', key='_PROG_', size=self.size)]]
             col2 = []
-            col2 += [
-                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
-            ]  ### convert all *args into one string that can be updated
+            col2 += [[T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]]  ### convert all *args into one string that can be updated
             col2 += [[T('', size=(25, 8), key='_STATS_')], [Cancel(button_color=self.button_color), Stretch()]]
             layout = [Column(col), Column(col2)]
         self.window = Window(self.title, grab_anywhere=self.grab_anywhere, border_depth=self.border_width)
@@ -6901,18 +6769,12 @@ class QuickMeter(object):
         self.max_value = max_value
         self.window.Element('_PROG_').UpdateBar(self.current_value, self.max_value)
         self.window.Element('_STATS_').Update('\n'.join(self.ComputeProgressStats()))
-        self.window.Element('_OPTMSG_').Update(
-            value=''.join(map(lambda x: str(x) + '\n', args))
-        )  ###  update the string with the args
+        self.window.Element('_OPTMSG_').Update(value=''.join(map(lambda x: str(x) + '\n', args)))  ###  update the string with the args
         event, values = self.window.Read(timeout=0)
         if event in ('Cancel', None) or current_value >= max_value:
             self.window.Close()
             del QuickMeter.active_meters[self.key]
-            QuickMeter.exit_reasons[self.key] = (
-                METER_REASON_CANCELLED
-                if event == 'Cancel'
-                else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
-            )
+            QuickMeter.exit_reasons[self.key] = METER_REASON_CANCELLED if event == 'Cancel' else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
             return QuickMeter.exit_reasons[self.key]
         return METER_OK
 
@@ -7046,9 +6908,7 @@ class DebugWin:
             grab_anywhere=grab_anywhere,
             keep_on_top=keep_on_top,
         )
-        self.output_element = (
-            MultilineOutput(size=win_size, key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
-        )
+        self.output_element = MultilineOutput(size=win_size, key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
 
         if no_button:
             self.layout = [[self.output_element]]
@@ -7145,9 +7005,7 @@ def EasyPrintClose():
 
 # ========================  Scrolled Text Box   =====#
 # ===================================================#
-def PopupScrolled(
-    *args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None, size=(None, None)
-):
+def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None, size=(None, None)):
     if not args:
         return
     width, height = size
@@ -7173,9 +7031,7 @@ def PopupScrolled(
         height_computed += lines_needed
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = (
-        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
-    )
+    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
     if height:
         height_computed = height
     form.AddRow(Multiline(complete_output, size=(max_line_width, height_computed)))
@@ -9547,35 +9403,13 @@ sprint = ScrolledTextBox
 def ObjToStringSingleObj(obj):
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
-    )
+    return str(obj.__class__) + '\n' + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
 
 
 def ObjToString(obj, extra='    '):
     if obj is None:
         return 'None'
-    return (
-        str(obj.__class__)
-        + '\n'
-        + '\n'.join(
-            (
-                extra
-                + (
-                    str(item)
-                    + ' = '
-                    + (
-                        ObjToString(obj.__dict__[item], extra + '    ')
-                        if hasattr(obj.__dict__[item], '__dict__')
-                        else str(obj.__dict__[item])
-                    )
-                )
-                for item in sorted(obj.__dict__)
-            )
-        )
-    )
+    return str(obj.__class__) + '\n' + '\n'.join((extra + (str(item) + ' = ' + (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(obj.__dict__[item]))) for item in sorted(obj.__dict__)))
 
 
 # ------------------------------------------------------------------------------------------------------------------ #
@@ -9671,9 +9505,7 @@ def Popup(
         max_line_total = max(max_line_total, width_used)
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
-        window.AddRow(
-            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)
-        )
+        window.AddRow(Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color))
         total_lines += height
 
     if non_blocking:
@@ -9683,11 +9515,7 @@ def Popup(
     # show either an OK or Yes/No depending on paramater
     if custom_text != (None, None):
         if type(custom_text) is not tuple:
-            window.AddRow(
-                PopupButton(
-                    custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True, bind_return_key=True
-                )
-            )
+            window.AddRow(PopupButton(custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True, bind_return_key=True))
         elif custom_text[1] is None:
             window.AddRow(
                 PopupButton(
@@ -9711,21 +9539,13 @@ def Popup(
             )
     elif button_type is POPUP_BUTTONS_YES_NO:
         window.AddRow(
-            PopupButton(
-                'Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3), size=(5, 1)
-            ),
+            PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3), size=(5, 1)),
             PopupButton('No', button_color=button_color, size=(5, 1)),
         )
     elif button_type is POPUP_BUTTONS_CANCELLED:
-        window.AddRow(
-            PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3))
-        )
+        window.AddRow(PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
     elif button_type is POPUP_BUTTONS_ERROR:
-        window.AddRow(
-            PopupButton(
-                'Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
-            )
-        )
+        window.AddRow(PopupButton('Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
     elif button_type is POPUP_BUTTONS_OK_CANCEL:
         window.AddRow(
             PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
@@ -9734,11 +9554,7 @@ def Popup(
     elif button_type is POPUP_BUTTONS_NO_BUTTONS:
         pass
     else:
-        window.AddRow(
-            PopupButton(
-                'OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
-            )
-        )
+        window.AddRow(PopupButton('OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
 
     if non_blocking:
         button, values = window.Read(timeout=0)
@@ -10517,11 +10333,7 @@ def PopupGetFile(
             file_name = ''
         return file_name
 
-    browse_button = (
-        SaveAs(file_types=file_types, initial_folder=initial_folder)
-        if save_as
-        else FileBrowse(file_types=file_types, initial_folder=initial_folder)
-    )
+    browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder) if save_as else FileBrowse(file_types=file_types, initial_folder=initial_folder)
 
     layout = [
         [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],

--- a/FreeSimpleGUIWx/FreeSimpleGUIWx/FreeSimpleGUIWx.py
+++ b/FreeSimpleGUIWx/FreeSimpleGUIWx/FreeSimpleGUIWx.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
-version = __version__ = '0.17.1.5 Unreleased\n VSeparator added (spelling error), Radio.reset_group added and removed the clearing all when one cleared, added default key for one_line_progress_meter, auto-add keys to tables & trees, added theme_add_new'
+version = __version__ = (
+    '0.17.1.5 Unreleased\n VSeparator added (spelling error), Radio.reset_group added and removed the clearing all when one cleared, added default key for one_line_progress_meter, auto-add keys to tables & trees, added theme_add_new'
+)
 
 port = 'PySimpleGUIWx'
 
@@ -18,7 +20,6 @@ import time
 from random import randint
 
 RUN_INSPECTION_TOOL = False
-
 
 
 ######           #####                                       #####   #     #  ###  #     #
@@ -92,10 +93,10 @@ DEFAULT_DEBUG_WINDOW_SIZE = (80, 20)
 DEFAULT_WINDOW_LOCATION = (None, None)
 MAX_SCROLLED_TEXT_BOX_HEIGHT = 50
 DEFAULT_TOOLTIP_TIME = 400
-DEFAULT_PIXELS_TO_CHARS_SCALING = (10,26)      # 1 character represents x by y pixels
-DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT = (10,20)      # 1 character represents x by y pixels
-DEFAULT_PIXEL_TO_CHARS_CUTOFF = 20             # number of chars that triggers using pixels instead of chars
-DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE = 70             # number of chars that triggers using pixels instead of chars
+DEFAULT_PIXELS_TO_CHARS_SCALING = (10, 26)  # 1 character represents x by y pixels
+DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT = (10, 20)  # 1 character represents x by y pixels
+DEFAULT_PIXEL_TO_CHARS_CUTOFF = 20  # number of chars that triggers using pixels instead of chars
+DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE = 70  # number of chars that triggers using pixels instead of chars
 MENU_DISABLED_CHARACTER = '!'
 MENU_KEY_SEPARATOR = '::'
 
@@ -105,12 +106,14 @@ PURPLES = ('#480656', '#4F2398', '#380474')
 GREENS = ('#01826B', '#40A860', '#96D2AB', '#00A949', '#003532')
 YELLOWS = ('#F3FB62', '#F0F595')
 TANS = ('#FFF9D5', '#F4EFCF', '#DDD8BA')
-NICE_BUTTON_COLORS = ((GREENS[3], TANS[0]),
-                      ('#000000', '#FFFFFF'),
-                      ('#FFFFFF', '#000000'),
-                      (YELLOWS[0], PURPLES[1]),
-                      (YELLOWS[0], GREENS[3]),
-                      (YELLOWS[0], BLUES[2]))
+NICE_BUTTON_COLORS = (
+    (GREENS[3], TANS[0]),
+    ('#000000', '#FFFFFF'),
+    ('#FFFFFF', '#000000'),
+    (YELLOWS[0], PURPLES[1]),
+    (YELLOWS[0], GREENS[3]),
+    (YELLOWS[0], BLUES[2]),
+)
 
 COLOR_SYSTEM_DEFAULT = '1234567890'  # Colors should never be this long
 DEFAULT_BUTTON_COLOR = ('white', BLUES[0])  # Foreground, Background (None, None) == System Default
@@ -118,8 +121,6 @@ OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR = ('white', BLUES[0])  # Colors should never b
 
 
 CURRENT_LOOK_AND_FEEL = 'DarkBlue3'
-
-
 
 
 DEFAULT_ERROR_BUTTON_COLOR = ('#FFFFFF', '#FF0000')
@@ -170,7 +171,7 @@ SELECT_MODE_MULTIPLE = 00000
 LISTBOX_SELECT_MODE_MULTIPLE = 'multiple'
 SELECT_MODE_BROWSE = 00000
 LISTBOX_SELECT_MODE_BROWSE = 'browse'
-SELECT_MODE_EXTENDED =00000
+SELECT_MODE_EXTENDED = 00000
 LISTBOX_SELECT_MODE_EXTENDED = 'extended'
 SELECT_MODE_SINGLE = 00000
 LISTBOX_SELECT_MODE_SINGLE = 'single'
@@ -227,8 +228,9 @@ ICON_SCREEN_DEPTH = -1
 
 ICON_STOP = 512
 
+
 # a shameful global variable. This represents the top-level window information. Needed because opening a second window is different than opening the first.
-class MyWindows():
+class MyWindows:
     def __init__(self):
         self.NumOpenWindows = 0
         self.user_defined_icon = None
@@ -249,7 +251,8 @@ _my_windows = MyWindows()  # terrible hack using globals... means need a class f
 # ====================================================================== #
 # One-liner functions that are handy as f_ck                             #
 # ====================================================================== #
-def RGB(red, green, blue): return '#%02x%02x%02x' % (red, green, blue)
+def RGB(red, green, blue):
+    return '#%02x%02x%02x' % (red, green, blue)
 
 
 # ====================================================================== #
@@ -270,7 +273,7 @@ BUTTON_TYPE_REALTIME = 9
 BUTTON_TYPE_CALENDAR_CHOOSER = 30
 BUTTON_TYPE_COLOR_CHOOSER = 40
 
-BROWSE_FILES_DELIMITER = ';'            # the delimeter to be used between each file in the returned string
+BROWSE_FILES_DELIMITER = ';'  # the delimeter to be used between each file in the returned string
 
 # -------------------------  Element types  ------------------------- #
 # class ElementType(Enum):
@@ -322,10 +325,21 @@ POPUP_BUTTONS_NO_BUTTONS = 5
 # ---------------------------------------------------------------------- #
 #                       Element CLASS                                    #
 # ---------------------------------------------------------------------- #
-class Element():
-    def __init__(self, elem_type, size=(None, None), auto_size_text=None, font=None, background_color=None, text_color=None,
-                 key=None, pad=None, tooltip=None, visible=True, size_px=(None, None)):
-
+class Element:
+    def __init__(
+        self,
+        elem_type,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
 
         # if elem_type != ELEM_TYPE_GRAPH:
         #     self.Size = convert_tkinter_size_to_Wx(size)
@@ -333,10 +347,22 @@ class Element():
         #     self.Size = size
         self.Size = size_px
         if size_px == (None, None) and size != (None, None):
-            if elem_type in (ELEM_TYPE_MULTILINE_OUTPUT, ELEM_TYPE_INPUT_MULTILINE, ELEM_TYPE_OUTPUT, ELEM_TYPE_TABLE, ELEM_TYPE_TREE, ELEM_TYPE_TAB, ELEM_TYPE_COLUMN):
-                self.Size = _convert_tkinter_size_to_Wx(size, DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT, DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE)
+            if elem_type in (
+                ELEM_TYPE_MULTILINE_OUTPUT,
+                ELEM_TYPE_INPUT_MULTILINE,
+                ELEM_TYPE_OUTPUT,
+                ELEM_TYPE_TABLE,
+                ELEM_TYPE_TREE,
+                ELEM_TYPE_TAB,
+                ELEM_TYPE_COLUMN,
+            ):
+                self.Size = _convert_tkinter_size_to_Wx(
+                    size, DEFAULT_PIXELS_TO_CHARS_SCALING_MULTILINE_TEXT, DEFAULT_PIXEL_TO_CHARS_CUTOFF_MULTILINE
+                )
             else:
-                self.Size = _convert_tkinter_size_to_Wx(size, DEFAULT_PIXELS_TO_CHARS_SCALING, DEFAULT_PIXEL_TO_CHARS_CUTOFF)
+                self.Size = _convert_tkinter_size_to_Wx(
+                    size, DEFAULT_PIXELS_TO_CHARS_SCALING, DEFAULT_PIXEL_TO_CHARS_CUTOFF
+                )
         self.Type = elem_type
         self.AutoSizeText = auto_size_text
         # self.Pad = DEFAULT_ELEMENT_PADDING if pad is None else pad
@@ -354,7 +380,7 @@ class Element():
         self.TKEntry = None
         self.TKImage = None
 
-        self.ParentForm = None      # type: Window
+        self.ParentForm = None  # type: Window
         self.ParentContainer = None  # will be a Form, Column, or Frame element
         self.TextInputDefault = None
         self.Position = (0, 0)  # Default position Row 0, Col 0
@@ -364,9 +390,7 @@ class Element():
         self.Tooltip = tooltip
         self.TooltipObject = None
         self.Visible = visible
-        self.metadata = None                # type: Any
-
-
+        self.metadata = None  # type: Any
 
     def FindReturnKeyBoundButton(self, form):
         for row in form.Rows:
@@ -456,7 +480,6 @@ class Element():
         if self.ParentForm.CurrentlyRunningMainloop:
             self.ParentForm.TKroot.quit()
 
-
     def _KeyboardHandler(self, event):
         if self.Key is not None:
             self.ParentForm.LastButtonClicked = self.Key
@@ -466,12 +489,12 @@ class Element():
         if self.ParentForm.CurrentlyRunningMainloop:
             self.ParentForm.TKroot.quit()
 
-
     def _WxCallbackKeyboard(self, value):
         element_callback_quit_mainloop(self)
 
-
-    def Update(self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None):
+    def Update(
+        self, widget, background_color=None, text_color=None, font=None, visible=None, disabled=None, tooltip=None
+    ):
         if font:
             widget.SetFont(font_to_wx_font(font))
         if text_color not in (None, COLOR_SYSTEM_DEFAULT):
@@ -508,14 +531,31 @@ class Element():
 
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                           Input Class                                  #
 # ---------------------------------------------------------------------- #
 class InputText(Element):
-    def __init__(self, default_text='', size=(None,None), disabled=False, password_char='',
-                 justification=None, background_color=None, text_color=None, font=None, tooltip=None,
-                 change_submits=False, enable_events=False,
-                 do_not_clear=True, key=None, focus=False, pad=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        default_text='',
+        size=(None, None),
+        disabled=False,
+        password_char='',
+        justification=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        tooltip=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        focus=False,
+        pad=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Input a line of text Element
         :param default_text: Default value to display
@@ -536,12 +576,22 @@ class InputText(Element):
         self.ValueWasChanged = False
         self.WxTextCtrl = None
 
+        super().__init__(
+            ELEM_TYPE_INPUT_TEXT,
+            size=size,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            font=font,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
 
-        super().__init__(ELEM_TYPE_INPUT_TEXT,size=size, background_color=bg, text_color=fg, key=key, pad=pad,
-                         font=font, tooltip=tooltip, visible=visible, size_px=size_px)
-
-
-    def Update(self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self, value=None, disabled=None, select=None, background_color=None, text_color=None, font=None, visible=None
+    ):
         if disabled is True:
             self.WxTextCtrl.Enable(True)
         elif disabled is False:
@@ -556,8 +606,9 @@ class InputText(Element):
         #     self.ParentForm.VisibilityChanged()
         # elif visible is False:
         #     self.WxTextCtrl.Hide()
-        super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         return self.WxTextCtrl.GetValue()
@@ -575,13 +626,32 @@ In = InputText
 Input = InputText
 I = InputText
 
+
 # ---------------------------------------------------------------------- #
 #                           Combo                                        #
 # ---------------------------------------------------------------------- #
 class Combo(Element):
-    def __init__(self, values, default_value=None, size=(None, None), auto_size_text=None, background_color=None,
-                 text_color=None, change_submits=False, enable_events=False, disabled=False, key=None, pad=None, tooltip=None,
-                 readonly=False, visible_items=10, font=None, auto_complete=True, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        key=None,
+        pad=None,
+        tooltip=None,
+        readonly=False,
+        visible_items=10,
+        font=None,
+        auto_complete=True,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Input Combo Box Element (also called Dropdown box)
         :param values:
@@ -599,15 +669,34 @@ class Combo(Element):
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
         self.VisibleItems = visible_items
         self.AutoComplete = auto_complete
-        self.WxComboBox = None     # type: wx.ComboBox
+        self.WxComboBox = None  # type: wx.ComboBox
 
-        super().__init__(ELEM_TYPE_INPUT_COMBO, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_COMBO,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=size_px,
+        )
 
-
-
-
-    def Update(self, value=None, values=None, set_to_index=None, disabled=None, readonly=None,  background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self,
+        value=None,
+        values=None,
+        set_to_index=None,
+        disabled=None,
+        readonly=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        visible=None,
+    ):
         if values is not None:
             self.WxComboBox.Set(values)
         if value:
@@ -621,7 +710,9 @@ class Combo(Element):
         if readonly is not None:
             self.WxComboBox.SetWindowStyle(wx.CB_READONLY)
 
-        super().Update(self.WxComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.WxComboBox, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     update = Update
 
@@ -632,13 +723,23 @@ DropDown = InputCombo
 Drop = InputCombo
 
 
-
 # ---------------------------------------------------------------------- #
 #                           Option Menu                                  #
 # ---------------------------------------------------------------------- #
 class OptionMenu(Element):
-    def __init__(self, values, default_value=None, size=(None, None), disabled=False, auto_size_text=None,
-                 background_color=None, text_color=None, key=None, pad=None, tooltip=None):
+    def __init__(
+        self,
+        values,
+        default_value=None,
+        size=(None, None),
+        disabled=False,
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+    ):
         '''
         InputOptionMenu
         :param values:
@@ -659,8 +760,16 @@ class OptionMenu(Element):
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
 
-        super().__init__(ELEM_TYPE_INPUT_OPTION_MENU, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_INPUT_OPTION_MENU,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+        )
 
     def Update(self, value=None, values=None, disabled=None):
         if values is not None:
@@ -690,9 +799,24 @@ InputOptionMenu = OptionMenu
 #                           Listbox                                      #
 # ---------------------------------------------------------------------- #
 class Listbox(Element):
-    def __init__(self, values, default_values=None, select_mode=None, change_submits=False, bind_return_key=False,
-                 size=(None, None), disabled=False, auto_size_text=None, font=None, background_color=None, size_px=(None, None),
-                 text_color=None, key=None, pad=None, tooltip=None):
+    def __init__(
+        self,
+        values,
+        default_values=None,
+        select_mode=None,
+        change_submits=False,
+        bind_return_key=False,
+        size=(None, None),
+        disabled=False,
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        size_px=(None, None),
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+    ):
         '''
         Listbox Element
         :param values:
@@ -729,8 +853,18 @@ class Listbox(Element):
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
 
-        super().__init__(ELEM_TYPE_INPUT_LISTBOX, size=size, auto_size_text=auto_size_text, font=font,
-                         background_color=bg, text_color=fg, key=key, pad=pad, size_px=size_px, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_INPUT_LISTBOX,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            size_px=size_px,
+            tooltip=tooltip,
+        )
 
     def Update(self, values=None, disabled=None):
         if disabled == True:
@@ -762,13 +896,30 @@ class Listbox(Element):
     set_value = SetValue
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                           Radio                                        #
 # ---------------------------------------------------------------------- #
 class Radio(Element):
-    def __init__(self, text, group_id, default=False, disabled=False, size=(None, None), auto_size_text=None,
-                 background_color=None, text_color=None, font=None, key=None, pad=None, tooltip=None,
-                 change_submits=False, enable_events=False, visible=True, size_px=(None, None)):
+    def __init__(
+        self,
+        text,
+        group_id,
+        default=False,
+        disabled=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        font=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        change_submits=False,
+        enable_events=False,
+        visible=True,
+        size_px=(None, None),
+    ):
         """
 
         :param text:
@@ -795,20 +946,30 @@ class Radio(Element):
         self.Disabled = disabled
         self.TextColor = text_color or DEFAULT_TEXT_COLOR
         self.ChangeSubmits = change_submits or enable_events
-        self.WxRadioButton = None       # type: wx.RadioButton
+        self.WxRadioButton = None  # type: wx.RadioButton
 
-        super().__init__(ELEM_TYPE_INPUT_RADIO, size=size, auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip, visible=visible, size_px=size_px)
-
+        super().__init__(
+            ELEM_TYPE_INPUT_RADIO,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
 
     def Update(self, value=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
         if value is True:
             self.WxRadioButton.SetValue(True)
         elif value is False:
             self.WxRadioButton.SetValue(False)
-        super().Update(self.WxRadioButton, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.WxRadioButton, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def reset_group(self):
         self.WxRadioButton.SetValue(True)
@@ -816,12 +977,29 @@ class Radio(Element):
 
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                           Checkbox                                     #
 # ---------------------------------------------------------------------- #
 class Checkbox(Element):
-    def __init__(self, text, default=False, size=(None, None), auto_size_text=None, font=None, background_color=None,
-                 text_color=None, change_submits=False, enable_events=False, disabled=False, key=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        text,
+        default=False,
+        size=(None, None),
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        disabled=False,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Checkbox Element
         :param text:
@@ -839,15 +1017,24 @@ class Checkbox(Element):
         '''
         self.Text = text
         self.InitialState = default
-        self.WxCheckbox = None      # type:wx.CheckBox
+        self.WxCheckbox = None  # type:wx.CheckBox
         self.Disabled = disabled
         self.TextColor = text_color if text_color else DEFAULT_TEXT_COLOR
         self.ChangeSubmits = change_submits or enable_events
 
-
-        super().__init__(ELEM_TYPE_INPUT_CHECKBOX, size=size,  auto_size_text=auto_size_text, font=font,
-                         background_color=background_color, text_color=self.TextColor, key=key, pad=pad,
-                         tooltip=tooltip, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_CHECKBOX,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=background_color,
+            text_color=self.TextColor,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
 
     def Get(self):
         return self.WxCheckbox.GetValue()
@@ -878,10 +1065,29 @@ Check = Checkbox
 #                           Spin                                         #
 # ---------------------------------------------------------------------- #
 
+
 class Spin(Element):
     # Values = None
     # TKSpinBox = None
-    def __init__(self, values, initial_value=None, disabled=False, change_submits=False,  enable_events=False, size=(None, None), readonly=True, auto_size_text=None, font=None, background_color=None, text_color=None, key=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        values,
+        initial_value=None,
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        size=(None, None),
+        readonly=True,
+        auto_size_text=None,
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Spinner Element
         :param values:
@@ -903,19 +1109,28 @@ class Spin(Element):
         self.Disabled = disabled
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        self.WxSpinCtrl : wx.SpinCtrl = None
+        self.WxSpinCtrl: wx.SpinCtrl = None
         self.WxTextCtrl = None  # type : wx.TextCtrl
         self.CurrentValue = self.DefaultValue
         self.ReadOnly = readonly
 
-
-        super().__init__(ELEM_TYPE_INPUT_SPIN, size=size, auto_size_text=auto_size_text, font=font, background_color=bg, text_color=fg,
-                         key=key, pad=pad, tooltip=tooltip, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_SPIN,
+            size=size,
+            auto_size_text=auto_size_text,
+            font=font,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
-
     def _WxSpinCallback(self, event):
-        event = event       # type:wx.SpinEvent
+        event = event  # type:wx.SpinEvent
         print(f'spin event {event.GetInt()} {self.WxSpinCtrl.GetValue()}')
         offset = event.GetInt()
         self.WxTextCtrl.SetValue(self.Values[offset])
@@ -923,7 +1138,9 @@ class Spin(Element):
         if self.ChangeSubmits:
             element_callback_quit_mainloop(self)
 
-    def Update(self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(
+        self, value=None, values=None, disabled=None, background_color=None, text_color=None, font=None, visible=None
+    ):
         if values != None:
             self.Values = values
             self.QT_Spinner.setStrings(values)
@@ -939,7 +1156,9 @@ class Spin(Element):
             self.QT_Spinner.setDisabled(True)
         elif disabled == False:
             self.QT_Spinner.setDisabled(False)
-        super().Update(self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.QT_Spinner, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         return self.WxSpinCtrl.GetValue()
@@ -948,14 +1167,32 @@ class Spin(Element):
     update = Update
 
 
-
 # ---------------------------------------------------------------------- #
 #                           Multiline                                    #
 # ---------------------------------------------------------------------- #
 class Multiline(Element):
-    def __init__(self, default_text='', enter_submits=False, disabled=False, autoscroll=False, size=(None, None),
-                 auto_size_text=None, background_color=None, text_color=None, change_submits=False, enable_events=False, do_not_clear=True,
-                 key=None, write_only=False, focus=False, font=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        default_text='',
+        enter_submits=False,
+        disabled=False,
+        autoscroll=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        write_only=False,
+        focus=False,
+        font=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Multiline Element
         :param default_text:
@@ -986,31 +1223,45 @@ class Multiline(Element):
 
         self.Widget = self.WxTextCtrl = None
 
-        super().__init__(ELEM_TYPE_INPUT_MULTILINE, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_MULTILINE,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
+    def Update(
+        self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None
+    ):
+        try:  # added in case the widget has already been deleted for some readon.
+            if value is not None and not append:
+                self.WxTextCtrl.SetValue(value)
+            elif value is not None and append:
+                self.WxTextCtrl.AppendText(value)
+            if background_color is not None:
+                self.WxTextCtrl.SetBackgroundColour(background_color)
+            if text_color is not None:
+                self.WxTextCtrl.SetForegroundColour(text_color)
+            if font is not None:
+                self.WxTextCtrl.SetFont(font)
+            if disabled:
+                self.WxTextCtrl.Enable(True)
+            elif disabled is False:
+                self.WxTextCtrl.Enable(False)
+        except:
+            pass
 
-    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
-            try:        # added in case the widget has already been deleted for some readon.
-                if value is not None and not append:
-                    self.WxTextCtrl.SetValue(value)
-                elif value is not None and append:
-                    self.WxTextCtrl.AppendText(value)
-                if background_color is not None:
-                    self.WxTextCtrl.SetBackgroundColour(background_color)
-                if text_color is not None:
-                    self.WxTextCtrl.SetForegroundColour(text_color)
-                if font is not None:
-                    self.WxTextCtrl.SetFont(font)
-                if disabled:
-                    self.WxTextCtrl.Enable(True)
-                elif disabled is False:
-                    self.WxTextCtrl.Enable(False)
-            except:
-                pass
-
-            super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
+        super().Update(
+            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     #
     # def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
@@ -1026,7 +1277,6 @@ class Multiline(Element):
     #         self.QT_TextEdit.setDisabled(False)
     #     super().Update(self.QT_TextEdit, background_color=background_color, text_color=text_color, font=font, visible=visible)
 
-
     def Get(self):
         self.WxTextCtrl.GetValue()
 
@@ -1038,12 +1288,31 @@ class Multiline(Element):
     update = Update
 
 
-
 # ---------------------------------------------------------------------- #
 #                           Multiline Output                             #
 # ---------------------------------------------------------------------- #
 class MultilineOutput(Element):
-    def __init__(self, default_text='', enter_submits=False, disabled=False, autoscroll=False, size=(None, None), auto_size_text=None, background_color=None, text_color=None, change_submits=False, enable_events=False, do_not_clear=True, key=None, focus=False, font=None, pad=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        default_text='',
+        enter_submits=False,
+        disabled=False,
+        autoscroll=False,
+        size=(None, None),
+        auto_size_text=None,
+        background_color=None,
+        text_color=None,
+        change_submits=False,
+        enable_events=False,
+        do_not_clear=True,
+        key=None,
+        focus=False,
+        font=None,
+        pad=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Multiline Element
         :param default_text:
@@ -1073,28 +1342,41 @@ class MultilineOutput(Element):
 
         self.WxTextCtrl = None
 
-        super().__init__(ELEM_TYPE_MULTILINE_OUTPUT, size=size, auto_size_text=auto_size_text, background_color=bg,
-                         text_color=fg, key=key, pad=pad, tooltip=tooltip, font=font or DEFAULT_FONT, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_MULTILINE_OUTPUT,
+            size=size,
+            auto_size_text=auto_size_text,
+            background_color=bg,
+            text_color=fg,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            font=font or DEFAULT_FONT,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
-
-    def Update(self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None):
-            if value is not None and not append:
-                self.WxTextCtrl.SetLabel(value)
-            elif value is not None and append:
-                self.WxTextCtrl.AppendText(value)
-            if background_color is not None:
-                self.WxTextCtrl.SetBackgroundColour(background_color)
-            if text_color is not None:
-                self.WxTextCtrl.SetForegroundColour(text_color)
-            if font is not None:
-                self.WxTextCtrl.SetFont(font)
-            if disabled:
-                self.WxTextCtrl.Enable(True)
-            elif disabled is False:
-                self.WxTextCtrl.Enable(False)
-            super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+    def Update(
+        self, value=None, disabled=None, append=False, background_color=None, text_color=None, font=None, visible=None
+    ):
+        if value is not None and not append:
+            self.WxTextCtrl.SetLabel(value)
+        elif value is not None and append:
+            self.WxTextCtrl.AppendText(value)
+        if background_color is not None:
+            self.WxTextCtrl.SetBackgroundColour(background_color)
+        if text_color is not None:
+            self.WxTextCtrl.SetForegroundColour(text_color)
+        if font is not None:
+            self.WxTextCtrl.SetFont(font)
+        if disabled:
+            self.WxTextCtrl.Enable(True)
+        elif disabled is False:
+            self.WxTextCtrl.Enable(False)
+        super().Update(
+            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def Get(self):
         self.WxTextCtrl.GetValue()
@@ -1106,11 +1388,31 @@ class MultilineOutput(Element):
     set_focus = SetFocus
     update = Update
 
+
 # ---------------------------------------------------------------------- #
 #                                       Text                             #
 # ---------------------------------------------------------------------- #
 class Text(Element):
-    def __init__(self, text='', size=(None, None),  auto_size_text=None, click_submits=None, enable_events=False, relief=None, border_width=None, font=None, text_color=None, background_color=None, justification=None, pad=None, margins=None, key=None, tooltip=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        text='',
+        size=(None, None),
+        auto_size_text=None,
+        click_submits=None,
+        enable_events=False,
+        relief=None,
+        border_width=None,
+        font=None,
+        text_color=None,
+        background_color=None,
+        justification=None,
+        pad=None,
+        margins=None,
+        key=None,
+        tooltip=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         """
         Text
         :param text:
@@ -1143,12 +1445,23 @@ class Text(Element):
             bg = background_color
         pixelsize = size
         if size[1] is not None and size[1] < 10:
-            pixelsize = size[0]*10, size[1]*20
-        self.WxStaticText = None   # type: wx.StaticText  # wx.StaticText(form.MasterPanel, -1, element.DisplayText)
+            pixelsize = size[0] * 10, size[1] * 20
+        self.WxStaticText = None  # type: wx.StaticText  # wx.StaticText(form.MasterPanel, -1, element.DisplayText)
         self.BorderWidth = border_width if border_width is not None else DEFAULT_BORDER_WIDTH
 
-        super().__init__(ELEM_TYPE_TEXT, pixelsize, auto_size_text, background_color=bg, font=font if font else DEFAULT_FONT,
-                         text_color=self.TextColor, pad=pad, key=key, tooltip=tooltip, size_px=size_px, visible=visible)
+        super().__init__(
+            ELEM_TYPE_TEXT,
+            pixelsize,
+            auto_size_text,
+            background_color=bg,
+            font=font if font else DEFAULT_FONT,
+            text_color=self.TextColor,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            size_px=size_px,
+            visible=visible,
+        )
         return
 
     def Update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
@@ -1163,8 +1476,9 @@ class Text(Element):
             self.WxStaticText.SetForegroundColour(text_color)
         if font is not None:
             self.WxStaticText.SetFont(font)
-        super().Update(self.WxStaticText, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.WxStaticText, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     update = Update
 
@@ -1184,13 +1498,25 @@ class RedirectText(object):
     def flush(self):
         return
 
+
 # ---------------------------------------------------------------------- #
 #                           Output                                       #
 #  Routes stdout, stderr to a scrolled window                            #
 # ---------------------------------------------------------------------- #
 class Output(Element):
-    def __init__(self, size=(None, None), background_color=None, text_color=None, pad=None, font=None, tooltip=None,
-                 key=None, visible=True, size_px=(None,None), disabled=False):
+    def __init__(
+        self,
+        size=(None, None),
+        background_color=None,
+        text_color=None,
+        pad=None,
+        font=None,
+        tooltip=None,
+        key=None,
+        visible=True,
+        size_px=(None, None),
+        disabled=False,
+    ):
         '''
         Output Element
         :param size:
@@ -1204,13 +1530,23 @@ class Output(Element):
         self._TKOut = None
         bg = background_color if background_color else DEFAULT_INPUT_ELEMENTS_COLOR
         fg = text_color if text_color is not None else DEFAULT_INPUT_TEXT_COLOR
-        self.WxTextCtrl = None # type: wx.TextCtrl
+        self.WxTextCtrl = None  # type: wx.TextCtrl
         self.redir = None
         self.output = None
         self.Disabled = disabled
 
-        super().__init__(ELEM_TYPE_OUTPUT, size=size, background_color=bg, text_color=fg, pad=pad, font=font,
-                         tooltip=tooltip, key=key, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_OUTPUT,
+            size=size,
+            background_color=bg,
+            text_color=fg,
+            pad=pad,
+            font=font,
+            tooltip=tooltip,
+            key=key,
+            visible=visible,
+            size_px=size_px,
+        )
 
     def _reroute_stdout(self):
         self.my_stdout = sys.stdout
@@ -1224,32 +1560,55 @@ class Output(Element):
     def _reroute_again(self):
         sys.stdout = self.redir
 
-    def Update(self,value=None, background_color=None, text_color=None, font=None, visible=None):
+    def Update(self, value=None, background_color=None, text_color=None, font=None, visible=None):
         if value is not None:
             self.WxTextCtrl.AppendText(value)
-        super().Update(self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible)
-
+        super().Update(
+            self.WxTextCtrl, background_color=background_color, text_color=text_color, font=font, visible=visible
+        )
 
     def __del__(self):
         try:
             sys.stdout = self.my_stdout
             sys.stderr = self.my_stderr
-        except: pass
+        except:
+            pass
         # super().__del__()
 
-
-
     update = Update
+
 
 # ---------------------------------------------------------------------- #
 #                           Button Class                                 #
 # ---------------------------------------------------------------------- #
 class Button(Element):
-    def __init__(self, button_text='', button_type=BUTTON_TYPE_READ_FORM, target=(None, None), tooltip=None,
-                 file_types=(('ALL Files', '*'),), initial_folder=None, disabled=False, change_submits=False, enable_events=False,
-                 image_filename=None, image_data=None, image_size=(None, None), image_subsample=None, border_width=None,
-                 size=(None, None), auto_size_button=None, button_color=None, font=None, bind_return_key=False,
-                 focus=False, pad=None, key=None, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        button_text='',
+        button_type=BUTTON_TYPE_READ_FORM,
+        target=(None, None),
+        tooltip=None,
+        file_types=(('ALL Files', '*'),),
+        initial_folder=None,
+        disabled=False,
+        change_submits=False,
+        enable_events=False,
+        image_filename=None,
+        image_data=None,
+        image_size=(None, None),
+        image_subsample=None,
+        border_width=None,
+        size=(None, None),
+        auto_size_button=None,
+        button_color=None,
+        font=None,
+        bind_return_key=False,
+        focus=False,
+        pad=None,
+        key=None,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         Button Element
         :param button_text:
@@ -1299,10 +1658,21 @@ class Button(Element):
         self.QT_QPushButton = None
         self.ColorChosen = None
         self.Relief = None
-        self.WxButton = None        # type: wx.Button
+        self.WxButton = None  # type: wx.Button
         # self.temp_size = size if size != (NONE, NONE) else
 
-        super().__init__(ELEM_TYPE_BUTTON, size=size, font=font, pad=pad, key=key, tooltip=tooltip, text_color=self.TextColor, background_color=self.BackgroundColor, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_BUTTON,
+            size=size,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            text_color=self.TextColor,
+            background_color=self.BackgroundColor,
+            visible=visible,
+            size_px=size_px,
+        )
         return
 
     # Realtime button release callback
@@ -1355,7 +1725,7 @@ class Button(Element):
             except:
                 pass
         filetypes = (('ALL Files', '*'),) if self.FileTypes is None else self.FileTypes
-        if self.BType == BUTTON_TYPE_BROWSE_FOLDER:                     # Browse Folder
+        if self.BType == BUTTON_TYPE_BROWSE_FOLDER:  # Browse Folder
             wx_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
                 dialog = wx.DirDialog(self.ParentForm.MasterFrame, style=wx.FD_OPEN)
@@ -1369,10 +1739,12 @@ class Button(Element):
                     target_element.FileOrFolderName = folder_name
                 else:
                     target_element.Update(folder_name)
-        elif self.BType == BUTTON_TYPE_BROWSE_FILE:                     # Browse File
+        elif self.BType == BUTTON_TYPE_BROWSE_FILE:  # Browse File
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame,defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_OPEN
+                )
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_OPEN)
             file_name = ''
@@ -1385,10 +1757,12 @@ class Button(Element):
                     target_element.FileOrFolderName = file_name
                 else:
                     target_element.Update(file_name)
-        elif self.BType == BUTTON_TYPE_BROWSE_FILES:                    # Browse Files
+        elif self.BType == BUTTON_TYPE_BROWSE_FILES:  # Browse Files
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame,defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame, defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_MULTIPLE
+                )
             else:
                 dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_MULTIPLE)
             file_names = ''
@@ -1402,12 +1776,19 @@ class Button(Element):
                     target_element.FileOrFolderName = file_names
                 else:
                     target_element.Update(file_names)
-        elif self.BType == BUTTON_TYPE_SAVEAS_FILE:                     # Save As File
+        elif self.BType == BUTTON_TYPE_SAVEAS_FILE:  # Save As File
             qt_types = convert_tkinter_filetypes_to_wx(self.FileTypes)
             if self.InitialFolder:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame,defaultDir=self.InitialFolder, wildcard=qt_types, style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame,
+                    defaultDir=self.InitialFolder,
+                    wildcard=qt_types,
+                    style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+                )
             else:
-                dialog = wx.FileDialog(self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
+                dialog = wx.FileDialog(
+                    self.ParentForm.MasterFrame, wildcard=qt_types, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
+                )
             file_name = ''
             if dialog.ShowModal() == wx.ID_OK:
                 file_name = dialog.GetPath()
@@ -1418,15 +1799,15 @@ class Button(Element):
                     target_element.FileOrFolderName = file_name
                 else:
                     target_element.Update(file_name)
-        elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:                   # Color Chooser
+        elif self.BType == BUTTON_TYPE_COLOR_CHOOSER:  # Color Chooser
             qcolor = QColorDialog.getColor()
             rgb_color = qcolor.getRgb()
-            color= '#' + ''.join('%02x'% i for i in rgb_color[:3])
+            color = '#' + ''.join('%02x' % i for i in rgb_color[:3])
             if self.Target == (None, None):
                 self.FileOrFolderName = color
             else:
                 target_element.Update(color)
-        elif self.BType == BUTTON_TYPE_CLOSES_WIN:                      # Closes Window
+        elif self.BType == BUTTON_TYPE_CLOSES_WIN:  # Closes Window
             # first, get the results table built
             # modify the Results table in the parent FlexForm object
             if self.Key is not None:
@@ -1441,7 +1822,7 @@ class Button(Element):
             if self.ParentForm.NonBlocking:
                 Window.DecrementOpenCount()
             self.ParentForm._Close()
-        elif self.BType == BUTTON_TYPE_READ_FORM:                       # Read Button
+        elif self.BType == BUTTON_TYPE_READ_FORM:  # Read Button
             # first, get the results table built
             # modify the Results table in the parent FlexForm object
             if self.Key is not None:
@@ -1462,7 +1843,9 @@ class Button(Element):
             self.ParentForm.MasterFrame.Close()
             self.ParentForm._Close()
             Window.DecrementOpenCount()
-        elif self.BType == BUTTON_TYPE_CALENDAR_CHOOSER:  # this is a return type button so GET RESULTS and destroy window
+        elif (
+            self.BType == BUTTON_TYPE_CALENDAR_CHOOSER
+        ):  # this is a return type button so GET RESULTS and destroy window
             should_submit_window = False
 
         if should_submit_window:
@@ -1472,7 +1855,16 @@ class Button(Element):
                 self.ParentForm.App.ExitMainLoop()
         return
 
-    def Update(self, text=None, button_color=(None, None), disabled=None, image_data=None, image_filename=None, font=None, visible=None):
+    def Update(
+        self,
+        text=None,
+        button_color=(None, None),
+        disabled=None,
+        image_data=None,
+        image_filename=None,
+        font=None,
+        visible=None,
+    ):
         if text is not None:
             self.WxButton.SetLabelText(text)
             self.ButtonText = text
@@ -1481,7 +1873,6 @@ class Button(Element):
             self.ButtonColor = button_color
             fg, bg = button_color
         super().Update(self.WxButton, background_color=bg, text_color=fg, font=font, visible=visible, disabled=disabled)
-
 
     def GetText(self):
         return self.ButtonText
@@ -1494,11 +1885,10 @@ class Button(Element):
     update = Update
 
 
-
 def convert_tkinter_filetypes_to_wx(filetypes):
     wx_filetypes = ''
     for item in filetypes:
-        filetype = item[0] + ' (' + item[1] + ')|'+ item[1]
+        filetype = item[0] + ' (' + item[1] + ')|' + item[1]
         wx_filetypes += filetype
     return wx_filetypes
 
@@ -1512,8 +1902,23 @@ Btn = Button
 #                           ProgreessBar                                 #
 # ---------------------------------------------------------------------- #
 class ProgressBar(Element):
-    def __init__(self, max_value, orientation=None, size=(None, None),start_value=0,  auto_size_text=None, bar_color=(None, None),
-                 style=None, border_width=None, relief=None, key=None, pad=None, disabled=False, visible=True, size_px=(None,None)):
+    def __init__(
+        self,
+        max_value,
+        orientation=None,
+        size=(None, None),
+        start_value=0,
+        auto_size_text=None,
+        bar_color=(None, None),
+        style=None,
+        border_width=None,
+        relief=None,
+        key=None,
+        pad=None,
+        disabled=False,
+        visible=True,
+        size_px=(None, None),
+    ):
         '''
         ProgressBar Element
         :param max_value:
@@ -1542,20 +1947,28 @@ class ProgressBar(Element):
         tsize = size
         if size[0] is not None and size[0] < 100:
             # tsize = size[0] * DEFAULT_PIXELS_TO_CHARS_SCALING[0], size[1] * DEFAULT_PIXELS_TO_CHARS_SCALING[1]
-            tsize = size[0]*10, size[1]
-        self.WxGauge = None # type: wx.Gauge
+            tsize = size[0] * 10, size[1]
+        self.WxGauge = None  # type: wx.Gauge
 
-        super().__init__(ELEM_TYPE_PROGRESS_BAR, size=tsize, auto_size_text=auto_size_text, key=key, pad=pad, visible=visible, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_PROGRESS_BAR,
+            size=tsize,
+            auto_size_text=auto_size_text,
+            key=key,
+            pad=pad,
+            visible=visible,
+            size_px=size_px,
+        )
 
     # returns False if update failed
     def UpdateBar(self, current_count, max=None):
-        try:    # Could havae been destroyed by user
+        try:  # Could havae been destroyed by user
             if max is not None:
                 self.WxGauge.SetRange(max)
             self.WxGauge.SetValue(current_count)
-        except: pass
+        except:
+            pass
         return True
-
 
     def Update(self, visible=None):
         super().Update(self.WxGauge, visible=visible)
@@ -1568,8 +1981,9 @@ class ProgressBar(Element):
 #                           Image                                        #
 # ---------------------------------------------------------------------- #
 class Image(Element):
-    def __init__(self, filename=None, data=None, background_color=None, size=(None, None), pad=None, key=None,
-                 tooltip=None):
+    def __init__(
+        self, filename=None, data=None, background_color=None, size=(None, None), pad=None, key=None, tooltip=None
+    ):
         '''
         Image Element
         :param filename:
@@ -1586,8 +2000,15 @@ class Image(Element):
         self.BackgroundColor = background_color
         if data is None and filename is None:
             print('* Warning... no image specified in Image Element! *')
-        super().__init__(ELEM_TYPE_IMAGE, size=size, background_color=background_color, pad=pad, key=key,
-                         tooltip=tooltip, size_px=size)
+        super().__init__(
+            ELEM_TYPE_IMAGE,
+            size=size,
+            background_color=background_color,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            size_px=size,
+        )
         return
 
     def Update(self, filename=None, data=None, size=(None, None)):
@@ -1606,7 +2027,6 @@ class Image(Element):
         width, height = size[0] or image.width(), size[1] or image.height()
         self.tktext_label.configure(image=image, width=width, height=height)
         self.tktext_label.image = image
-
 
     update = Update
 
@@ -1628,8 +2048,9 @@ class Canvas(Element):
         self.BackgroundColor = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
         self._TKCanvas = canvas
 
-        super().__init__(ELEM_TYPE_CANVAS, background_color=background_color, size=size, pad=pad, key=key,
-                         tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_CANVAS, background_color=background_color, size=size, pad=pad, key=key, tooltip=tooltip
+        )
         return
 
     @property
@@ -1640,14 +2061,22 @@ class Canvas(Element):
         return self._TKCanvas
 
 
-
-
 # ---------------------------------------------------------------------- #
 #                           Graph                                        #
 # ---------------------------------------------------------------------- #
 class Graph(Element):
-    def __init__(self, canvas_size, graph_bottom_left, graph_top_right, background_color=None, pad=None,
-                 change_submits=False, drag_submits=False, key=None, tooltip=None):
+    def __init__(
+        self,
+        canvas_size,
+        graph_bottom_left,
+        graph_top_right,
+        background_color=None,
+        pad=None,
+        change_submits=False,
+        drag_submits=False,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Graph Element
         :param canvas_size:
@@ -1667,8 +2096,9 @@ class Graph(Element):
         self.DragSubmits = drag_submits
         self.ClickPosition = (None, None)
         self.MouseButtonDown = False
-        super().__init__(ELEM_TYPE_GRAPH, background_color=background_color, size_px=canvas_size, pad=pad, key=key,
-                         tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_GRAPH, background_color=background_color, size_px=canvas_size, pad=pad, key=key, tooltip=tooltip
+        )
         return
 
     def _convert_xy_to_canvas_xy(self, x_in, y_in):
@@ -1709,9 +2139,14 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_oval(converted_point[0] - size, converted_point[1] - size,
-                                           converted_point[0] + size, converted_point[1] + size, fill=color,
-                                           outline=color)
+        return self._TKCanvas2.create_oval(
+            converted_point[0] - size,
+            converted_point[1] - size,
+            converted_point[0] + size,
+            converted_point[1] + size,
+            fill=color,
+            outline=color,
+        )
 
     def DrawCircle(self, center_location, radius, fill_color=None, line_color='black'):
         if center_location == (None, None):
@@ -1721,9 +2156,14 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_oval(converted_point[0] - radius, converted_point[1] - radius,
-                                           converted_point[0] + radius, converted_point[1] + radius, fill=fill_color,
-                                           outline=line_color)
+        return self._TKCanvas2.create_oval(
+            converted_point[0] - radius,
+            converted_point[1] - radius,
+            converted_point[0] + radius,
+            converted_point[1] + radius,
+            fill=fill_color,
+            outline=line_color,
+        )
 
     def DrawOval(self, top_left, bottom_right, fill_color=None, line_color=None):
         converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
@@ -1732,8 +2172,14 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_oval(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                           converted_bottom_right[1], fill=fill_color, outline=line_color)
+        return self._TKCanvas2.create_oval(
+            converted_top_left[0],
+            converted_top_left[1],
+            converted_bottom_right[0],
+            converted_bottom_right[1],
+            fill=fill_color,
+            outline=line_color,
+        )
 
     def DrawArc(self, top_left, bottom_right, extent, start_angle, style=None, arc_color='black'):
         converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
@@ -1743,9 +2189,16 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_arc(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                          converted_bottom_right[1], extent=extent, start=start_angle, style=tkstyle,
-                                          outline=arc_color)
+        return self._TKCanvas2.create_arc(
+            converted_top_left[0],
+            converted_top_left[1],
+            converted_bottom_right[0],
+            converted_bottom_right[1],
+            extent=extent,
+            start=start_angle,
+            style=tkstyle,
+            outline=arc_color,
+        )
 
     def DrawRectangle(self, top_left, bottom_right, fill_color=None, line_color=None):
         converted_top_left = self._convert_xy_to_canvas_xy(top_left[0], top_left[1])
@@ -1754,8 +2207,14 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        return self._TKCanvas2.create_rectangle(converted_top_left[0], converted_top_left[1], converted_bottom_right[0],
-                                                converted_bottom_right[1], fill=fill_color, outline=line_color)
+        return self._TKCanvas2.create_rectangle(
+            converted_top_left[0],
+            converted_top_left[1],
+            converted_bottom_right[0],
+            converted_bottom_right[1],
+            fill=fill_color,
+            outline=line_color,
+        )
 
     def DrawText(self, text, location, color='black', font=None, angle=0):
         if location == (None, None):
@@ -1765,8 +2224,9 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        text_id = self._TKCanvas2.create_text(converted_point[0], converted_point[1], text=text, font=font, fill=color,
-                                              angle=angle)
+        text_id = self._TKCanvas2.create_text(
+            converted_point[0], converted_point[1], text=text, font=font, fill=color, angle=angle
+        )
         return text_id
 
     def Erase(self):
@@ -1814,7 +2274,6 @@ class Graph(Element):
         self.BottomLeft = graph_bottom_left
         self.TopRight = graph_top_right
 
-
     @property
     def TKCanvas(self):
         if self._TKCanvas2 is None:
@@ -1861,13 +2320,28 @@ class Graph(Element):
         if self.ParentForm.CurrentlyRunningMainloop:
             self.ParentForm.TKroot.quit()  # kick out of loop if read was called
 
+
 # ---------------------------------------------------------------------- #
 #                           Frame                                        #
 # ---------------------------------------------------------------------- #
 class Frame(Element):
-    def __init__(self, title, layout, title_color=None, background_color=None, title_location=None,element_justification='left',
-                 relief=DEFAULT_FRAME_RELIEF, size=(None, None), size_px=(None,None), font=None, pad=None, border_width=None, key=None,
-                 tooltip=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        background_color=None,
+        title_location=None,
+        element_justification='left',
+        relief=DEFAULT_FRAME_RELIEF,
+        size=(None, None),
+        size_px=(None, None),
+        font=None,
+        pad=None,
+        border_width=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Frame Element
         :param title:
@@ -1901,12 +2375,21 @@ class Frame(Element):
 
         self._Layout(layout)
 
-        super().__init__(ELEM_TYPE_FRAME, background_color=background_color, text_color=title_color, size=size,
-                         font=font, pad=pad, key=key, tooltip=tooltip, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_FRAME,
+            background_color=background_color,
+            text_color=title_color,
+            size=size,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+            size_px=size_px,
+        )
         return
 
     def _AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -1931,8 +2414,6 @@ class Frame(Element):
         return element
 
 
-
-
 # ---------------------------------------------------------------------- #
 #                           Separator                                    #
 #  Routes stdout, stderr to a scrolled window                            #
@@ -1945,9 +2426,8 @@ class VerticalSeparator(Element):
         '''
         self.Orientation = 'vertical'  # for now only vertical works
         self.Disabled = None
-        self.WxStaticLine = None        # type: wx.StaticLine
+        self.WxStaticLine = None  # type: wx.StaticLine
         super().__init__(ELEM_TYPE_SEPARATOR, pad=pad, size=size, size_px=size_px)
-
 
 
 VSeparator = VerticalSeparator
@@ -1955,36 +2435,44 @@ VSeparator = VerticalSeparator
 VSep = VerticalSeparator
 
 
-
 # ---------------------------------------------------------------------- #
 #                           Separator                                    #
 # ---------------------------------------------------------------------- #
 class HorizontalSeparator(Element):
-    def __init__(self, pad=None, size=(None, None), size_px=(None,None)):
+    def __init__(self, pad=None, size=(None, None), size_px=(None, None)):
         '''
         VerticalSeperator - A separator that spans only 1 row in a vertical fashion
         :param pad:
         '''
         self.Orientation = 'horizontal'  # for now only vertical works
         self.Disabled = None
-        self.WxStaticLine = None        # type: wx.StaticLine
+        self.WxStaticLine = None  # type: wx.StaticLine
 
         super().__init__(ELEM_TYPE_SEPARATOR, pad=pad, size=size, size_px=size_px)
-
 
 
 HSeperator = HorizontalSeparator
 HSep = HorizontalSeparator
 
 
-
-
 # ---------------------------------------------------------------------- #
 #                           Tab                                          #
 # ---------------------------------------------------------------------- #
 class Tab(Element):
-    def __init__(self, title, layout, title_color=None, background_color=None, font=None, element_justification='left', pad=None, disabled=False,
-                 border_width=None, key=None, tooltip=None):
+    def __init__(
+        self,
+        title,
+        layout,
+        title_color=None,
+        background_color=None,
+        font=None,
+        element_justification='left',
+        pad=None,
+        disabled=False,
+        border_width=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Tab Element
         :param title:
@@ -2016,12 +2504,19 @@ class Tab(Element):
 
         self._Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB, background_color=background_color, text_color=title_color, font=font, pad=pad,
-                         key=key, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_TAB,
+            background_color=background_color,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
         return
 
     def _AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2061,8 +2556,21 @@ class Tab(Element):
 #                           TabGroup                                     #
 # ---------------------------------------------------------------------- #
 class TabGroup(Element):
-    def __init__(self, layout, tab_location=None, title_color=None, selected_title_color=None, background_color=None,
-                 font=None, change_submits=False, pad=None, border_width=None, theme=None, key=None, tooltip=None):
+    def __init__(
+        self,
+        layout,
+        tab_location=None,
+        title_color=None,
+        selected_title_color=None,
+        background_color=None,
+        font=None,
+        change_submits=False,
+        pad=None,
+        border_width=None,
+        theme=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         TabGroup Element
         :param layout:
@@ -2096,12 +2604,19 @@ class TabGroup(Element):
 
         self._Layout(layout)
 
-        super().__init__(ELEM_TYPE_TAB_GROUP, background_color=background_color, text_color=title_color, font=font,
-                         pad=pad, key=key, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_TAB_GROUP,
+            background_color=background_color,
+            text_color=title_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
         return
 
     def _AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2139,9 +2654,26 @@ class TabGroup(Element):
 #                           Slider                                       #
 # ---------------------------------------------------------------------- #
 class Slider(Element):
-    def __init__(self, range=(None, None), default_value=None, resolution=None, tick_interval=None, orientation=None,
-                 border_width=None, relief=None, change_submits=False, disabled=False, size=(None, None), size_px=(None,None), font=None,
-                 background_color=None, text_color=None, key=None, pad=None, tooltip=None):
+    def __init__(
+        self,
+        range=(None, None),
+        default_value=None,
+        resolution=None,
+        tick_interval=None,
+        orientation=None,
+        border_width=None,
+        relief=None,
+        change_submits=False,
+        disabled=False,
+        size=(None, None),
+        size_px=(None, None),
+        font=None,
+        background_color=None,
+        text_color=None,
+        key=None,
+        pad=None,
+        tooltip=None,
+    ):
         '''
         Slider Element
         :param range:
@@ -2174,8 +2706,17 @@ class Slider(Element):
         if temp_size == (None, None):
             temp_size = (20, 20) if orientation.startswith('h') else (8, 20)
 
-        super().__init__(ELEM_TYPE_INPUT_SLIDER, size=temp_size, font=font, background_color=background_color,
-                         text_color=text_color, key=key, pad=pad, tooltip=tooltip, size_px=size_px)
+        super().__init__(
+            ELEM_TYPE_INPUT_SLIDER,
+            size=temp_size,
+            font=font,
+            background_color=background_color,
+            text_color=text_color,
+            key=key,
+            pad=pad,
+            tooltip=tooltip,
+            size_px=size_px,
+        )
         return
 
     def Update(self, value=None, range=(None, None), disabled=None):
@@ -2192,9 +2733,7 @@ class Slider(Element):
         elif disabled == False:
             self.TKScale['state'] = 'normal'
 
-
     update = Update
-
 
 
 #
@@ -2202,7 +2741,20 @@ class Slider(Element):
 #                           Column                                       #
 # ---------------------------------------------------------------------- #
 class Column(Element):
-    def __init__(self, layout, background_color=None, element_justification='left', size=(None, None), size_px=(None, None), pad=None, scrollable=False, vertical_scroll_only=False, right_click_menu=None, key=None, visible=True):
+    def __init__(
+        self,
+        layout,
+        background_color=None,
+        element_justification='left',
+        size=(None, None),
+        size_px=(None, None),
+        pad=None,
+        scrollable=False,
+        vertical_scroll_only=False,
+        right_click_menu=None,
+        key=None,
+        visible=True,
+    ):
         '''
         Column Element
         :param layout:
@@ -2223,17 +2775,19 @@ class Column(Element):
         self.VerticalScrollOnly = vertical_scroll_only
         self.RightClickMenu = right_click_menu
         bg = background_color if background_color is not None else DEFAULT_BACKGROUND_COLOR
-        self.WxBoxSizer = None      # type: wx.BoxSizer
-        self.WxHSizer = None        # type: wx.BoxSizer
+        self.WxBoxSizer = None  # type: wx.BoxSizer
+        self.WxHSizer = None  # type: wx.BoxSizer
         self._Layout(layout)
         self.ElementJustification = element_justification
         tsize = size_px if size_px != (None, None) else size
 
-        super().__init__(ELEM_TYPE_COLUMN, background_color=background_color, size_px=tsize, pad=pad, key=key, visible=visible)
+        super().__init__(
+            ELEM_TYPE_COLUMN, background_color=background_color, size_px=tsize, pad=pad, key=key, visible=visible
+        )
         return
 
     def _AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2256,7 +2810,6 @@ class Column(Element):
         row = self.Rows[row_num]
         element = row[col_num]
         return element
-
 
     def Update(self, visible=None):
         if visible:
@@ -2299,15 +2852,34 @@ class Menu(Element):
             self.ParentForm.TKroot.quit()  # kick the users out of the mainloop
 
 
-
 # ---------------------------------------------------------------------- #
 #                           Table                                        #
 # ---------------------------------------------------------------------- #
 class Table(Element):
-    def __init__(self, values, headings=None, visible_column_map=None, col_widths=None, def_col_width=10,
-                 auto_size_columns=True, max_col_width=20, select_mode=None, display_row_numbers=False, num_rows=None,
-                 font=None, justification='right', text_color=None, background_color=None, alternating_row_color=None,
-                 size=(None, None), change_submits=False, bind_return_key=False, pad=None, key=None, tooltip=None):
+    def __init__(
+        self,
+        values,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        display_row_numbers=False,
+        num_rows=None,
+        font=None,
+        justification='right',
+        text_color=None,
+        background_color=None,
+        alternating_row_color=None,
+        size=(None, None),
+        change_submits=False,
+        bind_return_key=False,
+        pad=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Table Element
         :param values:
@@ -2349,8 +2921,16 @@ class Table(Element):
         self.BindReturnKey = bind_return_key
         self.StartingRowNumber = 0  # When displaying row numbers, where to start
         self.RowHeaderText = 'Row'
-        super().__init__(ELEM_TYPE_TABLE, text_color=text_color, background_color=background_color, font=font,
-                         size=size, pad=pad, key=key, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_TABLE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            size=size,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
         return
 
     def Update(self, values=None):
@@ -2377,10 +2957,28 @@ class Table(Element):
 #                           Tree                                         #
 # ---------------------------------------------------------------------- #
 class Tree(Element):
-    def __init__(self, data=None, headings=None, visible_column_map=None, col_widths=None, col0_width=10,
-                 def_col_width=10, auto_size_columns=True, max_col_width=20, select_mode=None, show_expanded=False,
-                 change_submits=False, font=None, justification='right', text_color=None, background_color=None, num_rows=None, pad=None, key=None,
-                 tooltip=None):
+    def __init__(
+        self,
+        data=None,
+        headings=None,
+        visible_column_map=None,
+        col_widths=None,
+        col0_width=10,
+        def_col_width=10,
+        auto_size_columns=True,
+        max_col_width=20,
+        select_mode=None,
+        show_expanded=False,
+        change_submits=False,
+        font=None,
+        justification='right',
+        text_color=None,
+        background_color=None,
+        num_rows=None,
+        pad=None,
+        key=None,
+        tooltip=None,
+    ):
         '''
         Tree Element
         :param headings:
@@ -2418,15 +3016,23 @@ class Tree(Element):
         self.SelectedRows = []
         self.ChangeSubmits = change_submits
 
-        super().__init__(ELEM_TYPE_TREE, text_color=text_color, background_color=background_color, font=font, pad=pad,
-                         key=key, tooltip=tooltip)
+        super().__init__(
+            ELEM_TYPE_TREE,
+            text_color=text_color,
+            background_color=background_color,
+            font=font,
+            pad=pad,
+            key=key,
+            tooltip=tooltip,
+        )
         return
 
     def add_treeview_data(self, node):
         # print(f'Inserting {node.key} under parent {node.parent}')
         if node.key != '':
-            self.TKTreeview.insert(node.parent, 'end', node.key, text=node.text, values=node.values,
-                                   open=self.ShowExpanded)
+            self.TKTreeview.insert(
+                node.parent, 'end', node.key, text=node.text, values=node.values, open=self.ShowExpanded
+            )
         for node in node.children:
             self.add_treeview_data(node)
 
@@ -2483,8 +3089,9 @@ class TreeData(object):
 
     def _NodeStr(self, node, level):
         return '\n'.join(
-            [str(node.key) + ' : ' + str(node.text)] +
-            [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children])
+            [str(node.key) + ' : ' + str(node.text)]
+            + [' ' * 4 * level + self._NodeStr(child, level + 1) for child in node.children]
+        )
 
 
 # ---------------------------------------------------------------------- #
@@ -2502,11 +3109,13 @@ class ErrorElement(Element):
         return
 
     def Update(self, *args, **kwargs):
-        PopupError('Keyword error in Update',
-                   'You need to stop this madness and check your spelling',
-                   'Bad key = {}'.format(self.Key),
-                   'Your bad line of code may resemble this:',
-                   'window.FindElement("{}")'.format(self.Key))
+        PopupError(
+            'Keyword error in Update',
+            'You need to stop this madness and check your spelling',
+            'Bad key = {}'.format(self.Key),
+            'Your bad line of code may resemble this:',
+            'window.FindElement("{}")'.format(self.Key),
+        )
         return self
 
     def Get(self):
@@ -2514,6 +3123,7 @@ class ErrorElement(Element):
 
     update = Update
     get = Get
+
 
 Stretch = ErrorElement
 
@@ -2542,7 +3152,7 @@ class SystemTray:
         self.timer = None
         self.DataBase64 = data_base64
         if Window.highest_level_app is None:
-            self.App = Window.highest_level_app =  wx.App(False)
+            self.App = Window.highest_level_app = wx.App(False)
             # This could be a very dangerous thing to add!
             # It was needed in order for an application to run the Tray in a Thread
             self.App.SetAssertMode(wx.APP_ASSERT_SUPPRESS)
@@ -2561,7 +3171,6 @@ class SystemTray:
 
         # self.App.MainLoop()
 
-
     class CustomTaskBarIcon(wx.adv.TaskBarIcon):
         def __init__(self, frame, app, menu, icon, tooltip=None):
             wx.adv.TaskBarIcon.__init__(self)
@@ -2571,7 +3180,6 @@ class SystemTray:
             self.menu = menu
             self.id_to_text = {}
             self.tooltip = tooltip or wx.EmptyString
-
 
             self.SetIcon(icon, tooltip=self.tooltip)
             self.Bind(wx.adv.EVT_TASKBAR_LEFT_DOWN, self.OnTaskBarLeftClick)
@@ -2615,7 +3223,7 @@ class SystemTray:
         def OnMenu(self, event):
             # print(f'On Menu {event}')
             menu = event.EventObject
-            text=''
+            text = ''
             item = menu.FindItemById(event.Id)
             # for item in menu.MenuItems:
             #     if item.Id == event.Id:
@@ -2625,8 +3233,6 @@ class SystemTray:
             # text = self.id_to_text[item.Id]
             self.menu_item_chosen = text
             self.app.ExitMainLoop()
-
-
 
     def Read(self, timeout=None):
         '''
@@ -2640,11 +3246,11 @@ class SystemTray:
         timeout1 = timeout
         # if timeout1 == 0:
         #     timeout1 = 1
-            # if wx.GetApp():
-            #     wx.GetApp().ProcessPendingEvents()
-            # self.App.ProcessPendingEvents()
-            # self.App.ProcessIdle()
-            # return self.MenuItemChosen
+        # if wx.GetApp():
+        #     wx.GetApp().ProcessPendingEvents()
+        # self.App.ProcessPendingEvents()
+        # self.App.ProcessIdle()
+        # return self.MenuItemChosen
         if timeout1 is not None:
             try:
                 self.timer = wx.Timer(self.TaskBarIcon)
@@ -2658,26 +3264,23 @@ class SystemTray:
         if self.timer:
             self.timer.Stop()
             self.TaskBarIcon.Unbind(wx.EVT_TIMER)
-            del(self.timer)
+            del self.timer
             self.timer = None
         self.MenuItemChosen = self.TaskBarIcon.menu_item_chosen
         return self.MenuItemChosen
 
     def timer_timeout(self, event):
         self.TaskBarIcon.Unbind(wx.EVT_TIMER)
-        del (self.timer)
+        del self.timer
         self.timer = None
         self.TaskBarIcon.menu_item_chosen = TIMEOUT_KEY
         self.App.ExitMainLoop()
 
-
     def Hide(self):
         self.TaskBarIcon.RemoveIcon()
 
-
     def UnHide(self):
         self.TaskBarIcon.SetIcon(icon=self.TaskBarIcon.icon, tooltip=self.TaskBarIcon.tooltip)
-
 
     def ShowMessage(self, title, message, filename=None, data=None, data_base64=None, messageicon=None, time=10000):
         '''
@@ -2709,8 +3312,14 @@ class SystemTray:
     def _DisableAsserts(self):
         wx.DisableAsserts()
 
-
-    def Update(self, menu=None, tooltip=None,filename=None, data=None, data_base64=None,):
+    def Update(
+        self,
+        menu=None,
+        tooltip=None,
+        filename=None,
+        data=None,
+        data_base64=None,
+    ):
         '''
         Updates the menu, tooltip or icon
         :param menu: menu defintion
@@ -2782,7 +3391,7 @@ class DragFrame(wx.Frame):
         else:
             pos = event.GetPosition()
             displacement = self._dragPos - pos
-            self.SetPosition( self.GetPosition() - displacement )
+            self.SetPosition(self.GetPosition() - displacement)
 
 
 # ------------------------------------------------------------------------- #
@@ -2799,12 +3408,40 @@ class Window:
     stdout_is_rerouted = False
     stdout_location = None
 
-    def __init__(self, title, layout=None, default_element_size=DEFAULT_ELEMENT_SIZE, default_button_element_size=(None, None),
-                 auto_size_text=None, auto_size_buttons=None, location=(None, None), size=(None, None), element_padding=None, button_color=None, font=None,
-                 progress_bar_color=(None, None), background_color=None, border_depth=None, auto_close=False,
-                 auto_close_duration=None, icon=DEFAULT_BASE64_ICON, force_toplevel=False, element_justification='left',
-                 alpha_channel=1, return_keyboard_events=False, use_default_focus=True, text_justification=None,
-                 no_titlebar=False, grab_anywhere=False, keep_on_top=False, resizable=True, disable_close=False, disable_minimize=False, background_image=None, finalize=False):
+    def __init__(
+        self,
+        title,
+        layout=None,
+        default_element_size=DEFAULT_ELEMENT_SIZE,
+        default_button_element_size=(None, None),
+        auto_size_text=None,
+        auto_size_buttons=None,
+        location=(None, None),
+        size=(None, None),
+        element_padding=None,
+        button_color=None,
+        font=None,
+        progress_bar_color=(None, None),
+        background_color=None,
+        border_depth=None,
+        auto_close=False,
+        auto_close_duration=None,
+        icon=DEFAULT_BASE64_ICON,
+        force_toplevel=False,
+        element_justification='left',
+        alpha_channel=1,
+        return_keyboard_events=False,
+        use_default_focus=True,
+        text_justification=None,
+        no_titlebar=False,
+        grab_anywhere=False,
+        keep_on_top=False,
+        resizable=True,
+        disable_close=False,
+        disable_minimize=False,
+        background_image=None,
+        finalize=False,
+    ):
         '''
 
         :param title:
@@ -2840,8 +3477,11 @@ class Window:
         self.Title = title
         self.Rows = []  # a list of ELEMENTS for this row
         self.DefaultElementSize = _convert_tkinter_size_to_Wx(default_element_size)
-        self.DefaultButtonElementSize = _convert_tkinter_size_to_Wx(default_button_element_size) if default_button_element_size != (
-            None, None) else _convert_tkinter_size_to_Wx(DEFAULT_BUTTON_ELEMENT_SIZE)
+        self.DefaultButtonElementSize = (
+            _convert_tkinter_size_to_Wx(default_button_element_size)
+            if default_button_element_size != (None, None)
+            else _convert_tkinter_size_to_Wx(DEFAULT_BUTTON_ELEMENT_SIZE)
+        )
         self.Location = location
         self.ButtonColor = button_color if button_color else DEFAULT_BUTTON_COLOR
         self.BackgroundColor = background_color if background_color else DEFAULT_BACKGROUND_COLOR
@@ -2849,7 +3489,11 @@ class Window:
         self.Font = font if font else DEFAULT_FONT
         self.RadioDict = {}
         self.BorderDepth = border_depth
-        self.WindowIcon = Window.user_defined_icon if Window.user_defined_icon is not None else icon if icon is not None else DEFAULT_WINDOW_ICON
+        self.WindowIcon = (
+            Window.user_defined_icon
+            if Window.user_defined_icon is not None
+            else icon if icon is not None else DEFAULT_WINDOW_ICON
+        )
         self.AutoClose = auto_close
         self.NonBlocking = False
         self.TKroot = None
@@ -2885,19 +3529,19 @@ class Window:
         self._Hidden = False
         # self.QTApplication = None
         # self.QT_QMainWindow = None
-        self._Size=size
+        self._Size = size
         self.ElementPadding = element_padding or DEFAULT_ELEMENT_PADDING
         self.FocusElement = None
         self.ElementJustification = element_justification
         self.BackgroundImage = background_image
         self.XFound = False
         self.DisableMinimize = disable_minimize
-        self.App = None             # type: wx.App
-        self.MasterFrame =  None    # type: wx.Frame
-        self.MasterPanel = None     # type: wx.Panel
+        self.App = None  # type: wx.App
+        self.MasterFrame = None  # type: wx.Frame
+        self.MasterPanel = None  # type: wx.Panel
         self.IgnoreClose = False
         self.UniqueKeyCounter = 0
-        self.AllKeysDict = {}       # dictionary containing all the keys and elements in this window
+        self.AllKeysDict = {}  # dictionary containing all the keys and elements in this window
 
         if layout is not None:
             self.Layout(layout)
@@ -2914,10 +3558,9 @@ class Window:
         self.NumOpenWindows -= 1 * (self.NumOpenWindows != 0)  # decrement if not 0
         # print('----- DECREMENTING Num Open Windows = {} ---'.format(Window.NumOpenWindows))
 
-
     # ------------------------- Add ONE Row to Form ------------------------- #
     def AddRow(self, *args):
-        ''' Parms are a variable number of Elements '''
+        '''Parms are a variable number of Elements'''
         NumRows = len(self.Rows)  # number of existing rows is our row number
         CurrentRowNumber = NumRows  # this row's number
         CurrentRow = []  # start with a blank row and build up
@@ -2940,7 +3583,9 @@ class Window:
         return self
 
     def LayoutAndRead(self, rows, non_blocking=False):
-        raise DeprecationWarning('LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()')
+        raise DeprecationWarning(
+            'LayoutAndRead is no longer supported... change your call to window.Layout(layout).Read()'
+        )
         # self.AddRows(rows)
         # self.Show(non_blocking=non_blocking)
         # return self.ReturnValues
@@ -2986,7 +3631,7 @@ class Window:
 
     # ------------------------- SetIcon - set the window's fav icon ------------------------- #
     def SetIcon(self, icon=None, pngbase64=None):
-            pass
+        pass
 
     def _GetElementAtLocation(self, location):
         (row_num, col_num) = location
@@ -3024,24 +3669,22 @@ class Window:
         if self.CurrentlyRunningMainloop:
             self.App.ExitMainLoop()
 
-
     def non_block_timer_timeout(self, event):
         # print('non-blocking timer timeout')
         self.App.ExitMainLoop()
-
 
     def autoclose_timer_callback(self, frame):
         # print('*** AUTOCLOSE TIMEOUT CALLBACK ***', frame)
         try:
             frame.Close()
         except:
-            pass        # if user has already closed the frame will get an error
+            pass  # if user has already closed the frame will get an error
         # TODO Sept - does this need adding back?
         # if self.CurrentlyRunningMainloop:
         #     self.App.ExitMainLoop()
 
     def callback_keyboard_char(self, event):
-        event = event       # type:wx.KeyEvent
+        event = event  # type:wx.KeyEvent
         self.LastButtonClicked = None
         self.FormRemainedOpen = True
         if event.ClassName == 'wxMouseEvent':
@@ -3057,8 +3700,6 @@ class Window:
             self.App.ExitMainLoop()  # kick the users out of the mainloop
         if event.ClassName != 'wxMouseEvent':
             event.DoAllowNextEvent()
-
-
 
     def Read(self, timeout=None, timeout_key=TIMEOUT_KEY, close=False):
         """
@@ -3077,9 +3718,6 @@ class Window:
             self.close()
 
         return results
-
-
-
 
     def _read(self, timeout=None, timeout_key=TIMEOUT_KEY):
         if timeout == 0:  # timeout of zero runs the old readnonblocking
@@ -3144,7 +3782,8 @@ class Window:
                 # self.App.Close()
                 try:
                     self.MasterFrame.Close()
-                except: pass
+                except:
+                    pass
                 Window.DecrementOpenCount()
             # if form was closed with X
             if self.LastButtonClicked is None and self.LastKeyboardEvent is None and self.ReturnValues[0] is None:
@@ -3156,11 +3795,15 @@ class Window:
                 self.LastButtonClicked = None
             return results
         else:
-            if not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None:       # Special Qt case because returning for no reason so fake timeout
-                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]   # fake a timeout
-            elif not self.XFound and self.ReturnValues[0] is None:                   # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
+            if (
+                not self.XFound and self.Timeout != 0 and self.Timeout is not None and self.ReturnValues[0] is None
+            ):  # Special Qt case because returning for no reason so fake timeout
+                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
+            elif (
+                not self.XFound and self.ReturnValues[0] is None
+            ):  # TODO HIGHLY EXPERIMENTAL... added due to tray icon interaction
                 # print("*** Faking timeout ***")
-                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]   # fake a timeout
+                self.ReturnValues = self.TimeoutKey, self.ReturnValues[1]  # fake a timeout
             return self.ReturnValues
 
     def _ReadNonBlocking(self):
@@ -3188,7 +3831,6 @@ class Window:
             #     self.App.ProcessPendingEvents()
         return BuildResults(self, False, self)
 
-
     def Finalize(self):
         if self.TKrootDestroyed:
             return self
@@ -3202,7 +3844,6 @@ class Window:
         #         self.TKrootDestroyed = True
         #         Window.DecrementOpenCount()
         return self
-
 
     def Refresh(self):
         # self.QTApplication.processEvents()              # refresh the window
@@ -3225,21 +3866,22 @@ class Window:
         if element is None:
             if not silent_on_error:
                 print('*** WARNING = FindElement did not find the key. Please check your key\'s spelling ***')
-                PopupError('Keyword error in FindElement Call',
-                           'Bad key = {}'.format(key),
-                           'Your bad line of code may resemble this:',
-                           'window.FindElement("{}")'.format(key))
+                PopupError(
+                    'Keyword error in FindElement Call',
+                    'Bad key = {}'.format(key),
+                    'Your bad line of code may resemble this:',
+                    'window.FindElement("{}")'.format(key),
+                )
                 return ErrorElement(key=key)
             else:
                 return False
         return element
 
-    Element = FindElement       # shortcut function definition
-
+    Element = FindElement  # shortcut function definition
 
     def BuildKeyDict(self):
         dict = {}
-        self.AllKeysDict = self._BuildKeyDictForWindow(self,self, dict)
+        self.AllKeysDict = self._BuildKeyDictForWindow(self, self, dict)
         # print(f'keys built = {self.AllKeysDict}')
 
     def _BuildKeyDictForWindow(self, top_window, window, key_dict):
@@ -3253,23 +3895,42 @@ class Window:
                     key_dict = self._BuildKeyDictForWindow(top_window, element, key_dict)
                 if element.Type == ELEM_TYPE_TAB:
                     key_dict = self._BuildKeyDictForWindow(top_window, element, key_dict)
-                if element.Key is None:   # if no key has been assigned.... create one for input elements
+                if element.Key is None:  # if no key has been assigned.... create one for input elements
                     if element.Type == ELEM_TYPE_BUTTON:
                         element.Key = element.ButtonText
-                    if element.Type in (ELEM_TYPE_MENUBAR, ELEM_TYPE_BUTTONMENU, ELEM_TYPE_CANVAS,
-                                        ELEM_TYPE_INPUT_SLIDER, ELEM_TYPE_GRAPH, ELEM_TYPE_IMAGE,
-                                        ELEM_TYPE_INPUT_CHECKBOX, ELEM_TYPE_INPUT_LISTBOX, ELEM_TYPE_INPUT_COMBO,
-                                        ELEM_TYPE_INPUT_MULTILINE, ELEM_TYPE_INPUT_OPTION_MENU, ELEM_TYPE_INPUT_SPIN,
-                                        ELEM_TYPE_TABLE, ELEM_TYPE_TREE,
-                                        ELEM_TYPE_INPUT_TEXT):
+                    if element.Type in (
+                        ELEM_TYPE_MENUBAR,
+                        ELEM_TYPE_BUTTONMENU,
+                        ELEM_TYPE_CANVAS,
+                        ELEM_TYPE_INPUT_SLIDER,
+                        ELEM_TYPE_GRAPH,
+                        ELEM_TYPE_IMAGE,
+                        ELEM_TYPE_INPUT_CHECKBOX,
+                        ELEM_TYPE_INPUT_LISTBOX,
+                        ELEM_TYPE_INPUT_COMBO,
+                        ELEM_TYPE_INPUT_MULTILINE,
+                        ELEM_TYPE_INPUT_OPTION_MENU,
+                        ELEM_TYPE_INPUT_SPIN,
+                        ELEM_TYPE_TABLE,
+                        ELEM_TYPE_TREE,
+                        ELEM_TYPE_INPUT_TEXT,
+                    ):
                         element.Key = top_window.DictionaryKeyCounter
                         top_window.DictionaryKeyCounter += 1
                 if element.Key is not None:
                     if element.Key in key_dict.keys():
-                        print('*** Duplicate key found in your layout {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None
+                        (
+                            print('*** Duplicate key found in your layout {} ***'.format(element.Key))
+                            if element.Type != ELEM_TYPE_BUTTON
+                            else None
+                        )
                         element.Key = element.Key + str(self.UniqueKeyCounter)
                         self.UniqueKeyCounter += 1
-                        print('*** Replaced new key with {} ***'.format(element.Key)) if element.Type != ELEM_TYPE_BUTTON else None
+                        (
+                            print('*** Replaced new key with {} ***'.format(element.Key))
+                            if element.Type != ELEM_TYPE_BUTTON
+                            else None
+                        )
                     key_dict[element.Key] = element
         return key_dict
 
@@ -3298,15 +3959,13 @@ class Window:
         return size
 
     def Move(self, x, y):
-        self.MasterFrame.SetPosition((x,y))
+        self.MasterFrame.SetPosition((x, y))
 
     def Minimize(self):
         self.MasterFrame.Iconize()
 
-
     def Maximize(self):
         self.MasterFrame.Maximize()
-
 
     def _Close(self):
         try:
@@ -3376,7 +4035,6 @@ class Window:
     def BringToFront(self):
         self.MasterFrame.ToggleWindowStyle(wx.STAY_ON_TOP)
 
-
     def CurrentLocation(self):
         location = self.MasterFrame.GetPosition()
         return location
@@ -3416,7 +4074,6 @@ class Window:
         self.TKrootDestroyed = True
         self.RootNeedsDestroying = True
 
-
     @property
     def Size(self):
         size = self.MasterFrame.GetSize()
@@ -3447,7 +4104,6 @@ class Window:
         except Exception as e:
             print('The key you passed in is no good. Key = {}*'.format(key))
             return None
-
 
     def __call__(self, *args, **kwargs):
         """
@@ -3493,11 +4149,13 @@ class Window:
     un_hide = UnHide
     visibility_changed = VisibilityChanged
 
+
 FlexForm = Window
 
 # =========================================================================== #
 # Stops the mainloop and sets the event information                           #
 # =========================================================================== #
+
 
 def element_callback_quit_mainloop(element):
     if element.Key is not None:
@@ -3506,7 +4164,7 @@ def element_callback_quit_mainloop(element):
         element.ParentForm.LastButtonClicked = ''
     element.ParentForm.FormRemainedOpen = True
     if element.ParentForm.CurrentlyRunningMainloop:
-        element.ParentForm.App.ExitMainLoop() # kick the users out of the mainloop
+        element.ParentForm.App.ExitMainLoop()  # kick the users out of the mainloop
 
 
 def quit_mainloop(window):
@@ -3531,17 +4189,18 @@ def quit_mainloop(window):
 # =========================================================================== #
 # Convert from characters to pixels                                           #
 # =========================================================================== #
-def _convert_tkinter_size_to_Wx(size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF):
+def _convert_tkinter_size_to_Wx(
+    size, scaling=DEFAULT_PIXELS_TO_CHARS_SCALING, height_cutoff=DEFAULT_PIXEL_TO_CHARS_CUTOFF
+):
     """
     Converts size in characters to size in pixels
     :param size:  size in characters, rows
     :return: size in pixels, pixels
     """
     qtsize = size
-    if size[1] is not None and size[1] < height_cutoff:        # change from character based size to pixels (roughly)
-        qtsize = size[0]*scaling[0], size[1]*scaling[1]
+    if size[1] is not None and size[1] < height_cutoff:  # change from character based size to pixels (roughly)
+        qtsize = size[0] * scaling[0], size[1] * scaling[1]
     return qtsize
-
 
 
 def font_to_wx_font(font):
@@ -3564,18 +4223,19 @@ def font_to_wx_font(font):
 
     # style = _font[2]
 
-    underline =  'underline' in _font[2:]
-    bold =  'bold' in _font
+    underline = 'underline' in _font[2:]
+    bold = 'bold' in _font
 
-    wxfont = wx.Font(point_size,
-                     wx.FONTFAMILY_DEFAULT,
-                     wx.FONTSTYLE_NORMAL,
-                     wx.FONTWEIGHT_BOLD if bold else wx.FONTWEIGHT_NORMAL,
-                     underline,
-                     faceName=family)
+    wxfont = wx.Font(
+        point_size,
+        wx.FONTFAMILY_DEFAULT,
+        wx.FONTSTYLE_NORMAL,
+        wx.FONTWEIGHT_BOLD if bold else wx.FONTWEIGHT_NORMAL,
+        underline,
+        faceName=family,
+    )
 
     return wxfont
-
 
 
 def preprocess_radio_elements(top_window, window):
@@ -3583,9 +4243,11 @@ def preprocess_radio_elements(top_window, window):
         for element in row:
             if element.Type == ELEM_TYPE_INPUT_RADIO:
                 if element.WxRadioButton is None:
-                    element.WxRadioButton = wx.RadioButton(top_window.MasterPanel, id=wx.ID_ANY, label=element.Text, style=wx.RB_GROUP)
+                    element.WxRadioButton = wx.RadioButton(
+                        top_window.MasterPanel, id=wx.ID_ANY, label=element.Text, style=wx.RB_GROUP
+                    )
                     create_wx_radio_buttons(top_window, top_window, element.GroupID)
-            if element.Type in (ELEM_TYPE_COLUMN, ELEM_TYPE_FRAME,ELEM_TYPE_TAB_GROUP, ELEM_TYPE_TAB) :
+            if element.Type in (ELEM_TYPE_COLUMN, ELEM_TYPE_FRAME, ELEM_TYPE_TAB_GROUP, ELEM_TYPE_TAB):
                 preprocess_radio_elements(top_window, element)
 
 
@@ -3594,8 +4256,8 @@ def create_wx_radio_buttons(top_window, window, group_id):
         for element in row:
             if element.Type == ELEM_TYPE_INPUT_RADIO:
                 if element.GroupID == group_id and element.WxRadioButton is None:
-                    element.WxRadioButton = wx.RadioButton(top_window.MasterPanel, id=wx.ID_ANY, label=element.Text )
-            if element.Type in (ELEM_TYPE_COLUMN, ELEM_TYPE_FRAME,ELEM_TYPE_TAB_GROUP, ELEM_TYPE_TAB) :
+                    element.WxRadioButton = wx.RadioButton(top_window.MasterPanel, id=wx.ID_ANY, label=element.Text)
+            if element.Type in (ELEM_TYPE_COLUMN, ELEM_TYPE_FRAME, ELEM_TYPE_TAB_GROUP, ELEM_TYPE_TAB):
                 create_wx_radio_buttons(top_window, element, group_id)
 
 
@@ -3612,181 +4274,624 @@ def create_wx_radio_buttons(top_window, window, group_id):
 
 
 # -------------------------  FOLDER BROWSE Element lazy function  ------------------------- #
-def FolderBrowse(button_text='Browse', target=(ThisRow, -1), initial_folder=None, tooltip=None, size=(None, None),
-                 auto_size_button=None, button_color=None, disabled=False, change_submits=False, font=None, pad=None,
-                 key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FOLDER, target=target,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  disabled=disabled, button_color=button_color, change_submits=change_submits, font=font, pad=pad,
-                  key=key)
+def FolderBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FOLDER,
+        target=target,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        change_submits=change_submits,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileBrowse(button_text='Browse', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), initial_folder=None,
-               tooltip=None, size=(None, None), auto_size_button=None, button_color=None, change_submits=False,
-               font=None, disabled=False,
-               pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  change_submits=change_submits, disabled=disabled, button_color=button_color, font=font, pad=pad,
-                  key=key)
+def FileBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    disabled=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        change_submits=change_submits,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  FILES BROWSE Element (Multiple file selection) lazy function  ------------------------- #
-def FilesBrowse(button_text='Browse', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), disabled=False,
-                initial_folder=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                change_submits=False,
-                font=None, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_BROWSE_FILES, target=target, file_types=file_types,
-                  initial_folder=initial_folder, change_submits=change_submits, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button,
-                  disabled=disabled, button_color=button_color, font=font, pad=pad, key=key)
+def FilesBrowse(
+    button_text='Browse',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    disabled=False,
+    initial_folder=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_BROWSE_FILES,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        change_submits=change_submits,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        disabled=disabled,
+        button_color=button_color,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  FILE BROWSE Element lazy function  ------------------------- #
-def FileSaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), initial_folder=None,
-               disabled=False, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-               change_submits=False, font=None,
-               pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits,
-                  font=font, pad=pad, key=key)
+def FileSaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    initial_folder=None,
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  SAVE AS Element lazy function  ------------------------- #
-def SaveAs(button_text='Save As...', target=(ThisRow, -1), file_types=(('ALL Files', '*.*'),), initial_folder=None,
-           disabled=False, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-           change_submits=False, font=None,
-           pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_SAVEAS_FILE, target=target, file_types=file_types,
-                  initial_folder=initial_folder, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, change_submits=change_submits,
-                  font=font, pad=pad, key=key)
+def SaveAs(
+    button_text='Save As...',
+    target=(ThisRow, -1),
+    file_types=(('ALL Files', '*.*'),),
+    initial_folder=None,
+    disabled=False,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    change_submits=False,
+    font=None,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_SAVEAS_FILE,
+        target=target,
+        file_types=file_types,
+        initial_folder=initial_folder,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        change_submits=change_submits,
+        font=font,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  SAVE BUTTON  lazy function  ------------------------- #
-def Save(button_text='Save', size=(None, None), auto_size_button=None, button_color=None, bind_return_key=True,
-         disabled=False, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Save(
+    button_text='Save',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    bind_return_key=True,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  SUBMIT BUTTON lazy function  ------------------------- #
-def Submit(button_text='Submit', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Submit(
+    button_text='Submit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  OPEN BUTTON lazy function  ------------------------- #
-def Open(button_text='Open', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-         bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Open(
+    button_text='Open',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  OK BUTTON lazy function  ------------------------- #
-def OK(button_text='OK', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def OK(
+    button_text='OK',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  YES BUTTON lazy function  ------------------------- #
-def Ok(button_text='Ok', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-       bind_return_key=True, tooltip=None, font=None, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Ok(
+    button_text='Ok',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    bind_return_key=True,
+    tooltip=None,
+    font=None,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  CANCEL BUTTON lazy function  ------------------------- #
-def Cancel(button_text='Cancel', size=(None, None), auto_size_button=None, button_color=None, disabled=False,
-           tooltip=None, font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Cancel(
+    button_text='Cancel',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  QUIT BUTTON lazy function  ------------------------- #
-def Quit(button_text='Quit', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Quit(
+    button_text='Quit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Exit BUTTON lazy function  ------------------------- #
-def Exit(button_text='Exit', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-         font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Exit(
+    button_text='Exit',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  YES BUTTON lazy function  ------------------------- #
-def Yes(button_text='Yes', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-        font=None, bind_return_key=True, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Yes(
+    button_text='Yes',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=True,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  NO BUTTON lazy function  ------------------------- #
-def No(button_text='No', size=(None, None), auto_size_button=None, button_color=None, disabled=False, tooltip=None,
-       font=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def No(
+    button_text='No',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    tooltip=None,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  NO BUTTON lazy function  ------------------------- #
-def Help(button_text='Help', size=(None, None), auto_size_button=None, button_color=None, disabled=False, font=None,
-         tooltip=None, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def Help(
+    button_text='Help',
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    tooltip=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  GENERIC BUTTON lazy function  ------------------------- #
-def SimpleButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                 border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                 font=None, bind_return_key=False, disabled=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def SimpleButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  CLOSE BUTTON lazy function  ------------------------- #
-def CloseButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-                bind_return_key=False, disabled=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def CloseButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 CButton = CloseButton
 
 
 # -------------------------  GENERIC BUTTON lazy function  ------------------------- #
-def ReadButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-               border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-               bind_return_key=False, disabled=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_READ_FORM, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, disabled=disabled,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def ReadButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    bind_return_key=False,
+    disabled=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_READ_FORM,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        disabled=disabled,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 ReadFormButton = ReadButton
@@ -3794,56 +4899,176 @@ RButton = ReadFormButton
 
 
 # -------------------------  Realtime BUTTON lazy function  ------------------------- #
-def RealtimeButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                   border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None,
-                   font=None, disabled=False, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_REALTIME, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, disabled=disabled, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def RealtimeButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_REALTIME,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        disabled=disabled,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Dummy BUTTON lazy function  ------------------------- #
-def DummyButton(button_text, image_filename=None, image_data=None, image_size=(None, None), image_subsample=None,
-                border_width=None, tooltip=None, size=(None, None), auto_size_button=None, button_color=None, font=None,
-                disabled=False, bind_return_key=False, focus=False, pad=None, key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_CLOSES_WIN_ONLY, image_filename=image_filename,
-                  image_data=image_data, image_size=image_size, image_subsample=image_subsample,
-                  border_width=border_width, tooltip=tooltip, size=size, auto_size_button=auto_size_button,
-                  button_color=button_color, font=font, disabled=disabled, bind_return_key=bind_return_key, focus=focus,
-                  pad=pad, key=key)
+def DummyButton(
+    button_text,
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    border_width=None,
+    tooltip=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    font=None,
+    disabled=False,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CLOSES_WIN_ONLY,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def CalendarButton(button_text, target=(None, None), close_when_date_chosen=True, default_date_m_d_y=(None, None, None),
-                   image_filename=None, image_data=None, image_size=(None, None),
-                   image_subsample=None, tooltip=None, border_width=None, size=(None, None), auto_size_button=None,
-                   button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None,
-                   key=None):
-    button = Button(button_text=button_text, button_type=BUTTON_TYPE_CALENDAR_CHOOSER, target=target,
-                    image_filename=image_filename, image_data=image_data, image_size=image_size,
-                    image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size,
-                    auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                    bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def CalendarButton(
+    button_text,
+    target=(None, None),
+    close_when_date_chosen=True,
+    default_date_m_d_y=(None, None, None),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    button = Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_CALENDAR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
     button.CalendarCloseWhenChosen = close_when_date_chosen
     button.DefaultDate_M_D_Y = default_date_m_d_y
     return button
 
 
 # -------------------------  Calendar Chooser Button lazy function  ------------------------- #
-def ColorChooserButton(button_text, target=(None, None), image_filename=None, image_data=None, image_size=(None, None),
-                       image_subsample=None, tooltip=None, border_width=None, size=(None, None), auto_size_button=None,
-                       button_color=None, disabled=False, font=None, bind_return_key=False, focus=False, pad=None,
-                       key=None):
-    return Button(button_text=button_text, button_type=BUTTON_TYPE_COLOR_CHOOSER, target=target,
-                  image_filename=image_filename, image_data=image_data, image_size=image_size,
-                  image_subsample=image_subsample, border_width=border_width, tooltip=tooltip, size=size,
-                  auto_size_button=auto_size_button, button_color=button_color, font=font, disabled=disabled,
-                  bind_return_key=bind_return_key, focus=focus, pad=pad, key=key)
+def ColorChooserButton(
+    button_text,
+    target=(None, None),
+    image_filename=None,
+    image_data=None,
+    image_size=(None, None),
+    image_subsample=None,
+    tooltip=None,
+    border_width=None,
+    size=(None, None),
+    auto_size_button=None,
+    button_color=None,
+    disabled=False,
+    font=None,
+    bind_return_key=False,
+    focus=False,
+    pad=None,
+    key=None,
+):
+    return Button(
+        button_text=button_text,
+        button_type=BUTTON_TYPE_COLOR_CHOOSER,
+        target=target,
+        image_filename=image_filename,
+        image_data=image_data,
+        image_size=image_size,
+        image_subsample=image_subsample,
+        border_width=border_width,
+        tooltip=tooltip,
+        size=size,
+        auto_size_button=auto_size_button,
+        button_color=button_color,
+        font=font,
+        disabled=disabled,
+        bind_return_key=bind_return_key,
+        focus=focus,
+        pad=pad,
+        key=key,
+    )
 
 
 #####################################  -----  RESULTS   ------ ##################################################
+
 
 def AddToReturnDictionary(form, element, value):
     form.ReturnValuesDictionary[element.Key] = value
@@ -3961,11 +5186,15 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
             if not initialize_only:
                 if element.Type == ELEM_TYPE_INPUT_TEXT:
                     value = element.WxTextCtrl.GetValue()
-                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
+                    if (
+                        not top_level_form.NonBlocking
+                        and not element.do_not_clear
+                        and not top_level_form.ReturnKeyboardEvents
+                    ):
                         element.WxTextCtrl.SetValue('')
                 elif element.Type == ELEM_TYPE_INPUT_CHECKBOX:
                     value = element.WxCheckbox.GetValue()
-                    value = (value != 0)
+                    value = value != 0
                 elif element.Type == ELEM_TYPE_INPUT_RADIO:
                     value = element.WxRadioButton.GetValue()
                 elif element.Type == ELEM_TYPE_BUTTON:
@@ -4009,7 +5238,11 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                     except:
                         pass
 
-                    if not top_level_form.NonBlocking and not element.do_not_clear and not top_level_form.ReturnKeyboardEvents:
+                    if (
+                        not top_level_form.NonBlocking
+                        and not element.do_not_clear
+                        and not top_level_form.ReturnKeyboardEvents
+                    ):
                         element.WxTextCtrl.SetValue('')
                 elif element.Type == ELEM_TYPE_TAB_GROUP:
                     try:
@@ -4029,26 +5262,43 @@ def BuildResultsForSubform(form, initialize_only, top_level_form):
                 value = None
 
             # if an input type element, update the results
-            if element.Type != ELEM_TYPE_BUTTON and \
-                    element.Type != ELEM_TYPE_TEXT and \
-                    element.Type != ELEM_TYPE_IMAGE and \
-                    element.Type != ELEM_TYPE_OUTPUT and \
-                    element.Type != ELEM_TYPE_PROGRESS_BAR and \
-                    element.Type != ELEM_TYPE_COLUMN and \
-                    element.Type != ELEM_TYPE_FRAME \
-                    and element.Type != ELEM_TYPE_TAB:
+            if (
+                element.Type != ELEM_TYPE_BUTTON
+                and element.Type != ELEM_TYPE_TEXT
+                and element.Type != ELEM_TYPE_IMAGE
+                and element.Type != ELEM_TYPE_OUTPUT
+                and element.Type != ELEM_TYPE_PROGRESS_BAR
+                and element.Type != ELEM_TYPE_COLUMN
+                and element.Type != ELEM_TYPE_FRAME
+                and element.Type != ELEM_TYPE_TAB
+            ):
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
-            elif (element.Type == ELEM_TYPE_BUTTON and
-                  element.BType == BUTTON_TYPE_CALENDAR_CHOOSER and
-                  element.Target == (None, None)) or \
-                    (element.Type == ELEM_TYPE_BUTTON and
-                     element.BType == BUTTON_TYPE_COLOR_CHOOSER and
-                     element.Target == (None, None)) or \
-                    (element.Type == ELEM_TYPE_BUTTON
-                     and element.Key is not None and
-                     (element.BType in (BUTTON_TYPE_SAVEAS_FILE, BUTTON_TYPE_BROWSE_FILE, BUTTON_TYPE_BROWSE_FILES,
-                                        BUTTON_TYPE_BROWSE_FOLDER))):
+            elif (
+                (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.BType == BUTTON_TYPE_CALENDAR_CHOOSER
+                    and element.Target == (None, None)
+                )
+                or (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.BType == BUTTON_TYPE_COLOR_CHOOSER
+                    and element.Target == (None, None)
+                )
+                or (
+                    element.Type == ELEM_TYPE_BUTTON
+                    and element.Key is not None
+                    and (
+                        element.BType
+                        in (
+                            BUTTON_TYPE_SAVEAS_FILE,
+                            BUTTON_TYPE_BROWSE_FILE,
+                            BUTTON_TYPE_BROWSE_FILES,
+                            BUTTON_TYPE_BROWSE_FOLDER,
+                        )
+                    )
+                )
+            ):
                 AddToReturnList(form, value)
                 AddToReturnDictionary(top_level_form, element, value)
 
@@ -4168,6 +5418,7 @@ def _FindElementWithFocusInSubForm(form):
 
 
 if sys.version_info[0] >= 3:
+
     def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False):
         return_val = None
         if type(sub_menu_info) is str:
@@ -4176,17 +5427,17 @@ if sys.version_info[0] >= 3:
                 pos = sub_menu_info.find('&')
                 if pos != -1:
                     if pos == 0 or sub_menu_info[pos - 1] != '\\':
-                        sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1:]
+                        sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1 :]
                 if sub_menu_info == '---':
                     top_menu.Append(wx.ID_SEPARATOR)
                 else:
                     try:
-                        item_without_key = sub_menu_info[:sub_menu_info.index(MENU_KEY_SEPARATOR)]
+                        item_without_key = sub_menu_info[: sub_menu_info.index(MENU_KEY_SEPARATOR)]
                     except:
                         item_without_key = sub_menu_info
 
                     if item_without_key[0] == MENU_DISABLED_CHARACTER:
-                        id = top_menu.Append(wx.ID_ANY, item_without_key[len(MENU_DISABLED_CHARACTER):])
+                        id = top_menu.Append(wx.ID_ANY, item_without_key[len(MENU_DISABLED_CHARACTER) :])
                         element.id_to_text[id] = sub_menu_info[1:]
                         top_menu.Enable(id.Id, False)
                     else:
@@ -4204,9 +5455,9 @@ if sys.version_info[0] >= 3:
                         pos = sub_menu_info[i].find('&')
                         if pos != -1:
                             if pos == 0 or sub_menu_info[i][pos - 1] != '\\':
-                                sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1:]
+                                sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1 :]
                         if sub_menu_info[i][0] == MENU_DISABLED_CHARACTER:
-                            id = top_menu.AppendSubMenu(new_menu, sub_menu_info[i][len(MENU_DISABLED_CHARACTER):])
+                            id = top_menu.AppendSubMenu(new_menu, sub_menu_info[i][len(MENU_DISABLED_CHARACTER) :])
                             top_menu.Enable(id.Id, False)
                         else:
                             top_menu.AppendSubMenu(new_menu, sub_menu_info[i])
@@ -4219,7 +5470,9 @@ if sys.version_info[0] >= 3:
                 i += 1
         return return_val
 
+
 if sys.version_info[0] >= 3:
+
     def AddMenuItem2(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False):
         if type(sub_menu_info) is str:
             if not is_sub_menu and not skip:
@@ -4227,7 +5480,7 @@ if sys.version_info[0] >= 3:
                 pos = sub_menu_info.find('&')
                 if pos != -1:
                     if pos == 0 or sub_menu_info[pos - 1] != '\\':
-                        sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1:]
+                        sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1 :]
                 if sub_menu_info == '---':
                     top_menu.Append(wx.ID_SEPARATOR)
                 else:
@@ -4242,7 +5495,7 @@ if sys.version_info[0] >= 3:
                         pos = sub_menu_info[i].find('&')
                         if pos != -1:
                             if pos == 0 or sub_menu_info[i][pos - 1] != '\\':
-                                sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1:]
+                                sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1 :]
                         top_menu.AppendSubMenu(new_menu, sub_menu_info[i])
                         AddMenuItem(new_menu, sub_menu_info[i + 1], element, is_sub_menu=True)
                         i += 1  # skip the next one
@@ -4251,7 +5504,9 @@ if sys.version_info[0] >= 3:
                 else:
                     AddMenuItem(top_menu, item, element)
                 i += 1
+
 else:
+
     def AddMenuItem(top_menu, sub_menu_info, element, is_sub_menu=False, skip=False):
         if isinstance(sub_menu_info, types.StringType):
             if not is_sub_menu and not skip:
@@ -4259,12 +5514,15 @@ else:
                 pos = sub_menu_info.find('&')
                 if pos != -1:
                     if pos == 0 or sub_menu_info[pos - 1] != '\\':
-                        sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1:]
+                        sub_menu_info = sub_menu_info[:pos] + sub_menu_info[pos + 1 :]
                 if sub_menu_info == '---':
                     top_menu.add('separator')
                 else:
-                    top_menu.add_command(label=sub_menu_info, underline=pos,
-                                         command=lambda: Menu._MenuItemChosenCallback(element, sub_menu_info))
+                    top_menu.add_command(
+                        label=sub_menu_info,
+                        underline=pos,
+                        command=lambda: Menu._MenuItemChosenCallback(element, sub_menu_info),
+                    )
         else:
             i = 0
             while i < (len(sub_menu_info)):
@@ -4275,7 +5533,7 @@ else:
                         pos = sub_menu_info[i].find('&')
                         if pos != -1:
                             if pos == 0 or sub_menu_info[i][pos - 1] != '\\':
-                                sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1:]
+                                sub_menu_info[i] = sub_menu_info[i][:pos] + sub_menu_info[i][pos + 1 :]
                         top_menu.add_cascade(label=sub_menu_info[i], menu=new_menu, underline=pos)
                         AddMenuItem(new_menu, sub_menu_info[i + 1], element, is_sub_menu=True)
                         i += 1  # skip the next one
@@ -4286,14 +5544,13 @@ else:
                 i += 1
 
 
-
- #     #        ######
- #  #  # #    # #     # #   # ##### #    #  ####  #    #
- #  #  #  #  #  #     #  # #    #   #    # #    # ##   #
- #  #  #   ##   ######    #     #   ###### #    # # #  #
- #  #  #   ##   #         #     #   #    # #    # #  # #
- #  #  #  #  #  #         #     #   #    # #    # #   ##
-  ## ##  #    # #         #     #   #    #  ####  #    #
+#     #        ######
+#  #  # #    # #     # #   # ##### #    #  ####  #    #
+#  #  #  #  #  #     #  # #    #   #    # #    # ##   #
+#  #  #   ##   ######    #     #   ###### #    # # #  #
+#  #  #   ##   #         #     #   #    # #    # #  # #
+#  #  #  #  #  #         #     #   #    # #    # #   ##
+## ##  #    # #         #     #   #    #  ####  #    #
 
 # My crappy WxPython code
 
@@ -4312,12 +5569,12 @@ else:
 # ░░░░░░░░░░░░░░░░░░░░░░░
 
 
-
 # ------------------------------------------------------------------------------------------------------------------ #
 # ------------------------------------------------------------------------------------------------------------------ #
 # =====================================   WxPython CODE STARTS HERE ================================================ #
 # ------------------------------------------------------------------------------------------------------------------ #
 # ------------------------------------------------------------------------------------------------------------------ #
+
 
 def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
     """
@@ -4330,6 +5587,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
     :type toplevel_form: Window
     :return:
     """
+
     def pad_widget(widget):
         lrsizer = wx.BoxSizer(wx.HORIZONTAL)
         if full_element_pad[1] == full_element_pad[3]:  # if right = left
@@ -4403,9 +5661,12 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
             text_color = element.TextColor
             # Determine Element size
             element_size = element.Size
-            if (element_size == (None, None) and element_type not in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU)):  # user did not specify a size
+            if element_size == (None, None) and element_type not in (
+                ELEM_TYPE_BUTTON,
+                ELEM_TYPE_BUTTONMENU,
+            ):  # user did not specify a size
                 element_size = toplevel_form.DefaultElementSize
-            elif (element_size == (None, None) and element_type in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU)):
+            elif element_size == (None, None) and element_type in (ELEM_TYPE_BUTTON, ELEM_TYPE_BUTTONMENU):
                 element_size = toplevel_form.DefaultButtonElementSize
             else:
                 auto_size_text = False  # if user has specified a size then it shouldn't autosize
@@ -4429,7 +5690,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
 
             # -------------------------  COLUMN element  ------------------------- #
             if element_type == ELEM_TYPE_COLUMN:
-                element = element   # type: Column
+                element = element  # type: Column
                 element.WxBoxSizer = vsizer = wx.BoxSizer(wx.VERTICAL)
                 element.WxHSizer = hsizer
                 # element.WxScrollBar = wx.ScrollBar(toplevel_form.MasterFrame, id=wx.ID_ANY, style=wx.SB_VERTICAL)
@@ -4467,7 +5728,6 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
             #
             # qt_row_layout.addWidget(column_widget)
 
-
             #     if element.Scrollable:
             #         col_frame = TkScrollableFrame(tk_row_frame,
             #                                       element.VerticalScrollOnly)  # do not use yet!  not working
@@ -4494,14 +5754,18 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
             #                             highlightcolor=element.BackgroundColor)
             # -------------------------  TEXT element  ------------------------- #
             elif element_type == ELEM_TYPE_TEXT:
-                element = element       # type: Text
+                element = element  # type: Text
                 if element.Justification is not None:
                     justification = element.Justification
                 elif toplevel_form.TextJustification is not None:
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                style = wx.ALIGN_LEFT if justification.startswith('l') else wx.ALIGN_CENTER if justification.startswith('c') else wx.ALIGN_RIGHT
+                style = (
+                    wx.ALIGN_LEFT
+                    if justification.startswith('l')
+                    else wx.ALIGN_CENTER if justification.startswith('c') else wx.ALIGN_RIGHT
+                )
                 # print(border_depth, element.BorderWidth)
                 if border_depth:
                     if element.Relief:
@@ -4509,18 +5773,20 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                             style |= wx.SIMPLE_BORDER
                         elif element.Relief == RELIEF_SUNKEN:
                             style |= wx.SUNKEN_BORDER
-                        elif element.Relief in(RELIEF_RAISED, RELIEF_RIDGE):
+                        elif element.Relief in (RELIEF_RAISED, RELIEF_RIDGE):
                             style |= wx.RAISED_BORDER
                         elif element.Relief in (RELIEF_SUNKEN, RELIEF_SUNKEN):
                             style |= wx.SUNKEN_BORDER
-                statictext = element.WxStaticText = wx.StaticText(toplevel_form.MasterPanel, -1, element.DisplayText, style=style)
+                statictext = element.WxStaticText = wx.StaticText(
+                    toplevel_form.MasterPanel, -1, element.DisplayText, style=style
+                )
                 if font:
                     statictext.SetFont(font_to_wx_font(font))
                 if element.TextColor not in (None, COLOR_SYSTEM_DEFAULT):
                     statictext.SetForegroundColour(element.TextColor)
                 if element.BackgroundColor not in (None, COLOR_SYSTEM_DEFAULT):
                     statictext.SetBackgroundColour(element.BackgroundColor)
-                display_text = element.DisplayText      # text to display
+                display_text = element.DisplayText  # text to display
                 if auto_size_text is False:
                     width, height = element_size
                 else:
@@ -4533,19 +5799,18 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                         width = max_line_len
                     height = num_lines
 
-                if element.ClickSubmits:                # bind events
+                if element.ClickSubmits:  # bind events
                     statictext.Bind(wx.EVT_LEFT_UP, element._WxCallbackKeyboard)
 
                 hsizer.Add(pad_widget(element.WxStaticText), 0)
 
                 if not auto_size_text:
-                    statictext.SetMinSize((width,height))
+                    statictext.SetMinSize((width, height))
 
                 if element.Tooltip:
                     statictext.SetToolTip(element.Tooltip)
                 if not element.Visible:
                     statictext.Hide()
-
 
                 # Set wrap-length for text (in PIXELS) == PAIN IN THE ASS
                 # wraplen = tktext_label.winfo_reqwidth() + 40  # width of widget in Pixels
@@ -4553,7 +5818,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 #     wraplen = 0
             # -------------------------  BUTTON element  ------------------------- #
             elif element_type == ELEM_TYPE_BUTTON:
-                element = element        # type: Button
+                element = element  # type: Button
                 element.WxButton = button = wx.Button(toplevel_form.MasterPanel, style=wx.NO_BORDER)
                 button.SetLabelText(element.ButtonText)
                 if font:
@@ -4574,7 +5839,9 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 if auto_size:
                     element.WxButton.SetWindowStyleFlag(element.WxButton.GetWindowStyleFlag() | wx.BU_EXACTFIT)
                 else:
-                    element.WxButton.SetMinSize(_convert_tkinter_size_to_Wx((width,height), DEFAULT_PIXEL_TO_CHARS_CUTOFF))
+                    element.WxButton.SetMinSize(
+                        _convert_tkinter_size_to_Wx((width, height), DEFAULT_PIXEL_TO_CHARS_CUTOFF)
+                    )
                 if element.ButtonColor != (None, None) and element.ButtonColor != DEFAULT_BUTTON_COLOR:
                     bc = element.ButtonColor
                 elif toplevel_form.ButtonColor != (None, None) and toplevel_form.ButtonColor != DEFAULT_BUTTON_COLOR:
@@ -4592,7 +5859,6 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                     button.Hide()
                 if element.Tooltip:
                     button.SetToolTip(element.Tooltip)
-
 
             #     if btype != BUTTON_TYPE_REALTIME:
             #         tkbutton = tk.Button(tk_row_frame, text=btext, width=width, height=height,
@@ -4642,14 +5908,18 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
 
             # # -------------------------  INPUT element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_TEXT:
-                element = element       # type: InputText
+                element = element  # type: InputText
                 if element.Justification is not None:
                     justification = element.Justification
                 elif toplevel_form.TextJustification is not None:
                     justification = toplevel_form.TextJustification
                 else:
                     justification = DEFAULT_TEXT_JUSTIFICATION
-                justify = wx.ALIGN_LEFT if justification.startswith('l') else wx.ALIGN_CENTER_HORIZONTAL if justification.startswith('c') else wx.ALIGN_RIGHT
+                justify = (
+                    wx.ALIGN_LEFT
+                    if justification.startswith('l')
+                    else wx.ALIGN_CENTER_HORIZONTAL if justification.startswith('c') else wx.ALIGN_RIGHT
+                )
                 if element.PasswordCharacter:
                     justify |= wx.TE_PASSWORD
 
@@ -4685,15 +5955,11 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
 
             # -------------------------  COMBO BOX (Drop Down) element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_COMBO:
-                element = element       # type: Combo
+                element = element  # type: Combo
                 if element.Readonly:
-                    element.WxComboBox = wx.Choice(toplevel_form.MasterPanel,
-                                                              id=wx.ID_ANY,
-                                                              choices=element.Values)
+                    element.WxComboBox = wx.Choice(toplevel_form.MasterPanel, id=wx.ID_ANY, choices=element.Values)
                 else:
-                    element.WxComboBox = wx.ComboBox(toplevel_form.MasterPanel,
-                                                            id=wx.ID_ANY,
-                                                            choices=element.Values)
+                    element.WxComboBox = wx.ComboBox(toplevel_form.MasterPanel, id=wx.ID_ANY, choices=element.Values)
                 if element.DefaultValue:
                     element.WxComboBox.SetSelection(element.WxComboBox.FindString(element.DefaultValue))
                 if element.Readonly:
@@ -4801,7 +6067,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
             #                                         timeout=DEFAULT_TOOLTIP_TIME)
             # -------------------------  INPUT MULTILINE element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_MULTILINE:
-                element = element   # type: Multiline
+                element = element  # type: Multiline
                 justify = 0
                 if element.EnterSubmits:
                     justify |= wx.TE_PROCESS_ENTER
@@ -4837,7 +6103,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                     element.SetFocus()
             # ------------------------- OUTPUT MULTILINE element  ------------------------- #
             elif element_type == ELEM_TYPE_MULTILINE_OUTPUT:
-                element = element                   # type: MultilineOutput
+                element = element  # type: MultilineOutput
                 style = 0
                 if element.EnterSubmits:
                     style |= wx.TE_PROCESS_ENTER
@@ -4857,13 +6123,12 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
 
                 hsizer.Add(sizer, 0)
 
-
                 if element.Focus is True or (toplevel_form.UseDefaultFocus and not focus_set):
                     focus_set = True
                     element.SetFocus()
                 # -------------------------  OUTPUT element  -----------------fd-------- #
             elif element_type == ELEM_TYPE_OUTPUT:
-                element = element                   # type: Output
+                element = element  # type: Output
                 style = 0
                 style |= wx.TE_MULTILINE | wx.TE_READONLY
                 style = wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL
@@ -4878,7 +6143,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 element._reroute_stdout()
             # -------------------------  INPUT CHECKBOX element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_CHECKBOX:
-                element = element                   # type:Checkbox
+                element = element  # type:Checkbox
                 element.WxCheckbox = widget = wx.CheckBox(toplevel_form.MasterPanel)
                 if element.Text:
                     widget.SetLabel(element.Text)
@@ -4896,11 +6161,13 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
 
             # # -------------------------  PROGRESS BAR element  ------------------------- #
             elif element_type == ELEM_TYPE_PROGRESS_BAR:
-                element = element                   # type: ProgressBar
+                element = element  # type: ProgressBar
                 style = wx.GA_HORIZONTAL if element.Orientation.startswith('h') else wx.GA_VERTICAL
                 element_size = element_size[::-1] if element.Orientation.startswith('v') else element_size
                 element_size = wx.Size((element_size[0], element_size[1]))
-                element.WxGauge = gauge = wx.Gauge(toplevel_form.MasterPanel, wx.ID_ANY, range=element.MaxValue, style=style, size=element_size)
+                element.WxGauge = gauge = wx.Gauge(
+                    toplevel_form.MasterPanel, wx.ID_ANY, range=element.MaxValue, style=style, size=element_size
+                )
                 if element.StartValue is not None:
                     gauge.SetValue(element.StartValue)
                 do_font_and_color(element.WxGauge)
@@ -4908,8 +6175,8 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 hsizer.Add(sizer, 0)
                 # -------------------------  INPUT RADIO BUTTON element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_RADIO:
-                element = element                   # type: Radio
-                widget = element.WxRadioButton      # type: wx.RadioButton
+                element = element  # type: Radio
+                widget = element.WxRadioButton  # type: wx.RadioButton
                 do_font_and_color(element.WxRadioButton)
                 sizer = pad_widget(widget)
                 if element.ChangeSubmits:
@@ -4922,7 +6189,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
 
                 # -------------------------  INPUT SPINNER element  ------------------------- #
             elif element_type == ELEM_TYPE_INPUT_SPIN:
-                element = element                   # type:Spin
+                element = element  # type:Spin
                 ######## First make an Input widget that will be used to display the text ########
                 style = wx.ALIGN_RIGHT
                 if element.ReadOnly:
@@ -4936,22 +6203,24 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                     text_ctrl.SetValue(str(element.DefaultValue))
                     element.CurrentValue = element.DefaultValue
                 saved_pad = full_element_pad
-                full_element_pad[3] = 0             # set right padding to 0
+                full_element_pad[3] = 0  # set right padding to 0
                 hsizer.Add(pad_widget(text_ctrl), 0)
 
                 full_element_pad = saved_pad
                 ######## Now make a "Spin Button" that has the arrows ########
                 # element.WxSpinCtrl = widget = wx.SpinCtrl(toplevel_form.MasterPanel, style=wx.SP_WRAP|wx.SP_ARROW_KEYS)
-                element.WxSpinCtrl = widget = wx.SpinButton(toplevel_form.MasterPanel, style=wx.SP_WRAP|wx.SP_ARROW_KEYS)
+                element.WxSpinCtrl = widget = wx.SpinButton(
+                    toplevel_form.MasterPanel, style=wx.SP_WRAP | wx.SP_ARROW_KEYS
+                )
                 do_font_and_color(element.WxSpinCtrl)
-                element.WxSpinCtrl.SetRange(0, len(element.Values)-1)
+                element.WxSpinCtrl.SetRange(0, len(element.Values) - 1)
                 if element.DefaultValue:
                     element.WxSpinCtrl.SetValue(element.Values.index(element.DefaultValue))
-                widget.SetMinSize((25,25))
+                widget.SetMinSize((25, 25))
 
                 widget.Bind(wx.EVT_SPIN, element._WxSpinCallback)
                 saved_pad = full_element_pad
-                full_element_pad[1] = 0             # trying to set left pad to 0 but doesn't seem to work
+                full_element_pad[1] = 0  # trying to set left pad to 0 but doesn't seem to work
                 hsizer.Add(pad_widget(widget), 0)
                 full_element_pad = saved_pad
 
@@ -5044,7 +6313,7 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 # toplevel_form.TKroot.configure(menu=element.TKMenu)
             # -------------------------  Frame element  ------------------------- #
             elif element_type == ELEM_TYPE_FRAME:
-                element = element   # type: Frame
+                element = element  # type: Frame
                 # ----- code from column as a pattern to follow -----
                 # element = element   # type: Column
                 # element.WxBoxSizer = vsizer = wx.BoxSizer(wx.VERTICAL)
@@ -5055,14 +6324,15 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 # if not element.Visible:
                 #     hsizer.Hide(vsizer, recursive=True)
                 # element.panel = panel = wx.Panel(toplevel_form.MasterFrame)
-                element.WxBoxSizer = vsizer = wx.StaticBoxSizer(orient=wx.VERTICAL, parent=toplevel_form.MasterFrame.panel, label=element.Title)
+                element.WxBoxSizer = vsizer = wx.StaticBoxSizer(
+                    orient=wx.VERTICAL, parent=toplevel_form.MasterFrame.panel, label=element.Title
+                )
                 element.WxHSizer = hsizer
                 PackFormIntoFrame(element, vsizer, toplevel_form)
 
                 hsizer.Add(pad_widget(vsizer), 0)
                 if not element.Visible:
                     hsizer.Hide(vsizer, recursive=True)
-
 
                 # labeled_frame = tk.LabelFrame(tk_row_frame, text=element.Title, relief=element.Relief)
                 # PackFormIntoFrame(element, labeled_frame, toplevel_form)
@@ -5338,11 +6608,13 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
                 #                                     timeout=DEFAULT_TOOLTIP_TIME)
             # -------------------------  Separator element  ------------------------- #
             elif element_type == ELEM_TYPE_SEPARATOR:
-                element = element       # type: VerticalSeparator
+                element = element  # type: VerticalSeparator
                 if element.Orientation.lower().startswith('v'):
                     element.WxStaticLine = static_line = wx.StaticLine(toplevel_form.MasterPanel, style=wx.LI_VERTICAL)
                 else:
-                    element.WxStaticLine = static_line = wx.StaticLine(toplevel_form.MasterPanel, style=wx.LI_HORIZONTAL)
+                    element.WxStaticLine = static_line = wx.StaticLine(
+                        toplevel_form.MasterPanel, style=wx.LI_HORIZONTAL
+                    )
 
                 do_font_and_color(element.WxStaticLine)
 
@@ -5350,22 +6622,21 @@ def PackFormIntoFrame(container_elem, containing_frame, toplevel_form):
 
                 hsizer.Add(sizer, 0)
 
-        #.................DONE WITH ROW pack the row of widgets ..................#
+        # .................DONE WITH ROW pack the row of widgets ..................#
 
         # Add the row to the layout.  Justify the row depending on the settings for its container
         if container_elem.ElementJustification.startswith('c'):
-            containing_frame.Add(hsizer, 0,wx.ALIGN_CENTER, border=0)
+            containing_frame.Add(hsizer, 0, wx.ALIGN_CENTER, border=0)
         elif container_elem.ElementJustification.startswith('r'):
-            containing_frame.Add(hsizer,0, wx.ALIGN_RIGHT, border=0)
+            containing_frame.Add(hsizer, 0, wx.ALIGN_RIGHT, border=0)
         else:
-            containing_frame.Add(hsizer, 0, wx.TOP|wx.BOTTOM, border=0)
-
+            containing_frame.Add(hsizer, 0, wx.TOP | wx.BOTTOM, border=0)
 
     return
 
 
 # ----====----====----====----====----==== STARTUP TK ====----====----====----====----====----#
-def StartupTK(window:Window):
+def StartupTK(window: Window):
 
     ow = Window.NumOpenWindows
     if Window.highest_level_app is None:
@@ -5380,13 +6651,13 @@ def StartupTK(window:Window):
     else:
         frame = wx.Frame(None, title=window.Title)
 
-    panel = wx.Panel(frame, -1,  style=wx.TRANSPARENT_WINDOW)
+    panel = wx.Panel(frame, -1, style=wx.TRANSPARENT_WINDOW)
     # panel.SetTransparent(.5)
     if window.GrabAnywhere:
         panel.Bind(wx.EVT_MOTION, frame.on_mouse)
 
     window.App = app
-    window.MasterFrame =  frame
+    window.MasterFrame = frame
     window.MasterPanel = panel
     window.MasterFrame.panel = panel
     frame.Bind(wx.EVT_CLOSE, window.OnClose)
@@ -5416,8 +6687,6 @@ def StartupTK(window:Window):
             else:
                 pic = PyEmbeddedImage(DEFAULT_BASE64_ICON).GetBitmap()
         window.bitmap1 = wx.StaticBitmap(window.MasterPanel, -1, pic, (0, 0))
-
-
 
     InitializeResults(window)
 
@@ -5451,11 +6720,11 @@ def StartupTK(window:Window):
     # ----------------------------- Sizers to create margins -----------------------------
     outersizer = wx.BoxSizer(wx.VERTICAL)
     outersizer.Fit(window.MasterFrame)
-    outersizer.Add(vsizer, 1, wx.TOP|wx.BOTTOM|wx.EXPAND, border=DEFAULT_MARGINS[1])
+    outersizer.Add(vsizer, 1, wx.TOP | wx.BOTTOM | wx.EXPAND, border=DEFAULT_MARGINS[1])
 
     window.OuterSizer = wx.BoxSizer(wx.VERTICAL)
     window.OuterSizer.Fit(window.MasterFrame)
-    window.OuterSizer.Add(outersizer, 1, wx.LEFT|wx.RIGHT|wx.EXPAND, border=DEFAULT_MARGINS[0])
+    window.OuterSizer.Add(outersizer, 1, wx.LEFT | wx.RIGHT | wx.EXPAND, border=DEFAULT_MARGINS[0])
 
     window.MasterPanel.SetSizer(window.OuterSizer)
 
@@ -5490,10 +6759,11 @@ def StartupTK(window:Window):
 
     if window.AutoClose:
         window.timer = wx.Timer(window.App, id=Window.NumOpenWindows)
-        window.App.Bind(wx.EVT_TIMER, lambda frame: window.autoclose_timer_callback(window.MasterFrame), id=Window.NumOpenWindows)
-        window.timer.Start(milliseconds=window.AutoCloseDuration*1000, oneShot=wx.TIMER_ONE_SHOT)
+        window.App.Bind(
+            wx.EVT_TIMER, lambda frame: window.autoclose_timer_callback(window.MasterFrame), id=Window.NumOpenWindows
+        )
+        window.timer.Start(milliseconds=window.AutoCloseDuration * 1000, oneShot=wx.TIMER_ONE_SHOT)
     # ------------------------------------ MAINLOOP ------------------------------------
-
 
     if not window.NonBlocking:
         window.App.MainLoop()
@@ -5535,8 +6805,17 @@ def _GetNumLinesNeeded(text, max_line_width):
 
 # ==============================  PROGRESS METER ========================================== #
 
+
 def ConvertArgsToSingleString(*args):
-    max_line_total, width_used, total_lines, = 0, 0, 0
+    (
+        max_line_total,
+        width_used,
+        total_lines,
+    ) = (
+        0,
+        0,
+        0,
+    )
     single_line_message = ''
     # loop through args and built a SINGLE string from them
     for message in args:
@@ -5558,12 +6837,25 @@ METER_REASON_REACHED_MAX = 'finished'
 METER_OK = True
 METER_STOPPED = False
 
+
 class QuickMeter(object):
     active_meters = {}
     exit_reasons = {}
 
-    def __init__(self, title, current_value, max_value, key, *args, orientation='v', bar_color=(None, None),
-                         button_color=(None, None), size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
+    def __init__(
+        self,
+        title,
+        current_value,
+        max_value,
+        key,
+        *args,
+        orientation='v',
+        bar_color=(None, None),
+        button_color=(None, None),
+        size=DEFAULT_PROGRESS_BAR_SIZE,
+        border_width=None,
+        grab_anywhere=False,
+    ):
         self.start_time = datetime.datetime.utcnow()
         self.key = key
         self.orientation = orientation
@@ -5582,17 +6874,22 @@ class QuickMeter(object):
         layout = []
         if self.orientation.lower().startswith('h'):
             col = []
-            col += [[T(''.join(map(lambda x: str(x)+'\n',args)),key='_OPTMSG_')]] ### convert all *args into one string that can be updated
-            col += [[T('', size=(25,8), key='_STATS_')],
-                    [ProgressBar(max_value=self.max_value, orientation='h', key='_PROG_', size=self.size)],
-                    [Cancel(button_color=self.button_color), Stretch()]]
+            col += [
+                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
+            ]  ### convert all *args into one string that can be updated
+            col += [
+                [T('', size=(25, 8), key='_STATS_')],
+                [ProgressBar(max_value=self.max_value, orientation='h', key='_PROG_', size=self.size)],
+                [Cancel(button_color=self.button_color), Stretch()],
+            ]
             layout = [Column(col)]
         else:
             col = [[ProgressBar(max_value=self.max_value, orientation='v', key='_PROG_', size=self.size)]]
             col2 = []
-            col2 += [[T(''.join(map(lambda x: str(x)+'\n',args)),key='_OPTMSG_')]] ### convert all *args into one string that can be updated
-            col2 += [[T('', size=(25,8), key='_STATS_')],
-                     [Cancel(button_color=self.button_color), Stretch()]]
+            col2 += [
+                [T(''.join(map(lambda x: str(x) + '\n', args)), key='_OPTMSG_')]
+            ]  ### convert all *args into one string that can be updated
+            col2 += [[T('', size=(25, 8), key='_STATS_')], [Cancel(button_color=self.button_color), Stretch()]]
             layout = [Column(col), Column(col2)]
         self.window = Window(self.title, grab_anywhere=self.grab_anywhere, border_depth=self.border_width)
         self.window.Layout([layout]).Finalize()
@@ -5604,15 +6901,20 @@ class QuickMeter(object):
         self.max_value = max_value
         self.window.Element('_PROG_').UpdateBar(self.current_value, self.max_value)
         self.window.Element('_STATS_').Update('\n'.join(self.ComputeProgressStats()))
-        self.window.Element('_OPTMSG_').Update(value=''.join(map(lambda x: str(x)+'\n',args))) ###  update the string with the args
+        self.window.Element('_OPTMSG_').Update(
+            value=''.join(map(lambda x: str(x) + '\n', args))
+        )  ###  update the string with the args
         event, values = self.window.Read(timeout=0)
-        if event in('Cancel', None) or current_value >= max_value:
+        if event in ('Cancel', None) or current_value >= max_value:
             self.window.Close()
-            del(QuickMeter.active_meters[self.key])
-            QuickMeter.exit_reasons[self.key] = METER_REASON_CANCELLED if event == 'Cancel' else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
+            del QuickMeter.active_meters[self.key]
+            QuickMeter.exit_reasons[self.key] = (
+                METER_REASON_CANCELLED
+                if event == 'Cancel'
+                else METER_REASON_CLOSED if event is None else METER_REASON_REACHED_MAX
+            )
             return QuickMeter.exit_reasons[self.key]
         return METER_OK
-
 
     def ComputeProgressStats(self):
         utc = datetime.datetime.utcnow()
@@ -5639,32 +6941,55 @@ class QuickMeter(object):
             '',
             '{} Elapsed Time'.format(time_delta_short),
             '{} Time Remaining'.format(time_remaining_short),
-            '{} Estimated Total Time'.format(total_time_short)]
+            '{} Estimated Total Time'.format(total_time_short),
+        ]
         return self.stat_messages
 
 
-def OneLineProgressMeter(title, current_value, max_value, key='OK for 1 meter', *args, orientation='v', bar_color=(None, None),
-                         button_color=None, size=DEFAULT_PROGRESS_BAR_SIZE, border_width=None, grab_anywhere=False):
+def OneLineProgressMeter(
+    title,
+    current_value,
+    max_value,
+    key='OK for 1 meter',
+    *args,
+    orientation='v',
+    bar_color=(None, None),
+    button_color=None,
+    size=DEFAULT_PROGRESS_BAR_SIZE,
+    border_width=None,
+    grab_anywhere=False,
+):
     if key not in QuickMeter.active_meters:
-        meter = QuickMeter(title, current_value, max_value, key, *args, orientation=orientation, bar_color=bar_color,
-                           button_color=button_color, size=size, border_width=border_width, grab_anywhere=grab_anywhere)
+        meter = QuickMeter(
+            title,
+            current_value,
+            max_value,
+            key,
+            *args,
+            orientation=orientation,
+            bar_color=bar_color,
+            button_color=button_color,
+            size=size,
+            border_width=border_width,
+            grab_anywhere=grab_anywhere,
+        )
         QuickMeter.active_meters[key] = meter
     else:
         meter = QuickMeter.active_meters[key]
 
     rc = meter.UpdateMeter(current_value, max_value, *args)
-    OneLineProgressMeter.exit_reasons = getattr(OneLineProgressMeter,'exit_reasons', QuickMeter.exit_reasons)
+    OneLineProgressMeter.exit_reasons = getattr(OneLineProgressMeter, 'exit_reasons', QuickMeter.exit_reasons)
     return rc == METER_OK
+
 
 def OneLineProgressMeterCancel(key='OK for 1 meter'):
     try:
         meter = QuickMeter.active_meters[key]
         meter.window.Close()
-        del(QuickMeter.active_meters[key])
+        del QuickMeter.active_meters[key]
         QuickMeter.exit_reasons[key] = METER_REASON_CANCELLED
     except:  # meter is already deleted
         return
-
 
 
 # input is #RRGGBB
@@ -5685,11 +7010,22 @@ def GetComplimentaryHex(color):
 # ========================  EasyPrint           =====#
 # ===================================================#
 
-class DebugWin():
+
+class DebugWin:
     debug_window = None
 
-    def __init__(self, size=(None, None), location=(None, None), font=None, no_titlebar=False, no_button=False,
-                 grab_anywhere=False, keep_on_top=False, title=None, do_not_reroute_stdout=False):
+    def __init__(
+        self,
+        size=(None, None),
+        location=(None, None),
+        font=None,
+        no_titlebar=False,
+        no_button=False,
+        grab_anywhere=False,
+        keep_on_top=False,
+        title=None,
+        do_not_reroute_stdout=False,
+    ):
         # Show a form that's a running counter
         self.size = size
         self.location = location
@@ -5701,17 +7037,23 @@ class DebugWin():
         self.do_not_reroute_stdout = do_not_reroute_stdout
 
         win_size = size if size != (None, None) else DEFAULT_DEBUG_WINDOW_SIZE
-        self.window = Window(title=title or 'Debug Window', no_titlebar=no_titlebar, auto_size_text=True, location=location,
-                             font=font or ('Courier New', 10), grab_anywhere=grab_anywhere, keep_on_top=keep_on_top)
-        self.output_element = MultilineOutput(size=win_size,  key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
+        self.window = Window(
+            title=title or 'Debug Window',
+            no_titlebar=no_titlebar,
+            auto_size_text=True,
+            location=location,
+            font=font or ('Courier New', 10),
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+        )
+        self.output_element = (
+            MultilineOutput(size=win_size, key='_MULTILINE_') if do_not_reroute_stdout else Output(size=win_size)
+        )
 
         if no_button:
             self.layout = [[self.output_element]]
         else:
-            self.layout = [
-                [self.output_element],
-                [DummyButton('Quit'), Stretch()]
-            ]
+            self.layout = [[self.output_element], [DummyButton('Quit'), Stretch()]]
         self.window.AddRows(self.layout)
         self.window.Read(timeout=0)  # Show a non-blocking form, returns immediately
         Window.active_popups[self.window] = 'debug window'
@@ -5722,11 +7064,29 @@ class DebugWin():
         endchar = end if end is not None else '\n'
 
         if self.window is None:  # if window was destroyed already, just print
-            self.__init__(size=self.size, location=self.location, font=self.font, no_titlebar=self.no_titlebar, no_button=self.no_button, grab_anywhere=self.grab_anywhere, keep_on_top=self.keep_on_top, do_not_reroute_stdout=self.do_not_reroute_stdout)
+            self.__init__(
+                size=self.size,
+                location=self.location,
+                font=self.font,
+                no_titlebar=self.no_titlebar,
+                no_button=self.no_button,
+                grab_anywhere=self.grab_anywhere,
+                keep_on_top=self.keep_on_top,
+                do_not_reroute_stdout=self.do_not_reroute_stdout,
+            )
         event, values = self.window.Read(timeout=0)
         if event == 'Quit' or event is None:
             self.Close()
-            self.__init__(size=self.size, location=self.location, font=self.font, no_titlebar=self.no_titlebar, no_button=self.no_button, grab_anywhere=self.grab_anywhere, keep_on_top=self.keep_on_top, do_not_reroute_stdout=self.do_not_reroute_stdout)
+            self.__init__(
+                size=self.size,
+                location=self.location,
+                font=self.font,
+                no_titlebar=self.no_titlebar,
+                no_button=self.no_button,
+                grab_anywhere=self.grab_anywhere,
+                keep_on_top=self.keep_on_top,
+                do_not_reroute_stdout=self.do_not_reroute_stdout,
+            )
         if self.do_not_reroute_stdout:
             outstring = ''
             for arg in args:
@@ -5735,7 +7095,6 @@ class DebugWin():
             self.output_element.Update(outstring, append=True)
         else:
             print(*args, sep=sepchar, end=endchar)
-
 
     def Close(self):
         self.window.Close()
@@ -5746,13 +7105,31 @@ def PrintClose():
     EasyPrintClose()
 
 
-def EasyPrint(*args, size=(None, None), end=None, sep=None, location=(None, None), font=None, no_titlebar=False,
-              no_button=False, grab_anywhere=False, keep_on_top=False, do_not_reroute_stdout=True):
-
+def EasyPrint(
+    *args,
+    size=(None, None),
+    end=None,
+    sep=None,
+    location=(None, None),
+    font=None,
+    no_titlebar=False,
+    no_button=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    do_not_reroute_stdout=True,
+):
 
     if DebugWin.debug_window is None:
-        DebugWin.debug_window = DebugWin(size=size, location=location, font=font, no_titlebar=no_titlebar,
-                                    no_button=no_button, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, do_not_reroute_stdout=do_not_reroute_stdout)
+        DebugWin.debug_window = DebugWin(
+            size=size,
+            location=location,
+            font=font,
+            no_titlebar=no_titlebar,
+            no_button=no_button,
+            grab_anywhere=grab_anywhere,
+            keep_on_top=keep_on_top,
+            do_not_reroute_stdout=do_not_reroute_stdout,
+        )
     DebugWin.debug_window.Print(*args, end=end, sep=sep)
 
 
@@ -5768,13 +7145,20 @@ def EasyPrintClose():
 
 # ========================  Scrolled Text Box   =====#
 # ===================================================#
-def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None,
-                  size=(None, None)):
-    if not args: return
+def PopupScrolled(
+    *args, button_color=None, yes_no=False, auto_close=False, auto_close_duration=None, size=(None, None)
+):
+    if not args:
+        return
     width, height = size
     width = width if width else MESSAGE_BOX_LINE_WIDTH
-    form = Window(args[0], auto_size_text=True, button_color=button_color, auto_close=auto_close,
-                  auto_close_duration=auto_close_duration)
+    form = Window(
+        args[0],
+        auto_size_text=True,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+    )
     max_line_total, max_line_width, total_lines, height_computed = 0, 0, 0, 0
     complete_output = ''
     for message in args:
@@ -5789,7 +7173,9 @@ def PopupScrolled(*args, button_color=None, yes_no=False, auto_close=False, auto
         height_computed += lines_needed
         complete_output += message + '\n'
         total_lines += lines_needed
-    height_computed = MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    height_computed = (
+        MAX_SCROLLED_TEXT_BOX_HEIGHT if height_computed > MAX_SCROLLED_TEXT_BOX_HEIGHT else height_computed
+    )
     if height:
         height_computed = height
     form.AddRow(Multiline(complete_output, size=(max_line_width, height_computed)))
@@ -5820,18 +7206,40 @@ def SetGlobalIcon(icon):
 # ============================== SetOptions =========#
 # Sets the icon to be used by default                #
 # ===================================================#
-def SetOptions(icon=None, button_color=None, element_size=(None, None), button_element_size=(None, None),
-               margins=(None, None),
-               element_padding=(None, None), auto_size_text=None, auto_size_buttons=None, font=None, border_width=None,
-               slider_border_width=None, slider_relief=None, slider_orientation=None,
-               autoclose_time=None, message_box_line_width=None,
-               progress_meter_border_depth=None, progress_meter_style=None,
-               progress_meter_relief=None, progress_meter_color=None, progress_meter_size=None,
-               text_justification=None, background_color=None, element_background_color=None,
-               text_element_background_color=None, input_elements_background_color=None, input_text_color=None,
-               scrollbar_color=None, text_color=None, element_text_color=None, debug_win_size=(None, None),
-               window_location=(None, None),
-               tooltip_time=None):
+def SetOptions(
+    icon=None,
+    button_color=None,
+    element_size=(None, None),
+    button_element_size=(None, None),
+    margins=(None, None),
+    element_padding=(None, None),
+    auto_size_text=None,
+    auto_size_buttons=None,
+    font=None,
+    border_width=None,
+    slider_border_width=None,
+    slider_relief=None,
+    slider_orientation=None,
+    autoclose_time=None,
+    message_box_line_width=None,
+    progress_meter_border_depth=None,
+    progress_meter_style=None,
+    progress_meter_relief=None,
+    progress_meter_color=None,
+    progress_meter_size=None,
+    text_justification=None,
+    background_color=None,
+    element_background_color=None,
+    text_element_background_color=None,
+    input_elements_background_color=None,
+    input_text_color=None,
+    scrollbar_color=None,
+    text_color=None,
+    element_text_color=None,
+    debug_win_size=(None, None),
+    window_location=(None, None),
+    tooltip_time=None,
+):
     global DEFAULT_ELEMENT_SIZE
     global DEFAULT_BUTTON_ELEMENT_SIZE
     global DEFAULT_MARGINS  # Margins for each LEFT/RIGHT margin is first term
@@ -5981,994 +7389,1834 @@ def SetOptions(icon=None, button_color=None, element_size=(None, None), button_e
 # Predefined settings that will change the colors and styles #
 # of the elements.                                           #
 ##############################################################
-LOOK_AND_FEEL_TABLE = {'SystemDefault':
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'SystemDefaultForReal':
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': COLOR_SYSTEM_DEFAULT,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'SystemDefault1':
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': COLOR_SYSTEM_DEFAULT,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'Material1': {'BACKGROUND': '#E3F2FD',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#86A8FF',
-                                     'TEXT_INPUT': '#000000',
-                                     'SCROLL': '#86A8FF',
-                                     'BUTTON': ('#FFFFFF', '#5079D3'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'Material2': {'BACKGROUND': '#FAFAFA',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#004EA1',
-                                     'TEXT_INPUT': '#FFFFFF',
-                                     'SCROLL': '#5EA7FF',
-                                     'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'Reddit': {'BACKGROUND': '#ffffff',
-                                  'TEXT': '#1a1a1b',
-                                  'INPUT': '#dae0e6',
-                                  'TEXT_INPUT': '#222222',
-                                  'SCROLL': '#a5a4a4',
-                                  'BUTTON': ('white', '#0079d3'),
-                                  'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                  'BORDER': 1,
-                                  'SLIDER_DEPTH': 0,
-                                  'PROGRESS_DEPTH': 0,
-                                  'ACCENT1': '#ff5414',
-                                  'ACCENT2': '#33a8ff',
-                                  'ACCENT3': '#dbf0ff'},
-
-                       'Topanga': {'BACKGROUND': '#282923',
-                                   'TEXT': '#E7DB74',
-                                   'INPUT': '#393a32',
-                                   'TEXT_INPUT': '#E7C855',
-                                   'SCROLL': '#E7C855',
-                                   'BUTTON': ('#E7C855', '#284B5A'),
-                                   'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                   'BORDER': 1,
-                                   'SLIDER_DEPTH': 0,
-                                   'PROGRESS_DEPTH': 0,
-                                   'ACCENT1': '#c15226',
-                                   'ACCENT2': '#7a4d5f',
-                                   'ACCENT3': '#889743'},
-
-                       'GreenTan': {'BACKGROUND': '#9FB8AD',
-                                    'TEXT': COLOR_SYSTEM_DEFAULT,
-                                    'INPUT': '#F7F3EC', 'TEXT_INPUT': 'black',
-                                    'SCROLL': '#F7F3EC',
-                                    'BUTTON': ('white', '#475841'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'Dark': {'BACKGROUND': '#404040',
-                                'TEXT': 'white',
-                                'INPUT': '#4D4D4D',
-                                'TEXT_INPUT': 'white',
-                                'SCROLL': '#707070',
-                                'BUTTON': ('white', '#004F00'),
-                                'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                'BORDER': 1,
-                                'SLIDER_DEPTH': 0,
-                                'PROGRESS_DEPTH': 0},
-
-                       'LightGreen': {'BACKGROUND': '#B7CECE',
-                                      'TEXT': 'black',
-                                      'INPUT': '#FDFFF7',
-                                      'TEXT_INPUT': 'black',
-                                      'SCROLL': '#FDFFF7',
-                                      'BUTTON': ('white', '#658268'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'ACCENT1': '#76506d',
-                                      'ACCENT2': '#5148f1',
-                                      'ACCENT3': '#0a1c84',
-                                      'PROGRESS_DEPTH': 0},
-
-                       'Dark2': {'BACKGROUND': '#404040',
-                                 'TEXT': 'white',
-                                 'INPUT': 'white',
-                                 'TEXT_INPUT': 'black',
-                                 'SCROLL': '#707070',
-                                 'BUTTON': ('white', '#004F00'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'Black': {'BACKGROUND': 'black',
-                                 'TEXT': 'white',
-                                 'INPUT': '#4D4D4D',
-                                 'TEXT_INPUT': 'white',
-                                 'SCROLL': '#707070',
-                                 'BUTTON': ('black', 'white'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'Tan': {'BACKGROUND': '#fdf6e3',
-                               'TEXT': '#268bd1',
-                               'INPUT': '#eee8d5',
-                               'TEXT_INPUT': '#6c71c3',
-                               'SCROLL': '#eee8d5',
-                               'BUTTON': ('white', '#063542'),
-                               'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                               'BORDER': 1,
-                               'SLIDER_DEPTH': 0,
-                               'PROGRESS_DEPTH': 0},
-
-                       'TanBlue': {'BACKGROUND': '#e5dece',
-                                   'TEXT': '#063289',
-                                   'INPUT': '#f9f8f4',
-                                   'TEXT_INPUT': '#242834',
-                                   'SCROLL': '#eee8d5',
-                                   'BUTTON': ('white', '#063289'),
-                                   'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                   'BORDER': 1,
-                                   'SLIDER_DEPTH': 0,
-                                   'PROGRESS_DEPTH': 0},
-
-                       'DarkTanBlue': {'BACKGROUND': '#242834',
-                                       'TEXT': '#dfe6f8',
-                                       'INPUT': '#97755c',
-                                       'TEXT_INPUT': 'white',
-                                       'SCROLL': '#a9afbb',
-                                       'BUTTON': ('white', '#063289'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkAmber': {'BACKGROUND': '#2c2825',
-                                     'TEXT': '#fdcb52',
-                                     'INPUT': '#705e52',
-                                     'TEXT_INPUT': '#fdcb52',
-                                     'SCROLL': '#705e52',
-                                     'BUTTON': ('black', '#fdcb52'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue': {'BACKGROUND': '#1a2835',
-                                    'TEXT': '#d1ecff',
-                                    'INPUT': '#335267',
-                                    'TEXT_INPUT': '#acc2d0',
-                                    'SCROLL': '#1b6497',
-                                    'BUTTON': ('black', '#fafaf8'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'Reds': {'BACKGROUND': '#280001',
-                                'TEXT': 'white',
-                                'INPUT': '#d8d584',
-                                'TEXT_INPUT': 'black',
-                                'SCROLL': '#763e00',
-                                'BUTTON': ('black', '#daad28'),
-                                'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                'BORDER': 1,
-                                'SLIDER_DEPTH': 0,
-                                'PROGRESS_DEPTH': 0},
-
-                       'Green': {'BACKGROUND': '#82a459',
-                                 'TEXT': 'black',
-                                 'INPUT': '#d8d584',
-                                 'TEXT_INPUT': 'black',
-                                 'SCROLL': '#e3ecf3',
-                                 'BUTTON': ('white', '#517239'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'BluePurple': {'BACKGROUND': '#A5CADD',
-                                      'TEXT': '#6E266E',
-                                      'INPUT': '#E0F5FF',
-                                      'TEXT_INPUT': 'black',
-                                      'SCROLL': '#E0F5FF',
-                                      'BUTTON': ('white', '#303952'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'Purple': {'BACKGROUND': '#B0AAC2',
-                                  'TEXT': 'black',
-                                  'INPUT': '#F2EFE8',
-                                  'SCROLL': '#F2EFE8',
-                                  'TEXT_INPUT': 'black',
-                                  'BUTTON': ('black', '#C2D4D8'),
-                                  'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                  'BORDER': 1,
-                                  'SLIDER_DEPTH': 0,
-                                  'PROGRESS_DEPTH': 0},
-
-                       'BlueMono': {'BACKGROUND': '#AAB6D3',
-                                    'TEXT': 'black',
-                                    'INPUT': '#F1F4FC',
-                                    'SCROLL': '#F1F4FC',
-                                    'TEXT_INPUT': 'black',
-                                    'BUTTON': ('white', '#7186C7'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1,
-                                    'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'GreenMono': {'BACKGROUND': '#A8C1B4',
-                                     'TEXT': 'black',
-                                     'INPUT': '#DDE0DE',
-                                     'SCROLL': '#E3E3E3',
-                                     'TEXT_INPUT': 'black',
-                                     'BUTTON': ('white', '#6D9F85'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'BrownBlue': {'BACKGROUND': '#64778d',
-                                     'TEXT': 'white',
-                                     'INPUT': '#f0f3f7',
-                                     'SCROLL': '#A6B2BE',
-                                     'TEXT_INPUT': 'black',
-                                     'BUTTON': ('white', '#283b5b'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'BrightColors': {'BACKGROUND': '#b4ffb4',
-                                        'TEXT': 'black',
-                                        'INPUT': '#ffff64',
-                                        'SCROLL': '#ffb482',
-                                        'TEXT_INPUT': 'black',
-                                        'BUTTON': ('black', '#ffa0dc'),
-                                        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                        'BORDER': 1,
-                                        'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0},
-
-                       'NeutralBlue': {'BACKGROUND': '#92aa9d',
-                                       'TEXT': 'black',
-                                       'INPUT': '#fcfff6',
-                                       'SCROLL': '#fcfff6',
-                                       'TEXT_INPUT': 'black',
-                                       'BUTTON': ('black', '#d0dbbd'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'Kayak': {'BACKGROUND': '#a7ad7f',
-                                 'TEXT': 'black',
-                                 'INPUT': '#e6d3a8',
-                                 'SCROLL': '#e6d3a8',
-                                 'TEXT_INPUT': 'black',
-                                 'BUTTON': ('white', '#5d907d'),
-                                 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                 'BORDER': 1,
-                                 'SLIDER_DEPTH': 0,
-                                 'PROGRESS_DEPTH': 0},
-
-                       'SandyBeach': {'BACKGROUND': '#efeccb',
-                                      'TEXT': '#012f2f',
-                                      'INPUT': '#e6d3a8',
-                                      'SCROLL': '#e6d3a8',
-                                      'TEXT_INPUT': '#012f2f',
-                                      'BUTTON': ('white', '#046380'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'TealMono': {'BACKGROUND': '#a8cfdd',
-                                    'TEXT': 'black',
-                                    'INPUT': '#dfedf2',
-                                    'SCROLL': '#dfedf2',
-                                    'TEXT_INPUT': 'black',
-                                    'BUTTON': ('white', '#183440'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1,
-                                    'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-                       ################################## Renamed Original Themes ##################################
-                       'Default':  # plain gray but blue buttons
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'Default1':  # everything is gray
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': COLOR_SYSTEM_DEFAULT,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'DefaultNoMoreNagging':  # a duplicate of "Default" for users that are tired of the nag screen
-                           {'BACKGROUND': COLOR_SYSTEM_DEFAULT,
-                            'TEXT': COLOR_SYSTEM_DEFAULT,
-                            'INPUT': COLOR_SYSTEM_DEFAULT,
-                            'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
-                            'SCROLL': COLOR_SYSTEM_DEFAULT,
-                            'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
-                            'PROGRESS': COLOR_SYSTEM_DEFAULT,
-                            'BORDER': 1, 'SLIDER_DEPTH': 1,
-                            'PROGRESS_DEPTH': 0},
-
-                       'LightBlue': {'BACKGROUND': '#E3F2FD',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#86A8FF',
-                                     'TEXT_INPUT': '#000000',
-                                     'SCROLL': '#86A8FF',
-                                     'BUTTON': ('#FFFFFF', '#5079D3'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'LightGrey': {'BACKGROUND': '#FAFAFA',
-                                     'TEXT': '#000000',
-                                     'INPUT': '#004EA1',
-                                     'TEXT_INPUT': '#FFFFFF',
-                                     'SCROLL': '#5EA7FF',
-                                     'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 0, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#FF0266',
-                                     'ACCENT2': '#FF5C93',
-                                     'ACCENT3': '#C5003C'},
-
-                       'LightGrey1': {'BACKGROUND': '#ffffff',
-                                      'TEXT': '#1a1a1b',
-                                      'INPUT': '#dae0e6',
-                                      'TEXT_INPUT': '#222222',
-                                      'SCROLL': '#a5a4a4',
-                                      'BUTTON': ('white', '#0079d3'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0,
-                                      'ACCENT1': '#ff5414',
-                                      'ACCENT2': '#33a8ff',
-                                      'ACCENT3': '#dbf0ff'},
-
-                       'DarkBrown': {'BACKGROUND': '#282923',
-                                     'TEXT': '#E7DB74',
-                                     'INPUT': '#393a32',
-                                     'TEXT_INPUT': '#E7C855',
-                                     'SCROLL': '#E7C855',
-                                     'BUTTON': ('#E7C855', '#284B5A'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'ACCENT1': '#c15226',
-                                     'ACCENT2': '#7a4d5f',
-                                     'ACCENT3': '#889743'},
-
-                       'LightGreen1': {'BACKGROUND': '#9FB8AD',
-                                       'TEXT': COLOR_SYSTEM_DEFAULT,
-                                       'INPUT': '#F7F3EC', 'TEXT_INPUT': 'black',
-                                       'SCROLL': '#F7F3EC',
-                                       'BUTTON': ('white', '#475841'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkGrey': {'BACKGROUND': '#404040',
-                                    'TEXT': 'white',
-                                    'INPUT': '#4D4D4D',
-                                    'TEXT_INPUT': 'white',
-                                    'SCROLL': '#707070',
-                                    'BUTTON': ('white', '#004F00'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                    'BORDER': 1,
-                                    'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0},
-
-                       'LightGreen2': {'BACKGROUND': '#B7CECE',
-                                       'TEXT': 'black',
-                                       'INPUT': '#FDFFF7',
-                                       'TEXT_INPUT': 'black',
-                                       'SCROLL': '#FDFFF7',
-                                       'BUTTON': ('white', '#658268'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'ACCENT1': '#76506d',
-                                       'ACCENT2': '#5148f1',
-                                       'ACCENT3': '#0a1c84',
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkGrey1': {'BACKGROUND': '#404040',
-                                     'TEXT': 'white',
-                                     'INPUT': 'white',
-                                     'TEXT_INPUT': 'black',
-                                     'SCROLL': '#707070',
-                                     'BUTTON': ('white', '#004F00'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBlack': {'BACKGROUND': 'black',
-                                     'TEXT': 'white',
-                                     'INPUT': '#4D4D4D',
-                                     'TEXT_INPUT': 'white',
-                                     'SCROLL': '#707070',
-                                     'BUTTON': ('black', 'white'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'LightBrown': {'BACKGROUND': '#fdf6e3',
-                                      'TEXT': '#268bd1',
-                                      'INPUT': '#eee8d5',
-                                      'TEXT_INPUT': '#6c71c3',
-                                      'SCROLL': '#eee8d5',
-                                      'BUTTON': ('white', '#063542'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'LightBrown1': {'BACKGROUND': '#e5dece',
-                                       'TEXT': '#063289',
-                                       'INPUT': '#f9f8f4',
-                                       'TEXT_INPUT': '#242834',
-                                       'SCROLL': '#eee8d5',
-                                       'BUTTON': ('white', '#063289'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue1': {'BACKGROUND': '#242834',
-                                     'TEXT': '#dfe6f8',
-                                     'INPUT': '#97755c',
-                                     'TEXT_INPUT': 'white',
-                                     'SCROLL': '#a9afbb',
-                                     'BUTTON': ('white', '#063289'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBrown1': {'BACKGROUND': '#2c2825',
-                                      'TEXT': '#fdcb52',
-                                      'INPUT': '#705e52',
-                                      'TEXT_INPUT': '#fdcb52',
-                                      'SCROLL': '#705e52',
-                                      'BUTTON': ('black', '#fdcb52'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue2': {'BACKGROUND': '#1a2835',
-                                     'TEXT': '#d1ecff',
-                                     'INPUT': '#335267',
-                                     'TEXT_INPUT': '#acc2d0',
-                                     'SCROLL': '#1b6497',
-                                     'BUTTON': ('black', '#fafaf8'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'DarkBrown2': {'BACKGROUND': '#280001',
-                                      'TEXT': 'white',
-                                      'INPUT': '#d8d584',
-                                      'TEXT_INPUT': 'black',
-                                      'SCROLL': '#763e00',
-                                      'BUTTON': ('black', '#daad28'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'DarkGreen': {'BACKGROUND': '#82a459',
-                                     'TEXT': 'black',
-                                     'INPUT': '#d8d584',
-                                     'TEXT_INPUT': 'black',
-                                     'SCROLL': '#e3ecf3',
-                                     'BUTTON': ('white', '#517239'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'LightBlue1': {'BACKGROUND': '#A5CADD',
-                                      'TEXT': '#6E266E',
-                                      'INPUT': '#E0F5FF',
-                                      'TEXT_INPUT': 'black',
-                                      'SCROLL': '#E0F5FF',
-                                      'BUTTON': ('white', '#303952'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'LightPurple': {'BACKGROUND': '#B0AAC2',
-                                       'TEXT': 'black',
-                                       'INPUT': '#F2EFE8',
-                                       'SCROLL': '#F2EFE8',
-                                       'TEXT_INPUT': 'black',
-                                       'BUTTON': ('black', '#C2D4D8'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBlue2': {'BACKGROUND': '#AAB6D3',
-                                      'TEXT': 'black',
-                                      'INPUT': '#F1F4FC',
-                                      'SCROLL': '#F1F4FC',
-                                      'TEXT_INPUT': 'black',
-                                      'BUTTON': ('white', '#7186C7'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       'LightGreen3': {'BACKGROUND': '#A8C1B4',
-                                       'TEXT': 'black',
-                                       'INPUT': '#DDE0DE',
-                                       'SCROLL': '#E3E3E3',
-                                       'TEXT_INPUT': 'black',
-                                       'BUTTON': ('white', '#6D9F85'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'DarkBlue3': {'BACKGROUND': '#64778d',
-                                     'TEXT': 'white',
-                                     'INPUT': '#f0f3f7',
-                                     'SCROLL': '#A6B2BE',
-                                     'TEXT_INPUT': 'black',
-                                     'BUTTON': ('white', '#283b5b'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                     'BORDER': 1,
-                                     'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0},
-
-                       'LightGreen4': {'BACKGROUND': '#b4ffb4',
-                                       'TEXT': 'black',
-                                       'INPUT': '#ffff64',
-                                       'SCROLL': '#ffb482',
-                                       'TEXT_INPUT': 'black',
-                                       'BUTTON': ('black', '#ffa0dc'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightGreen5': {'BACKGROUND': '#92aa9d',
-                                       'TEXT': 'black',
-                                       'INPUT': '#fcfff6',
-                                       'SCROLL': '#fcfff6',
-                                       'TEXT_INPUT': 'black',
-                                       'BUTTON': ('black', '#d0dbbd'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBrown2': {'BACKGROUND': '#a7ad7f',
-                                       'TEXT': 'black',
-                                       'INPUT': '#e6d3a8',
-                                       'SCROLL': '#e6d3a8',
-                                       'TEXT_INPUT': 'black',
-                                       'BUTTON': ('white', '#5d907d'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1,
-                                       'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBrown3': {'BACKGROUND': '#efeccb',
-                                       'TEXT': '#012f2f',
-                                       'INPUT': '#e6d3a8',
-                                       'SCROLL': '#e6d3a8',
-                                       'TEXT_INPUT': '#012f2f',
-                                       'BUTTON': ('white', '#046380'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                       'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0},
-
-                       'LightBlue3': {'BACKGROUND': '#a8cfdd',
-                                      'TEXT': 'black',
-                                      'INPUT': '#dfedf2',
-                                      'SCROLL': '#dfedf2',
-                                      'TEXT_INPUT': 'black',
-                                      'BUTTON': ('white', '#183440'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
-                                      'BORDER': 1,
-                                      'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0},
-
-                       ################################## End Renamed Original Themes ##################################
-
-                       #
-                       'LightBrown4': {'BACKGROUND': '#d7c79e', 'TEXT': '#a35638', 'INPUT': '#9dab86', 'TEXT_INPUT': '#000000', 'SCROLL': '#a35638',
-                                       'BUTTON': ('white', '#a35638'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'], },
-                       'DarkTeal': {'BACKGROUND': '#003f5c', 'TEXT': '#fb5b5a', 'INPUT': '#bc4873', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#bc4873',
-                                    'BUTTON': ('white', '#fb5b5a'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                    'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'], },
-                       'DarkPurple': {'BACKGROUND': '#472b62', 'TEXT': '#fb5b5a', 'INPUT': '#bc4873', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#bc4873',
-                                      'BUTTON': ('#FFFFFF', '#472b62'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'], },
-                       'LightGreen6': {'BACKGROUND': '#eafbea', 'TEXT': '#1f6650', 'INPUT': '#6f9a8d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#1f6650',
-                                       'BUTTON': ('white', '#1f6650'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'], },
-                       'DarkGrey2': {'BACKGROUND': '#2b2b28', 'TEXT': '#f8f8f8', 'INPUT': '#f1d6ab', 'TEXT_INPUT': '#000000', 'SCROLL': '#f1d6ab',
-                                     'BUTTON': ('#2b2b28', '#e3b04b'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'], },
-                       'LightBrown6': {'BACKGROUND': '#f9b282', 'TEXT': '#8f4426', 'INPUT': '#de6b35', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#8f4426',
-                                       'BUTTON': ('white', '#8f4426'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'], },
-                       'DarkTeal1': {'BACKGROUND': '#396362', 'TEXT': '#ffe7d1', 'INPUT': '#f6c89f', 'TEXT_INPUT': '#000000', 'SCROLL': '#f6c89f',
-                                     'BUTTON': ('#ffe7d1', '#4b8e8d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'], },
-                       'LightBrown7': {'BACKGROUND': '#f6c89f', 'TEXT': '#396362', 'INPUT': '#4b8e8d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#396362',
-                                       'BUTTON': ('white', '#396362'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'], },
-                       'DarkPurple1': {'BACKGROUND': '#0c093c', 'TEXT': '#fad6d6', 'INPUT': '#eea5f6', 'TEXT_INPUT': '#000000', 'SCROLL': '#eea5f6',
-                                       'BUTTON': ('#FFFFFF', '#df42d1'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'], },
-                       'DarkGrey3': {'BACKGROUND': '#211717', 'TEXT': '#dfddc7', 'INPUT': '#f58b54', 'TEXT_INPUT': '#000000', 'SCROLL': '#f58b54',
-                                     'BUTTON': ('#dfddc7', '#a34a28'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'], },
-                       'LightBrown8': {'BACKGROUND': '#dfddc7', 'TEXT': '#211717', 'INPUT': '#a34a28', 'TEXT_INPUT': '#dfddc7', 'SCROLL': '#211717',
-                                       'BUTTON': ('#dfddc7', '#a34a28'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'], },
-                       'DarkBlue4': {'BACKGROUND': '#494ca2', 'TEXT': '#e3e7f1', 'INPUT': '#c6cbef', 'TEXT_INPUT': '#000000', 'SCROLL': '#c6cbef',
-                                     'BUTTON': ('#FFFFFF', '#8186d5'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'], },
-                       'LightBlue4': {'BACKGROUND': '#5c94bd', 'TEXT': '#470938', 'INPUT': '#1a3e59', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#470938',
-                                      'BUTTON': ('white', '#470938'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'], },
-                       'DarkTeal2': {'BACKGROUND': '#394a6d', 'TEXT': '#c0ffb3', 'INPUT': '#52de97', 'TEXT_INPUT': '#000000', 'SCROLL': '#52de97',
-                                     'BUTTON': ('#c0ffb3', '#394a6d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'], },
-                       'DarkTeal3': {'BACKGROUND': '#3c9d9b', 'TEXT': '#c0ffb3', 'INPUT': '#52de97', 'TEXT_INPUT': '#000000', 'SCROLL': '#52de97',
-                                     'BUTTON': ('#c0ffb3', '#394a6d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'], },
-                       'DarkPurple5': {'BACKGROUND': '#730068', 'TEXT': '#f6f078', 'INPUT': '#01d28e', 'TEXT_INPUT': '#000000', 'SCROLL': '#01d28e',
-                                       'BUTTON': ('#f6f078', '#730068'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'], },
-                       'DarkPurple2': {'BACKGROUND': '#202060', 'TEXT': '#b030b0', 'INPUT': '#602080', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#602080',
-                                       'BUTTON': ('white', '#202040'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'], },
-                       'DarkBlue5': {'BACKGROUND': '#000272', 'TEXT': '#ff6363', 'INPUT': '#a32f80', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#a32f80',
-                                     'BUTTON': ('#FFFFFF', '#341677'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'], },
-                       'LightGrey2': {'BACKGROUND': '#f6f6f6', 'TEXT': '#420000', 'INPUT': '#d4d7dd', 'TEXT_INPUT': '#420000', 'SCROLL': '#420000',
-                                      'BUTTON': ('#420000', '#d4d7dd'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'], },
-                       'LightGrey3': {'BACKGROUND': '#eae9e9', 'TEXT': '#420000', 'INPUT': '#d4d7dd', 'TEXT_INPUT': '#420000', 'SCROLL': '#420000',
-                                      'BUTTON': ('#420000', '#d4d7dd'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'], },
-                       'DarkBlue6': {'BACKGROUND': '#01024e', 'TEXT': '#ff6464', 'INPUT': '#8b4367', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#8b4367',
-                                     'BUTTON': ('#FFFFFF', '#543864'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'], },
-                       'DarkBlue7': {'BACKGROUND': '#241663', 'TEXT': '#eae7af', 'INPUT': '#a72693', 'TEXT_INPUT': '#eae7af', 'SCROLL': '#a72693',
-                                     'BUTTON': ('#eae7af', '#160f30'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'], },
-                       'LightBrown9': {'BACKGROUND': '#f6d365', 'TEXT': '#3a1f5d', 'INPUT': '#c83660', 'TEXT_INPUT': '#f6d365', 'SCROLL': '#3a1f5d',
-                                       'BUTTON': ('#f6d365', '#c83660'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'], },
-                       'DarkPurple3': {'BACKGROUND': '#6e2142', 'TEXT': '#ffd692', 'INPUT': '#e16363', 'TEXT_INPUT': '#ffd692', 'SCROLL': '#e16363',
-                                       'BUTTON': ('#ffd692', '#943855'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'], },
-                       'LightBrown10': {'BACKGROUND': '#ffd692', 'TEXT': '#6e2142', 'INPUT': '#943855', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#6e2142',
-                                        'BUTTON': ('white', '#6e2142'),
-                                        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'], },
-                       'DarkPurple4': {'BACKGROUND': '#200f21', 'TEXT': '#f638dc', 'INPUT': '#5a3d5c', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#5a3d5c',
-                                       'BUTTON': ('#FFFFFF', '#382039'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'], },
-                       'LightBlue5': {'BACKGROUND': '#b2fcff', 'TEXT': '#3e64ff', 'INPUT': '#5edfff', 'TEXT_INPUT': '#000000', 'SCROLL': '#3e64ff',
-                                      'BUTTON': ('white', '#3e64ff'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'], },
-                       'DarkTeal4': {'BACKGROUND': '#464159', 'TEXT': '#c7f0db', 'INPUT': '#8bbabb', 'TEXT_INPUT': '#000000', 'SCROLL': '#8bbabb',
-                                     'BUTTON': ('#FFFFFF', '#6c7b95'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-                       'LightTeal': {'BACKGROUND': '#c7f0db', 'TEXT': '#464159', 'INPUT': '#6c7b95', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#464159',
-                                     'BUTTON': ('white', '#464159'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-                       'DarkTeal5': {'BACKGROUND': '#8bbabb', 'TEXT': '#464159', 'INPUT': '#6c7b95', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#464159',
-                                     'BUTTON': ('#c7f0db', '#6c7b95'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'], },
-                       'LightGrey4': {'BACKGROUND': '#faf5ef', 'TEXT': '#672f2f', 'INPUT': '#99b19c', 'TEXT_INPUT': '#672f2f', 'SCROLL': '#672f2f',
-                                      'BUTTON': ('#672f2f', '#99b19c'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-                       'LightGreen7': {'BACKGROUND': '#99b19c', 'TEXT': '#faf5ef', 'INPUT': '#d7d1c9', 'TEXT_INPUT': '#000000', 'SCROLL': '#d7d1c9',
-                                       'BUTTON': ('#FFFFFF', '#99b19c'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-                       'LightGrey5': {'BACKGROUND': '#d7d1c9', 'TEXT': '#672f2f', 'INPUT': '#99b19c', 'TEXT_INPUT': '#672f2f', 'SCROLL': '#672f2f',
-                                      'BUTTON': ('white', '#672f2f'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'], },
-                       'DarkBrown3': {'BACKGROUND': '#a0855b', 'TEXT': '#f9f6f2', 'INPUT': '#f1d6ab', 'TEXT_INPUT': '#000000', 'SCROLL': '#f1d6ab',
-                                      'BUTTON': ('white', '#38470b'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'], },
-                       'LightBrown11': {'BACKGROUND': '#f1d6ab', 'TEXT': '#38470b', 'INPUT': '#a0855b', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#38470b',
-                                        'BUTTON': ('#f9f6f2', '#a0855b'),
-                                        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'], },
-                       'DarkRed': {'BACKGROUND': '#83142c', 'TEXT': '#f9d276', 'INPUT': '#ad1d45', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#ad1d45',
-                                   'BUTTON': ('#f9d276', '#ad1d45'),
-                                   'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                   'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'], },
-                       'DarkTeal6': {'BACKGROUND': '#204969', 'TEXT': '#fff7f7', 'INPUT': '#dadada', 'TEXT_INPUT': '#000000', 'SCROLL': '#dadada',
-                                     'BUTTON': ('black', '#fff7f7'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'], },
-                       'DarkBrown4': {'BACKGROUND': '#252525', 'TEXT': '#ff0000', 'INPUT': '#af0404', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#af0404',
-                                      'BUTTON': ('white', '#252525'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'], },
-                       'LightYellow': {'BACKGROUND': '#f4ff61', 'TEXT': '#27aa80', 'INPUT': '#32ff6a', 'TEXT_INPUT': '#000000', 'SCROLL': '#27aa80',
-                                       'BUTTON': ('#f4ff61', '#27aa80'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'], },
-                       'DarkGreen1': {'BACKGROUND': '#2b580c', 'TEXT': '#fdef96', 'INPUT': '#f7b71d', 'TEXT_INPUT': '#000000', 'SCROLL': '#f7b71d',
-                                      'BUTTON': ('#fdef96', '#2b580c'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'], },
-
-                       'LightGreen8': {'BACKGROUND': '#c8dad3', 'TEXT': '#63707e', 'INPUT': '#93b5b3', 'TEXT_INPUT': '#000000', 'SCROLL': '#63707e',
-                                       'BUTTON': ('white', '#63707e'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'], },
-
-                       'DarkTeal7': {'BACKGROUND': '#248ea9', 'TEXT': '#fafdcb', 'INPUT': '#aee7e8', 'TEXT_INPUT': '#000000', 'SCROLL': '#aee7e8',
-                                     'BUTTON': ('black', '#fafdcb'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'], },
-                       'DarkBlue8': {'BACKGROUND': '#454d66', 'TEXT': '#d9d872', 'INPUT': '#58b368', 'TEXT_INPUT': '#000000', 'SCROLL': '#58b368',
-                                     'BUTTON': ('black', '#009975'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'], },
-                       'DarkBlue9': {'BACKGROUND': '#263859', 'TEXT': '#ff6768', 'INPUT': '#6b778d', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#6b778d',
-                                     'BUTTON': ('#ff6768', '#263859'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'], },
-                       'DarkBlue10': {'BACKGROUND': '#0028ff', 'TEXT': '#f1f4df', 'INPUT': '#10eaf0', 'TEXT_INPUT': '#000000', 'SCROLL': '#10eaf0',
-                                      'BUTTON': ('#f1f4df', '#24009c'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'], },
-                       'DarkBlue11': {'BACKGROUND': '#6384b3', 'TEXT': '#e6f0b6', 'INPUT': '#b8e9c0', 'TEXT_INPUT': '#000000', 'SCROLL': '#b8e9c0',
-                                      'BUTTON': ('#e6f0b6', '#684949'),
-                                      'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'], },
-
-                       'DarkTeal8': {'BACKGROUND': '#71a0a5', 'TEXT': '#212121', 'INPUT': '#665c84', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#212121',
-                                     'BUTTON': ('#fab95b', '#665c84'),
-                                     'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                     'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b']},
-                       'DarkRed1': {'BACKGROUND': '#c10000', 'TEXT': '#eeeeee', 'INPUT': '#dedede', 'TEXT_INPUT': '#000000', 'SCROLL': '#dedede',
-                                    'BUTTON': ('#c10000', '#eeeeee'),
-                                    'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                    'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'], },
-                       'LightBrown5': {'BACKGROUND': '#fff591', 'TEXT': '#e41749', 'INPUT': '#f5587b', 'TEXT_INPUT': '#000000', 'SCROLL': '#e41749',
-                                       'BUTTON': ('#fff591', '#e41749'),
-                                       'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0, 'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591']},
-                       'LightGreen9': {'BACKGROUND': '#f1edb3', 'TEXT': '#3b503d', 'INPUT': '#4a746e', 'TEXT_INPUT': '#f1edb3', 'SCROLL': '#3b503d',
-                                       'BUTTON': ('#f1edb3', '#3b503d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0,
-                                       'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'], 'DESCRIPTION': ['Green', 'Turquoise', 'Yellow']},
-                       'DarkGreen2': {'BACKGROUND': '#3b503d', 'TEXT': '#f1edb3', 'INPUT': '#c8cf94', 'TEXT_INPUT': '#000000', 'SCROLL': '#c8cf94',
-                                      'BUTTON': ('#f1edb3', '#3b503d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0,
-                                      'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'], 'DESCRIPTION': ['Green', 'Turquoise', 'Yellow']},
-                       'LightGray1': {'BACKGROUND': '#f2f2f2', 'TEXT': '#222831', 'INPUT': '#393e46', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#222831',
-                                      'BUTTON': ('#f2f2f2', '#222831'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],
-                                      'DESCRIPTION': ['Black', 'Grey', 'Orange', 'Grey', 'Autumn']},
-                       'DarkGrey4': {'BACKGROUND': '#52524e', 'TEXT': '#e9e9e5', 'INPUT': '#d4d6c8', 'TEXT_INPUT': '#000000', 'SCROLL': '#d4d6c8',
-                                     'BUTTON': ('#FFFFFF', '#9a9b94'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],
-                                     'DESCRIPTION': ['Grey', 'Pastel', 'Winter']},
-                       'DarkBlue12': {'BACKGROUND': '#324e7b', 'TEXT': '#f8f8f8', 'INPUT': '#86a6df', 'TEXT_INPUT': '#000000', 'SCROLL': '#86a6df',
-                                      'BUTTON': ('#FFFFFF', '#5068a9'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],
-                                      'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter']},
-                       'DarkPurple6': {'BACKGROUND': '#070739', 'TEXT': '#e1e099', 'INPUT': '#c327ab', 'TEXT_INPUT': '#e1e099', 'SCROLL': '#c327ab',
-                                       'BUTTON': ('#e1e099', '#521477'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                       'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],
-                                       'DESCRIPTION': ['Black', 'Purple', 'Yellow', 'Dark']},
-                       'DarkBlue13': {'BACKGROUND': '#203562', 'TEXT': '#e3e8f8', 'INPUT': '#c0c5cd', 'TEXT_INPUT': '#000000', 'SCROLL': '#c0c5cd',
-                                      'BUTTON': ('#FFFFFF', '#3e588f'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],
-                                      'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold']},
-                       'DarkBrown5': {'BACKGROUND': '#3c1b1f', 'TEXT': '#f6e1b5', 'INPUT': '#e2bf81', 'TEXT_INPUT': '#000000', 'SCROLL': '#e2bf81',
-                                      'BUTTON': ('#3c1b1f', '#f6e1b5'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],
-                                      'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm']},
-                       'DarkGreen3': {'BACKGROUND': '#062121', 'TEXT': '#eeeeee', 'INPUT': '#e4dcad', 'TEXT_INPUT': '#000000', 'SCROLL': '#e4dcad',
-                                      'BUTTON': ('#eeeeee', '#181810'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
-                                      'DESCRIPTION': ['Black', 'Black', 'Brown', 'Grey']},
-                       'DarkBlack1': {'BACKGROUND': '#181810', 'TEXT': '#eeeeee', 'INPUT': '#e4dcad', 'TEXT_INPUT': '#000000', 'SCROLL': '#e4dcad',
-                                      'BUTTON': ('white', '#062121'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
-                                      'DESCRIPTION': ['Black', 'Black', 'Brown', 'Grey']},
-                       'DarkGrey5': {'BACKGROUND': '#343434', 'TEXT': '#f3f3f3', 'INPUT': '#e9dcbe', 'TEXT_INPUT': '#000000', 'SCROLL': '#e9dcbe',
-                                     'BUTTON': ('#FFFFFF', '#8e8b82'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'], 'DESCRIPTION': ['Grey', 'Brown']},
-                       'LightBrown12': {'BACKGROUND': '#8e8b82', 'TEXT': '#f3f3f3', 'INPUT': '#e9dcbe', 'TEXT_INPUT': '#000000', 'SCROLL': '#e9dcbe',
-                                        'BUTTON': ('#f3f3f3', '#8e8b82'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'], 'DESCRIPTION': ['Grey', 'Brown']},
-                       'DarkTeal9': {'BACKGROUND': '#13445a', 'TEXT': '#fef4e8', 'INPUT': '#446878', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#446878',
-                                     'BUTTON': ('#fef4e8', '#446878'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],
-                                     'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro']},
-                       'DarkBlue14': {'BACKGROUND': '#21273d', 'TEXT': '#f1f6f8', 'INPUT': '#b9d4f1', 'TEXT_INPUT': '#000000', 'SCROLL': '#b9d4f1',
-                                      'BUTTON': ('#FFFFFF', '#6a759b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
-                                      'DESCRIPTION': ['Blue', 'Black', 'Grey', 'Cold', 'Winter']},
-                       'LightBlue6': {'BACKGROUND': '#f1f6f8', 'TEXT': '#21273d', 'INPUT': '#6a759b', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#21273d',
-                                      'BUTTON': ('#f1f6f8', '#6a759b'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
-                                      'DESCRIPTION': ['Blue', 'Black', 'Grey', 'Cold', 'Winter']},
-                       'DarkGreen4': {'BACKGROUND': '#044343', 'TEXT': '#e4e4e4', 'INPUT': '#045757', 'TEXT_INPUT': '#e4e4e4', 'SCROLL': '#045757',
-                                      'BUTTON': ('#e4e4e4', '#045757'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],
-                                      'DESCRIPTION': ['Black', 'Turquoise', 'Grey', 'Dark']},
-                       'DarkGreen5': {'BACKGROUND': '#1b4b36', 'TEXT': '#e0e7f1', 'INPUT': '#aebd77', 'TEXT_INPUT': '#000000', 'SCROLL': '#aebd77',
-                                      'BUTTON': ('#FFFFFF', '#538f6a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'], 'DESCRIPTION': ['Green', 'Grey']},
-                       'DarkTeal10': {'BACKGROUND': '#0d3446', 'TEXT': '#d8dfe2', 'INPUT': '#71adb5', 'TEXT_INPUT': '#000000', 'SCROLL': '#71adb5',
-                                      'BUTTON': ('#FFFFFF', '#176d81'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],
-                                      'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold']},
-                       'DarkGrey6': {'BACKGROUND': '#3e3e3e', 'TEXT': '#ededed', 'INPUT': '#68868c', 'TEXT_INPUT': '#ededed', 'SCROLL': '#68868c',
-                                     'BUTTON': ('#FFFFFF', '#405559'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
-                                     'DESCRIPTION': ['Grey', 'Turquoise', 'Winter']},
-                       'DarkTeal11': {'BACKGROUND': '#405559', 'TEXT': '#ededed', 'INPUT': '#68868c', 'TEXT_INPUT': '#ededed', 'SCROLL': '#68868c',
-                                      'BUTTON': ('#ededed', '#68868c'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
-                                      'DESCRIPTION': ['Grey', 'Turquoise', 'Winter']},
-                       'LightBlue7': {'BACKGROUND': '#9ed0e0', 'TEXT': '#19483f', 'INPUT': '#5c868e', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#19483f',
-                                      'BUTTON': ('white', '#19483f'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],
-                                      'DESCRIPTION': ['Orange', 'Blue', 'Turquoise']},
-                       'LightGreen10': {'BACKGROUND': '#d8ebb5', 'TEXT': '#205d67', 'INPUT': '#639a67', 'TEXT_INPUT': '#FFFFFF', 'SCROLL': '#205d67',
-                                        'BUTTON': ('#d8ebb5', '#205d67'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],
-                                        'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage']},
-                       'DarkBlue15': {'BACKGROUND': '#151680', 'TEXT': '#f1fea4', 'INPUT': '#375fc0', 'TEXT_INPUT': '#f1fea4', 'SCROLL': '#375fc0',
-                                      'BUTTON': ('#f1fea4', '#1c44ac'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
-                                      'DESCRIPTION': ['Blue', 'Yellow', 'Cold']},
-                       'DarkBlue16': {'BACKGROUND': '#1c44ac', 'TEXT': '#f1fea4', 'INPUT': '#375fc0', 'TEXT_INPUT': '#f1fea4', 'SCROLL': '#375fc0',
-                                      'BUTTON': ('#f1fea4', '#151680'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
-                                      'DESCRIPTION': ['Blue', 'Yellow', 'Cold']},
-                       'DarkTeal12': {'BACKGROUND': '#004a7c', 'TEXT': '#fafafa', 'INPUT': '#e8f1f5', 'TEXT_INPUT': '#000000', 'SCROLL': '#e8f1f5',
-                                      'BUTTON': ('#fafafa', '#005691'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],
-                                      'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter']},
-                       'LightBrown13': {'BACKGROUND': '#ebf5ee', 'TEXT': '#921224', 'INPUT': '#bdc6b8', 'TEXT_INPUT': '#921224', 'SCROLL': '#921224',
-                                        'BUTTON': ('white', '#921224'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                        'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],
-                                        'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding']},
-                       'DarkBlue17': {'BACKGROUND': '#21294c', 'TEXT': '#f9f2d7', 'INPUT': '#f2dea8', 'TEXT_INPUT': '#000000', 'SCROLL': '#f2dea8',
-                                      'BUTTON': ('#f9f2d7', '#141829'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
-                                      'DESCRIPTION': ['Black', 'Blue', 'Yellow']},
-                       'DarkBrown6': {'BACKGROUND': '#785e4d', 'TEXT': '#f2eee3', 'INPUT': '#baaf92', 'TEXT_INPUT': '#000000', 'SCROLL': '#baaf92',
-                                      'BUTTON': ('white', '#785e4d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],
-                                      'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn']},
-                       'DarkGreen6': {'BACKGROUND': '#5c715e', 'TEXT': '#f2f9f1', 'INPUT': '#ddeedf', 'TEXT_INPUT': '#000000', 'SCROLL': '#ddeedf',
-                                      'BUTTON': ('#f2f9f1', '#5c715e'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],
-                                      'DESCRIPTION': ['Grey', 'Green', 'Vintage']},
-                       'DarkGrey7': {'BACKGROUND': '#4b586e', 'TEXT': '#dddddd', 'INPUT': '#574e6d', 'TEXT_INPUT': '#dddddd', 'SCROLL': '#574e6d',
-                                     'BUTTON': ('#dddddd', '#43405d'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                     'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],
-                                     'DESCRIPTION': ['Grey', 'Winter', 'Cold']},
-                       'DarkRed2': {'BACKGROUND': '#ab1212', 'TEXT': '#f6e4b5', 'INPUT': '#cd3131', 'TEXT_INPUT': '#f6e4b5', 'SCROLL': '#cd3131',
-                                    'BUTTON': ('#f6e4b5', '#ab1212'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                    'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],
-                                    'DESCRIPTION': ['Turquoise', 'Red', 'Yellow']},
-                       'LightGrey6': {'BACKGROUND': '#e3e3e3', 'TEXT': '#233142', 'INPUT': '#455d7a', 'TEXT_INPUT': '#e3e3e3', 'SCROLL': '#233142',
-                                      'BUTTON': ('#e3e3e3', '#455d7a'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0, 'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],
-                                      'DESCRIPTION': ['Black', 'Blue', 'Red', 'Grey']},
-                       'HotDogStand': {'BACKGROUND': 'red', 'TEXT': 'yellow', 'INPUT': 'yellow', 'TEXT_INPUT': 'black', 'SCROLL': 'yellow',
-                                      'BUTTON': ('red', 'yellow'), 'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR, 'BORDER': 1, 'SLIDER_DEPTH': 0,
-                                      'PROGRESS_DEPTH': 0,
-                                     },
-                       }
+LOOK_AND_FEEL_TABLE = {
+    'SystemDefault': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefaultForReal': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SystemDefault1': {
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Material1': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Material2': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'Reddit': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('white', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'Topanga': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'GreenTan': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('white', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark': {
+        'BACKGROUND': '#404040',
+        'TEXT': 'white',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': 'white',
+        'SCROLL': '#707070',
+        'BUTTON': ('white', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': 'black',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('white', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'Dark2': {
+        'BACKGROUND': '#404040',
+        'TEXT': 'white',
+        'INPUT': 'white',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#707070',
+        'BUTTON': ('white', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Black': {
+        'BACKGROUND': 'black',
+        'TEXT': 'white',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': 'white',
+        'SCROLL': '#707070',
+        'BUTTON': ('black', 'white'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Tan': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('white', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TanBlue': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('white', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkTanBlue': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': 'white',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('white', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkAmber': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('black', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('black', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Reds': {
+        'BACKGROUND': '#280001',
+        'TEXT': 'white',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#763e00',
+        'BUTTON': ('black', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Green': {
+        'BACKGROUND': '#82a459',
+        'TEXT': 'black',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('white', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BluePurple': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('white', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Purple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': 'black',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('black', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BlueMono': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': 'black',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'GreenMono': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': 'black',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrownBlue': {
+        'BACKGROUND': '#64778d',
+        'TEXT': 'white',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'BrightColors': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': 'black',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('black', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'NeutralBlue': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': 'black',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('black', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Kayak': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': 'black',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'SandyBeach': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('white', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'TealMono': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': 'black',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    ################################## Renamed Original Themes ##################################
+    'Default': {  # plain gray but blue buttons
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'Default1': {  # everything is gray
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': COLOR_SYSTEM_DEFAULT,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DefaultNoMoreNagging': {  # a duplicate of "Default" for users that are tired of the nag screen
+        'BACKGROUND': COLOR_SYSTEM_DEFAULT,
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': COLOR_SYSTEM_DEFAULT,
+        'TEXT_INPUT': COLOR_SYSTEM_DEFAULT,
+        'SCROLL': COLOR_SYSTEM_DEFAULT,
+        'BUTTON': OFFICIAL_PYSIMPLEGUI_BUTTON_COLOR,
+        'PROGRESS': COLOR_SYSTEM_DEFAULT,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 1,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue': {
+        'BACKGROUND': '#E3F2FD',
+        'TEXT': '#000000',
+        'INPUT': '#86A8FF',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86A8FF',
+        'BUTTON': ('#FFFFFF', '#5079D3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey': {
+        'BACKGROUND': '#FAFAFA',
+        'TEXT': '#000000',
+        'INPUT': '#004EA1',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5EA7FF',
+        'BUTTON': ('#FFFFFF', '#0079D3'),  # based on Reddit color
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 0,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#FF0266',
+        'ACCENT2': '#FF5C93',
+        'ACCENT3': '#C5003C',
+    },
+    'LightGrey1': {
+        'BACKGROUND': '#ffffff',
+        'TEXT': '#1a1a1b',
+        'INPUT': '#dae0e6',
+        'TEXT_INPUT': '#222222',
+        'SCROLL': '#a5a4a4',
+        'BUTTON': ('white', '#0079d3'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#ff5414',
+        'ACCENT2': '#33a8ff',
+        'ACCENT3': '#dbf0ff',
+    },
+    'DarkBrown': {
+        'BACKGROUND': '#282923',
+        'TEXT': '#E7DB74',
+        'INPUT': '#393a32',
+        'TEXT_INPUT': '#E7C855',
+        'SCROLL': '#E7C855',
+        'BUTTON': ('#E7C855', '#284B5A'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'ACCENT1': '#c15226',
+        'ACCENT2': '#7a4d5f',
+        'ACCENT3': '#889743',
+    },
+    'LightGreen1': {
+        'BACKGROUND': '#9FB8AD',
+        'TEXT': COLOR_SYSTEM_DEFAULT,
+        'INPUT': '#F7F3EC',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#F7F3EC',
+        'BUTTON': ('white', '#475841'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey': {
+        'BACKGROUND': '#404040',
+        'TEXT': 'white',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': 'white',
+        'SCROLL': '#707070',
+        'BUTTON': ('white', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen2': {
+        'BACKGROUND': '#B7CECE',
+        'TEXT': 'black',
+        'INPUT': '#FDFFF7',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#FDFFF7',
+        'BUTTON': ('white', '#658268'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'ACCENT1': '#76506d',
+        'ACCENT2': '#5148f1',
+        'ACCENT3': '#0a1c84',
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGrey1': {
+        'BACKGROUND': '#404040',
+        'TEXT': 'white',
+        'INPUT': 'white',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#707070',
+        'BUTTON': ('white', '#004F00'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlack': {
+        'BACKGROUND': 'black',
+        'TEXT': 'white',
+        'INPUT': '#4D4D4D',
+        'TEXT_INPUT': 'white',
+        'SCROLL': '#707070',
+        'BUTTON': ('black', 'white'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown': {
+        'BACKGROUND': '#fdf6e3',
+        'TEXT': '#268bd1',
+        'INPUT': '#eee8d5',
+        'TEXT_INPUT': '#6c71c3',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('white', '#063542'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown1': {
+        'BACKGROUND': '#e5dece',
+        'TEXT': '#063289',
+        'INPUT': '#f9f8f4',
+        'TEXT_INPUT': '#242834',
+        'SCROLL': '#eee8d5',
+        'BUTTON': ('white', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue1': {
+        'BACKGROUND': '#242834',
+        'TEXT': '#dfe6f8',
+        'INPUT': '#97755c',
+        'TEXT_INPUT': 'white',
+        'SCROLL': '#a9afbb',
+        'BUTTON': ('white', '#063289'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown1': {
+        'BACKGROUND': '#2c2825',
+        'TEXT': '#fdcb52',
+        'INPUT': '#705e52',
+        'TEXT_INPUT': '#fdcb52',
+        'SCROLL': '#705e52',
+        'BUTTON': ('black', '#fdcb52'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue2': {
+        'BACKGROUND': '#1a2835',
+        'TEXT': '#d1ecff',
+        'INPUT': '#335267',
+        'TEXT_INPUT': '#acc2d0',
+        'SCROLL': '#1b6497',
+        'BUTTON': ('black', '#fafaf8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBrown2': {
+        'BACKGROUND': '#280001',
+        'TEXT': 'white',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#763e00',
+        'BUTTON': ('black', '#daad28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkGreen': {
+        'BACKGROUND': '#82a459',
+        'TEXT': 'black',
+        'INPUT': '#d8d584',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#e3ecf3',
+        'BUTTON': ('white', '#517239'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue1': {
+        'BACKGROUND': '#A5CADD',
+        'TEXT': '#6E266E',
+        'INPUT': '#E0F5FF',
+        'TEXT_INPUT': 'black',
+        'SCROLL': '#E0F5FF',
+        'BUTTON': ('white', '#303952'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightPurple': {
+        'BACKGROUND': '#B0AAC2',
+        'TEXT': 'black',
+        'INPUT': '#F2EFE8',
+        'SCROLL': '#F2EFE8',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('black', '#C2D4D8'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue2': {
+        'BACKGROUND': '#AAB6D3',
+        'TEXT': 'black',
+        'INPUT': '#F1F4FC',
+        'SCROLL': '#F1F4FC',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#7186C7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen3': {
+        'BACKGROUND': '#A8C1B4',
+        'TEXT': 'black',
+        'INPUT': '#DDE0DE',
+        'SCROLL': '#E3E3E3',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#6D9F85'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'DarkBlue3': {
+        'BACKGROUND': '#64778d',
+        'TEXT': 'white',
+        'INPUT': '#f0f3f7',
+        'SCROLL': '#A6B2BE',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#283b5b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen4': {
+        'BACKGROUND': '#b4ffb4',
+        'TEXT': 'black',
+        'INPUT': '#ffff64',
+        'SCROLL': '#ffb482',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('black', '#ffa0dc'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightGreen5': {
+        'BACKGROUND': '#92aa9d',
+        'TEXT': 'black',
+        'INPUT': '#fcfff6',
+        'SCROLL': '#fcfff6',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('black', '#d0dbbd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown2': {
+        'BACKGROUND': '#a7ad7f',
+        'TEXT': 'black',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#5d907d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBrown3': {
+        'BACKGROUND': '#efeccb',
+        'TEXT': '#012f2f',
+        'INPUT': '#e6d3a8',
+        'SCROLL': '#e6d3a8',
+        'TEXT_INPUT': '#012f2f',
+        'BUTTON': ('white', '#046380'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    'LightBlue3': {
+        'BACKGROUND': '#a8cfdd',
+        'TEXT': 'black',
+        'INPUT': '#dfedf2',
+        'SCROLL': '#dfedf2',
+        'TEXT_INPUT': 'black',
+        'BUTTON': ('white', '#183440'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+    ################################## End Renamed Original Themes ##################################
+    #
+    'LightBrown4': {
+        'BACKGROUND': '#d7c79e',
+        'TEXT': '#a35638',
+        'INPUT': '#9dab86',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#a35638',
+        'BUTTON': ('white', '#a35638'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#a35638', '#9dab86', '#e08f62', '#d7c79e'],
+    },
+    'DarkTeal': {
+        'BACKGROUND': '#003f5c',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('white', '#fb5b5a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'DarkPurple': {
+        'BACKGROUND': '#472b62',
+        'TEXT': '#fb5b5a',
+        'INPUT': '#bc4873',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#bc4873',
+        'BUTTON': ('#FFFFFF', '#472b62'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#003f5c', '#472b62', '#bc4873', '#fb5b5a'],
+    },
+    'LightGreen6': {
+        'BACKGROUND': '#eafbea',
+        'TEXT': '#1f6650',
+        'INPUT': '#6f9a8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#1f6650',
+        'BUTTON': ('white', '#1f6650'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1f6650', '#6f9a8d', '#ea5e5e', '#eafbea'],
+    },
+    'DarkGrey2': {
+        'BACKGROUND': '#2b2b28',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('#2b2b28', '#e3b04b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b2b28', '#e3b04b', '#f1d6ab', '#f8f8f8'],
+    },
+    'LightBrown6': {
+        'BACKGROUND': '#f9b282',
+        'TEXT': '#8f4426',
+        'INPUT': '#de6b35',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8f4426',
+        'BUTTON': ('white', '#8f4426'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#8f4426', '#de6b35', '#64ccda', '#f9b282'],
+    },
+    'DarkTeal1': {
+        'BACKGROUND': '#396362',
+        'TEXT': '#ffe7d1',
+        'INPUT': '#f6c89f',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f6c89f',
+        'BUTTON': ('#ffe7d1', '#4b8e8d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'LightBrown7': {
+        'BACKGROUND': '#f6c89f',
+        'TEXT': '#396362',
+        'INPUT': '#4b8e8d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#396362',
+        'BUTTON': ('white', '#396362'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#396362', '#4b8e8d', '#f6c89f', '#ffe7d1'],
+    },
+    'DarkPurple1': {
+        'BACKGROUND': '#0c093c',
+        'TEXT': '#fad6d6',
+        'INPUT': '#eea5f6',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#eea5f6',
+        'BUTTON': ('#FFFFFF', '#df42d1'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0c093c', '#df42d1', '#eea5f6', '#fad6d6'],
+    },
+    'DarkGrey3': {
+        'BACKGROUND': '#211717',
+        'TEXT': '#dfddc7',
+        'INPUT': '#f58b54',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f58b54',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'LightBrown8': {
+        'BACKGROUND': '#dfddc7',
+        'TEXT': '#211717',
+        'INPUT': '#a34a28',
+        'TEXT_INPUT': '#dfddc7',
+        'SCROLL': '#211717',
+        'BUTTON': ('#dfddc7', '#a34a28'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#211717', '#a34a28', '#f58b54', '#dfddc7'],
+    },
+    'DarkBlue4': {
+        'BACKGROUND': '#494ca2',
+        'TEXT': '#e3e7f1',
+        'INPUT': '#c6cbef',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c6cbef',
+        'BUTTON': ('#FFFFFF', '#8186d5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#494ca2', '#8186d5', '#c6cbef', '#e3e7f1'],
+    },
+    'LightBlue4': {
+        'BACKGROUND': '#5c94bd',
+        'TEXT': '#470938',
+        'INPUT': '#1a3e59',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#470938',
+        'BUTTON': ('white', '#470938'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#470938', '#1a3e59', '#5c94bd', '#f2d6eb'],
+    },
+    'DarkTeal2': {
+        'BACKGROUND': '#394a6d',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkTeal3': {
+        'BACKGROUND': '#3c9d9b',
+        'TEXT': '#c0ffb3',
+        'INPUT': '#52de97',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#52de97',
+        'BUTTON': ('#c0ffb3', '#394a6d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#394a6d', '#3c9d9b', '#52de97', '#c0ffb3'],
+    },
+    'DarkPurple5': {
+        'BACKGROUND': '#730068',
+        'TEXT': '#f6f078',
+        'INPUT': '#01d28e',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#01d28e',
+        'BUTTON': ('#f6f078', '#730068'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#730068', '#434982', '#01d28e', '#f6f078'],
+    },
+    'DarkPurple2': {
+        'BACKGROUND': '#202060',
+        'TEXT': '#b030b0',
+        'INPUT': '#602080',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#602080',
+        'BUTTON': ('white', '#202040'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#202040', '#202060', '#602080', '#b030b0'],
+    },
+    'DarkBlue5': {
+        'BACKGROUND': '#000272',
+        'TEXT': '#ff6363',
+        'INPUT': '#a32f80',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#a32f80',
+        'BUTTON': ('#FFFFFF', '#341677'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#000272', '#341677', '#a32f80', '#ff6363'],
+    },
+    'LightGrey2': {
+        'BACKGROUND': '#f6f6f6',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'LightGrey3': {
+        'BACKGROUND': '#eae9e9',
+        'TEXT': '#420000',
+        'INPUT': '#d4d7dd',
+        'TEXT_INPUT': '#420000',
+        'SCROLL': '#420000',
+        'BUTTON': ('#420000', '#d4d7dd'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#420000', '#d4d7dd', '#eae9e9', '#f6f6f6'],
+    },
+    'DarkBlue6': {
+        'BACKGROUND': '#01024e',
+        'TEXT': '#ff6464',
+        'INPUT': '#8b4367',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#8b4367',
+        'BUTTON': ('#FFFFFF', '#543864'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#01024e', '#543864', '#8b4367', '#ff6464'],
+    },
+    'DarkBlue7': {
+        'BACKGROUND': '#241663',
+        'TEXT': '#eae7af',
+        'INPUT': '#a72693',
+        'TEXT_INPUT': '#eae7af',
+        'SCROLL': '#a72693',
+        'BUTTON': ('#eae7af', '#160f30'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#160f30', '#241663', '#a72693', '#eae7af'],
+    },
+    'LightBrown9': {
+        'BACKGROUND': '#f6d365',
+        'TEXT': '#3a1f5d',
+        'INPUT': '#c83660',
+        'TEXT_INPUT': '#f6d365',
+        'SCROLL': '#3a1f5d',
+        'BUTTON': ('#f6d365', '#c83660'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3a1f5d', '#c83660', '#e15249', '#f6d365'],
+    },
+    'DarkPurple3': {
+        'BACKGROUND': '#6e2142',
+        'TEXT': '#ffd692',
+        'INPUT': '#e16363',
+        'TEXT_INPUT': '#ffd692',
+        'SCROLL': '#e16363',
+        'BUTTON': ('#ffd692', '#943855'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'LightBrown10': {
+        'BACKGROUND': '#ffd692',
+        'TEXT': '#6e2142',
+        'INPUT': '#943855',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6e2142',
+        'BUTTON': ('white', '#6e2142'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#6e2142', '#943855', '#e16363', '#ffd692'],
+    },
+    'DarkPurple4': {
+        'BACKGROUND': '#200f21',
+        'TEXT': '#f638dc',
+        'INPUT': '#5a3d5c',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#5a3d5c',
+        'BUTTON': ('#FFFFFF', '#382039'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#200f21', '#382039', '#5a3d5c', '#f638dc'],
+    },
+    'LightBlue5': {
+        'BACKGROUND': '#b2fcff',
+        'TEXT': '#3e64ff',
+        'INPUT': '#5edfff',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#3e64ff',
+        'BUTTON': ('white', '#3e64ff'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e64ff', '#5edfff', '#b2fcff', '#ecfcff'],
+    },
+    'DarkTeal4': {
+        'BACKGROUND': '#464159',
+        'TEXT': '#c7f0db',
+        'INPUT': '#8bbabb',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#8bbabb',
+        'BUTTON': ('#FFFFFF', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightTeal': {
+        'BACKGROUND': '#c7f0db',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('white', '#464159'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'DarkTeal5': {
+        'BACKGROUND': '#8bbabb',
+        'TEXT': '#464159',
+        'INPUT': '#6c7b95',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#464159',
+        'BUTTON': ('#c7f0db', '#6c7b95'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#464159', '#6c7b95', '#8bbabb', '#c7f0db'],
+    },
+    'LightGrey4': {
+        'BACKGROUND': '#faf5ef',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('#672f2f', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGreen7': {
+        'BACKGROUND': '#99b19c',
+        'TEXT': '#faf5ef',
+        'INPUT': '#d7d1c9',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d7d1c9',
+        'BUTTON': ('#FFFFFF', '#99b19c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'LightGrey5': {
+        'BACKGROUND': '#d7d1c9',
+        'TEXT': '#672f2f',
+        'INPUT': '#99b19c',
+        'TEXT_INPUT': '#672f2f',
+        'SCROLL': '#672f2f',
+        'BUTTON': ('white', '#672f2f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#672f2f', '#99b19c', '#d7d1c9', '#faf5ef'],
+    },
+    'DarkBrown3': {
+        'BACKGROUND': '#a0855b',
+        'TEXT': '#f9f6f2',
+        'INPUT': '#f1d6ab',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f1d6ab',
+        'BUTTON': ('white', '#38470b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'LightBrown11': {
+        'BACKGROUND': '#f1d6ab',
+        'TEXT': '#38470b',
+        'INPUT': '#a0855b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#38470b',
+        'BUTTON': ('#f9f6f2', '#a0855b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#38470b', '#a0855b', '#f1d6ab', '#f9f6f2'],
+    },
+    'DarkRed': {
+        'BACKGROUND': '#83142c',
+        'TEXT': '#f9d276',
+        'INPUT': '#ad1d45',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#ad1d45',
+        'BUTTON': ('#f9d276', '#ad1d45'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#44000d', '#83142c', '#ad1d45', '#f9d276'],
+    },
+    'DarkTeal6': {
+        'BACKGROUND': '#204969',
+        'TEXT': '#fff7f7',
+        'INPUT': '#dadada',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dadada',
+        'BUTTON': ('black', '#fff7f7'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#204969', '#08ffc8', '#dadada', '#fff7f7'],
+    },
+    'DarkBrown4': {
+        'BACKGROUND': '#252525',
+        'TEXT': '#ff0000',
+        'INPUT': '#af0404',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#af0404',
+        'BUTTON': ('white', '#252525'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#252525', '#414141', '#af0404', '#ff0000'],
+    },
+    'LightYellow': {
+        'BACKGROUND': '#f4ff61',
+        'TEXT': '#27aa80',
+        'INPUT': '#32ff6a',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#27aa80',
+        'BUTTON': ('#f4ff61', '#27aa80'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#27aa80', '#32ff6a', '#a8ff3e', '#f4ff61'],
+    },
+    'DarkGreen1': {
+        'BACKGROUND': '#2b580c',
+        'TEXT': '#fdef96',
+        'INPUT': '#f7b71d',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f7b71d',
+        'BUTTON': ('#fdef96', '#2b580c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#2b580c', '#afa939', '#f7b71d', '#fdef96'],
+    },
+    'LightGreen8': {
+        'BACKGROUND': '#c8dad3',
+        'TEXT': '#63707e',
+        'INPUT': '#93b5b3',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#63707e',
+        'BUTTON': ('white', '#63707e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#63707e', '#93b5b3', '#c8dad3', '#f2f6f5'],
+    },
+    'DarkTeal7': {
+        'BACKGROUND': '#248ea9',
+        'TEXT': '#fafdcb',
+        'INPUT': '#aee7e8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aee7e8',
+        'BUTTON': ('black', '#fafdcb'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#248ea9', '#28c3d4', '#aee7e8', '#fafdcb'],
+    },
+    'DarkBlue8': {
+        'BACKGROUND': '#454d66',
+        'TEXT': '#d9d872',
+        'INPUT': '#58b368',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#58b368',
+        'BUTTON': ('black', '#009975'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#009975', '#454d66', '#58b368', '#d9d872'],
+    },
+    'DarkBlue9': {
+        'BACKGROUND': '#263859',
+        'TEXT': '#ff6768',
+        'INPUT': '#6b778d',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#6b778d',
+        'BUTTON': ('#ff6768', '#263859'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#17223b', '#263859', '#6b778d', '#ff6768'],
+    },
+    'DarkBlue10': {
+        'BACKGROUND': '#0028ff',
+        'TEXT': '#f1f4df',
+        'INPUT': '#10eaf0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#10eaf0',
+        'BUTTON': ('#f1f4df', '#24009c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#24009c', '#0028ff', '#10eaf0', '#f1f4df'],
+    },
+    'DarkBlue11': {
+        'BACKGROUND': '#6384b3',
+        'TEXT': '#e6f0b6',
+        'INPUT': '#b8e9c0',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b8e9c0',
+        'BUTTON': ('#e6f0b6', '#684949'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#684949', '#6384b3', '#b8e9c0', '#e6f0b6'],
+    },
+    'DarkTeal8': {
+        'BACKGROUND': '#71a0a5',
+        'TEXT': '#212121',
+        'INPUT': '#665c84',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#212121',
+        'BUTTON': ('#fab95b', '#665c84'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#212121', '#665c84', '#71a0a5', '#fab95b'],
+    },
+    'DarkRed1': {
+        'BACKGROUND': '#c10000',
+        'TEXT': '#eeeeee',
+        'INPUT': '#dedede',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#dedede',
+        'BUTTON': ('#c10000', '#eeeeee'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#c10000', '#ff4949', '#dedede', '#eeeeee'],
+    },
+    'LightBrown5': {
+        'BACKGROUND': '#fff591',
+        'TEXT': '#e41749',
+        'INPUT': '#f5587b',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e41749',
+        'BUTTON': ('#fff591', '#e41749'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#e41749', '#f5587b', '#ff8a5c', '#fff591'],
+    },
+    'LightGreen9': {
+        'BACKGROUND': '#f1edb3',
+        'TEXT': '#3b503d',
+        'INPUT': '#4a746e',
+        'TEXT_INPUT': '#f1edb3',
+        'SCROLL': '#3b503d',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'DarkGreen2': {
+        'BACKGROUND': '#3b503d',
+        'TEXT': '#f1edb3',
+        'INPUT': '#c8cf94',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c8cf94',
+        'BUTTON': ('#f1edb3', '#3b503d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3b503d', '#4a746e', '#c8cf94', '#f1edb3'],
+        'DESCRIPTION': ['Green', 'Turquoise', 'Yellow'],
+    },
+    'LightGray1': {
+        'BACKGROUND': '#f2f2f2',
+        'TEXT': '#222831',
+        'INPUT': '#393e46',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#222831',
+        'BUTTON': ('#f2f2f2', '#222831'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222831', '#393e46', '#f96d00', '#f2f2f2'],
+        'DESCRIPTION': ['Black', 'Grey', 'Orange', 'Grey', 'Autumn'],
+    },
+    'DarkGrey4': {
+        'BACKGROUND': '#52524e',
+        'TEXT': '#e9e9e5',
+        'INPUT': '#d4d6c8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#d4d6c8',
+        'BUTTON': ('#FFFFFF', '#9a9b94'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#52524e', '#9a9b94', '#d4d6c8', '#e9e9e5'],
+        'DESCRIPTION': ['Grey', 'Pastel', 'Winter'],
+    },
+    'DarkBlue12': {
+        'BACKGROUND': '#324e7b',
+        'TEXT': '#f8f8f8',
+        'INPUT': '#86a6df',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#86a6df',
+        'BUTTON': ('#FFFFFF', '#5068a9'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#324e7b', '#5068a9', '#86a6df', '#f8f8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkPurple6': {
+        'BACKGROUND': '#070739',
+        'TEXT': '#e1e099',
+        'INPUT': '#c327ab',
+        'TEXT_INPUT': '#e1e099',
+        'SCROLL': '#c327ab',
+        'BUTTON': ('#e1e099', '#521477'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#070739', '#521477', '#c327ab', '#e1e099'],
+        'DESCRIPTION': ['Black', 'Purple', 'Yellow', 'Dark'],
+    },
+    'DarkBlue13': {
+        'BACKGROUND': '#203562',
+        'TEXT': '#e3e8f8',
+        'INPUT': '#c0c5cd',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#c0c5cd',
+        'BUTTON': ('#FFFFFF', '#3e588f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#203562', '#3e588f', '#c0c5cd', '#e3e8f8'],
+        'DESCRIPTION': ['Blue', 'Grey', 'Wedding', 'Cold'],
+    },
+    'DarkBrown5': {
+        'BACKGROUND': '#3c1b1f',
+        'TEXT': '#f6e1b5',
+        'INPUT': '#e2bf81',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e2bf81',
+        'BUTTON': ('#3c1b1f', '#f6e1b5'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3c1b1f', '#b21e4b', '#e2bf81', '#f6e1b5'],
+        'DESCRIPTION': ['Brown', 'Red', 'Yellow', 'Warm'],
+    },
+    'DarkGreen3': {
+        'BACKGROUND': '#062121',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('#eeeeee', '#181810'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['Black', 'Black', 'Brown', 'Grey'],
+    },
+    'DarkBlack1': {
+        'BACKGROUND': '#181810',
+        'TEXT': '#eeeeee',
+        'INPUT': '#e4dcad',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e4dcad',
+        'BUTTON': ('white', '#062121'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#062121', '#181810', '#e4dcad', '#eeeeee'],
+        'DESCRIPTION': ['Black', 'Black', 'Brown', 'Grey'],
+    },
+    'DarkGrey5': {
+        'BACKGROUND': '#343434',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#FFFFFF', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'LightBrown12': {
+        'BACKGROUND': '#8e8b82',
+        'TEXT': '#f3f3f3',
+        'INPUT': '#e9dcbe',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e9dcbe',
+        'BUTTON': ('#f3f3f3', '#8e8b82'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#343434', '#8e8b82', '#e9dcbe', '#f3f3f3'],
+        'DESCRIPTION': ['Grey', 'Brown'],
+    },
+    'DarkTeal9': {
+        'BACKGROUND': '#13445a',
+        'TEXT': '#fef4e8',
+        'INPUT': '#446878',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#446878',
+        'BUTTON': ('#fef4e8', '#446878'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#13445a', '#970747', '#446878', '#fef4e8'],
+        'DESCRIPTION': ['Red', 'Grey', 'Blue', 'Wedding', 'Retro'],
+    },
+    'DarkBlue14': {
+        'BACKGROUND': '#21273d',
+        'TEXT': '#f1f6f8',
+        'INPUT': '#b9d4f1',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#b9d4f1',
+        'BUTTON': ('#FFFFFF', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', 'Black', 'Grey', 'Cold', 'Winter'],
+    },
+    'LightBlue6': {
+        'BACKGROUND': '#f1f6f8',
+        'TEXT': '#21273d',
+        'INPUT': '#6a759b',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#21273d',
+        'BUTTON': ('#f1f6f8', '#6a759b'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#21273d', '#6a759b', '#b9d4f1', '#f1f6f8'],
+        'DESCRIPTION': ['Blue', 'Black', 'Grey', 'Cold', 'Winter'],
+    },
+    'DarkGreen4': {
+        'BACKGROUND': '#044343',
+        'TEXT': '#e4e4e4',
+        'INPUT': '#045757',
+        'TEXT_INPUT': '#e4e4e4',
+        'SCROLL': '#045757',
+        'BUTTON': ('#e4e4e4', '#045757'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#222222', '#044343', '#045757', '#e4e4e4'],
+        'DESCRIPTION': ['Black', 'Turquoise', 'Grey', 'Dark'],
+    },
+    'DarkGreen5': {
+        'BACKGROUND': '#1b4b36',
+        'TEXT': '#e0e7f1',
+        'INPUT': '#aebd77',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#aebd77',
+        'BUTTON': ('#FFFFFF', '#538f6a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#1b4b36', '#538f6a', '#aebd77', '#e0e7f1'],
+        'DESCRIPTION': ['Green', 'Grey'],
+    },
+    'DarkTeal10': {
+        'BACKGROUND': '#0d3446',
+        'TEXT': '#d8dfe2',
+        'INPUT': '#71adb5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#71adb5',
+        'BUTTON': ('#FFFFFF', '#176d81'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#0d3446', '#176d81', '#71adb5', '#d8dfe2'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter', 'Cold'],
+    },
+    'DarkGrey6': {
+        'BACKGROUND': '#3e3e3e',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#FFFFFF', '#405559'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'DarkTeal11': {
+        'BACKGROUND': '#405559',
+        'TEXT': '#ededed',
+        'INPUT': '#68868c',
+        'TEXT_INPUT': '#ededed',
+        'SCROLL': '#68868c',
+        'BUTTON': ('#ededed', '#68868c'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#3e3e3e', '#405559', '#68868c', '#ededed'],
+        'DESCRIPTION': ['Grey', 'Turquoise', 'Winter'],
+    },
+    'LightBlue7': {
+        'BACKGROUND': '#9ed0e0',
+        'TEXT': '#19483f',
+        'INPUT': '#5c868e',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#19483f',
+        'BUTTON': ('white', '#19483f'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#19483f', '#5c868e', '#ff6a38', '#9ed0e0'],
+        'DESCRIPTION': ['Orange', 'Blue', 'Turquoise'],
+    },
+    'LightGreen10': {
+        'BACKGROUND': '#d8ebb5',
+        'TEXT': '#205d67',
+        'INPUT': '#639a67',
+        'TEXT_INPUT': '#FFFFFF',
+        'SCROLL': '#205d67',
+        'BUTTON': ('#d8ebb5', '#205d67'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#205d67', '#639a67', '#d9bf77', '#d8ebb5'],
+        'DESCRIPTION': ['Blue', 'Green', 'Brown', 'Vintage'],
+    },
+    'DarkBlue15': {
+        'BACKGROUND': '#151680',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#1c44ac'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkBlue16': {
+        'BACKGROUND': '#1c44ac',
+        'TEXT': '#f1fea4',
+        'INPUT': '#375fc0',
+        'TEXT_INPUT': '#f1fea4',
+        'SCROLL': '#375fc0',
+        'BUTTON': ('#f1fea4', '#151680'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#151680', '#1c44ac', '#375fc0', '#f1fea4'],
+        'DESCRIPTION': ['Blue', 'Yellow', 'Cold'],
+    },
+    'DarkTeal12': {
+        'BACKGROUND': '#004a7c',
+        'TEXT': '#fafafa',
+        'INPUT': '#e8f1f5',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#e8f1f5',
+        'BUTTON': ('#fafafa', '#005691'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#004a7c', '#005691', '#e8f1f5', '#fafafa'],
+        'DESCRIPTION': ['Grey', 'Blue', 'Cold', 'Winter'],
+    },
+    'LightBrown13': {
+        'BACKGROUND': '#ebf5ee',
+        'TEXT': '#921224',
+        'INPUT': '#bdc6b8',
+        'TEXT_INPUT': '#921224',
+        'SCROLL': '#921224',
+        'BUTTON': ('white', '#921224'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#921224', '#bdc6b8', '#bce0da', '#ebf5ee'],
+        'DESCRIPTION': ['Red', 'Blue', 'Grey', 'Vintage', 'Wedding'],
+    },
+    'DarkBlue17': {
+        'BACKGROUND': '#21294c',
+        'TEXT': '#f9f2d7',
+        'INPUT': '#f2dea8',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#f2dea8',
+        'BUTTON': ('#f9f2d7', '#141829'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#141829', '#21294c', '#f2dea8', '#f9f2d7'],
+        'DESCRIPTION': ['Black', 'Blue', 'Yellow'],
+    },
+    'DarkBrown6': {
+        'BACKGROUND': '#785e4d',
+        'TEXT': '#f2eee3',
+        'INPUT': '#baaf92',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#baaf92',
+        'BUTTON': ('white', '#785e4d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#785e4d', '#ff8426', '#baaf92', '#f2eee3'],
+        'DESCRIPTION': ['Grey', 'Brown', 'Orange', 'Autumn'],
+    },
+    'DarkGreen6': {
+        'BACKGROUND': '#5c715e',
+        'TEXT': '#f2f9f1',
+        'INPUT': '#ddeedf',
+        'TEXT_INPUT': '#000000',
+        'SCROLL': '#ddeedf',
+        'BUTTON': ('#f2f9f1', '#5c715e'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#5c715e', '#b6cdbd', '#ddeedf', '#f2f9f1'],
+        'DESCRIPTION': ['Grey', 'Green', 'Vintage'],
+    },
+    'DarkGrey7': {
+        'BACKGROUND': '#4b586e',
+        'TEXT': '#dddddd',
+        'INPUT': '#574e6d',
+        'TEXT_INPUT': '#dddddd',
+        'SCROLL': '#574e6d',
+        'BUTTON': ('#dddddd', '#43405d'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#43405d', '#4b586e', '#574e6d', '#dddddd'],
+        'DESCRIPTION': ['Grey', 'Winter', 'Cold'],
+    },
+    'DarkRed2': {
+        'BACKGROUND': '#ab1212',
+        'TEXT': '#f6e4b5',
+        'INPUT': '#cd3131',
+        'TEXT_INPUT': '#f6e4b5',
+        'SCROLL': '#cd3131',
+        'BUTTON': ('#f6e4b5', '#ab1212'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#ab1212', '#1fad9f', '#cd3131', '#f6e4b5'],
+        'DESCRIPTION': ['Turquoise', 'Red', 'Yellow'],
+    },
+    'LightGrey6': {
+        'BACKGROUND': '#e3e3e3',
+        'TEXT': '#233142',
+        'INPUT': '#455d7a',
+        'TEXT_INPUT': '#e3e3e3',
+        'SCROLL': '#233142',
+        'BUTTON': ('#e3e3e3', '#455d7a'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+        'COLOR_LIST': ['#233142', '#455d7a', '#f95959', '#e3e3e3'],
+        'DESCRIPTION': ['Black', 'Blue', 'Red', 'Grey'],
+    },
+    'HotDogStand': {
+        'BACKGROUND': 'red',
+        'TEXT': 'yellow',
+        'INPUT': 'yellow',
+        'TEXT_INPUT': 'black',
+        'SCROLL': 'yellow',
+        'BUTTON': ('red', 'yellow'),
+        'PROGRESS': DEFAULT_PROGRESS_BAR_COLOR,
+        'BORDER': 1,
+        'SLIDER_DEPTH': 0,
+        'PROGRESS_DEPTH': 0,
+    },
+}
 
 
 def ListOfLookAndFeelValues():
@@ -7026,7 +9274,6 @@ def theme_text_color(color=None):
     return DEFAULT_TEXT_COLOR
 
 
-
 def theme_input_background_color(color=None):
     """
     Sets/Returns the input element background color currently in use
@@ -7047,7 +9294,6 @@ def theme_input_text_color(color=None):
     if color is not None:
         set_options(input_text_color=color)
     return DEFAULT_INPUT_TEXT_COLOR
-
 
 
 def theme_button_color(color=None):
@@ -7117,7 +9363,6 @@ def theme_progress_bar_border_width(border_width=None):
     return DEFAULT_PROGRESS_BAR_BORDER_WIDTH
 
 
-
 def theme_element_text_color(color=None):
     """
     Sets/Returns the text color used by elements that have text as part of their display (Tables, Trees and Sliders)
@@ -7154,7 +9399,6 @@ def theme_add_new(new_theme_name, new_theme_dict):
         print('Exception during adding new theme {}'.format(e))
 
 
-
 def theme_previewer(columns=12):
     """
     Show a window with all of the color themes - takes a while so be patient
@@ -7162,6 +9406,7 @@ def theme_previewer(columns=12):
     :param columns: (int) number of themes in a single row
     """
     preview_all_look_and_feel_themes(columns)
+
 
 def ChangeLookAndFeel(index, force=False):
     """
@@ -7224,24 +9469,25 @@ def ChangeLookAndFeel(index, force=False):
         else:
             colors['PROGRESS'] = DEFAULT_PROGRESS_BAR_COLOR_OFFICIAL
         # call to change all the colors
-        SetOptions(background_color=colors['BACKGROUND'],
-                   text_element_background_color=colors['BACKGROUND'],
-                   element_background_color=colors['BACKGROUND'],
-                   text_color=colors['TEXT'],
-                   input_elements_background_color=colors['INPUT'],
-                   # button_color=colors['BUTTON'] if not sys.platform.startswith('darwin') else None,
-                   button_color=colors['BUTTON'],
-                   progress_meter_color=colors['PROGRESS'],
-                   border_width=colors['BORDER'],
-                   slider_border_width=colors['SLIDER_DEPTH'],
-                   progress_meter_border_depth=colors['PROGRESS_DEPTH'],
-                   scrollbar_color=(colors['SCROLL']),
-                   element_text_color=colors['TEXT'],
-                   input_text_color=colors['TEXT_INPUT'])
+        SetOptions(
+            background_color=colors['BACKGROUND'],
+            text_element_background_color=colors['BACKGROUND'],
+            element_background_color=colors['BACKGROUND'],
+            text_color=colors['TEXT'],
+            input_elements_background_color=colors['INPUT'],
+            # button_color=colors['BUTTON'] if not sys.platform.startswith('darwin') else None,
+            button_color=colors['BUTTON'],
+            progress_meter_color=colors['PROGRESS'],
+            border_width=colors['BORDER'],
+            slider_border_width=colors['SLIDER_DEPTH'],
+            progress_meter_border_depth=colors['PROGRESS_DEPTH'],
+            scrollbar_color=(colors['SCROLL']),
+            element_text_color=colors['TEXT'],
+            input_text_color=colors['TEXT_INPUT'],
+        )
     except:  # most likely an index out of range
         print('** Warning - Theme value not valid. Change your theme call. **')
         print('valid values are', list_of_look_and_feel_values())
-
 
 
 def preview_all_look_and_feel_themes(columns=12):
@@ -7252,15 +9498,23 @@ def preview_all_look_and_feel_themes(columns=12):
     """
 
     # Show a "splash" type message so the user doesn't give up waiting
-    popup_quick_message('Hang on for a moment, this will take a bit to create....', background_color='red', text_color='white', auto_close=True, non_blocking=True)
+    popup_quick_message(
+        'Hang on for a moment, this will take a bit to create....',
+        background_color='red',
+        text_color='white',
+        auto_close=True,
+        non_blocking=True,
+    )
 
     web = False
 
     win_bg = 'black'
 
     def sample_layout():
-        return [[Text('Text element'), InputText('Input data here', size=(10, 1))],
-                [Button('Ok'), Button('Cancel'), Slider((1, 10), orientation='h', size=(5, 15))]]
+        return [
+            [Text('Text element'), InputText('Input data here', size=(10, 1))],
+            [Button('Ok'), Button('Cancel'), Slider((1, 10), orientation='h', size=(5, 15))],
+        ]
 
     layout = [[Text('Here is a complete list of themes', font='Default 18', background_color=win_bg)]]
 
@@ -7293,18 +9547,35 @@ sprint = ScrolledTextBox
 def ObjToStringSingleObj(obj):
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join((repr(item) + ' = ' + repr(obj.__dict__[item]) for item in sorted(obj.__dict__)))
+    )
 
 
 def ObjToString(obj, extra='    '):
     if obj is None:
         return 'None'
-    return str(obj.__class__) + '\n' + '\n'.join(
-        (extra + (str(item) + ' = ' +
-                  (ObjToString(obj.__dict__[item], extra + '    ') if hasattr(obj.__dict__[item], '__dict__') else str(
-                      obj.__dict__[item])))
-         for item in sorted(obj.__dict__)))
+    return (
+        str(obj.__class__)
+        + '\n'
+        + '\n'.join(
+            (
+                extra
+                + (
+                    str(item)
+                    + ' = '
+                    + (
+                        ObjToString(obj.__dict__[item], extra + '    ')
+                        if hasattr(obj.__dict__[item], '__dict__')
+                        else str(obj.__dict__[item])
+                    )
+                )
+                for item in sorted(obj.__dict__)
+            )
+        )
+    )
 
 
 # ------------------------------------------------------------------------------------------------------------------ #
@@ -7321,13 +9592,28 @@ def ObjToString(obj, extra='    '):
 #         ####   #        ####   #        ####
 
 
-
 # ----------------------------------- The mighty Popup! ------------------------------------------------------------ #
 
 
-def Popup(*args, title=None, button_color=None, background_color=None, text_color=None, button_type=POPUP_BUTTONS_OK,
-          auto_close=False, auto_close_duration=None, custom_text=(None, None), non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None,
-          font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def Popup(
+    *args,
+    title=None,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    button_type=POPUP_BUTTONS_OK,
+    auto_close=False,
+    auto_close_duration=None,
+    custom_text=(None, None),
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Popup - Display a popup box with as many parms as you wish to include
     :param args:
@@ -7355,10 +9641,21 @@ def Popup(*args, title=None, button_color=None, background_color=None, text_colo
         local_line_width = line_width
     else:
         local_line_width = MESSAGE_BOX_LINE_WIDTH
-    _title =  title if title is not None else args_to_print[0]
-    window = Window(_title, auto_size_text=True, background_color=background_color, button_color=button_color,
-                    auto_close=auto_close, auto_close_duration=auto_close_duration, icon=icon, font=font,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    _title = title if title is not None else args_to_print[0]
+    window = Window(
+        _title,
+        auto_size_text=True,
+        background_color=background_color,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        icon=icon,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
     max_line_total, total_lines = 0, 0
     for message in args_to_print:
         # fancy code to check if string and convert if not is not need. Just always convert to string :-)
@@ -7375,7 +9672,8 @@ def Popup(*args, title=None, button_color=None, background_color=None, text_colo
         # height = _GetNumLinesNeeded(message, width_used)
         height = message_wrapped_lines
         window.AddRow(
-            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color))
+            Text(message_wrapped, auto_size_text=True, text_color=text_color, background_color=background_color)
+        )
         total_lines += height
 
     if non_blocking:
@@ -7385,29 +9683,62 @@ def Popup(*args, title=None, button_color=None, background_color=None, text_colo
     # show either an OK or Yes/No depending on paramater
     if custom_text != (None, None):
         if type(custom_text) is not tuple:
-            window.AddRow(PopupButton(custom_text,size=(len(custom_text),1), button_color=button_color, focus=True, bind_return_key=True))
+            window.AddRow(
+                PopupButton(
+                    custom_text, size=(len(custom_text), 1), button_color=button_color, focus=True, bind_return_key=True
+                )
+            )
         elif custom_text[1] is None:
-            window.AddRow(PopupButton(custom_text[0],size=(len(custom_text[0]),1), button_color=button_color, focus=True, bind_return_key=True))
+            window.AddRow(
+                PopupButton(
+                    custom_text[0],
+                    size=(len(custom_text[0]), 1),
+                    button_color=button_color,
+                    focus=True,
+                    bind_return_key=True,
+                )
+            )
         else:
-            window.AddRow(PopupButton(custom_text[0], button_color=button_color, focus=True, bind_return_key=True, size=(len(custom_text[0]), 1)),
-                          PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[0]), 1)))
+            window.AddRow(
+                PopupButton(
+                    custom_text[0],
+                    button_color=button_color,
+                    focus=True,
+                    bind_return_key=True,
+                    size=(len(custom_text[0]), 1),
+                ),
+                PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[0]), 1)),
+            )
     elif button_type is POPUP_BUTTONS_YES_NO:
-        window.AddRow(PopupButton('Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3),
-                                  size=(5, 1)), PopupButton('No', button_color=button_color, size=(5, 1)))
+        window.AddRow(
+            PopupButton(
+                'Yes', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 5), 3), size=(5, 1)
+            ),
+            PopupButton('No', button_color=button_color, size=(5, 1)),
+        )
     elif button_type is POPUP_BUTTONS_CANCELLED:
         window.AddRow(
-            PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)))
+            PopupButton('Cancelled', button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3))
+        )
     elif button_type is POPUP_BUTTONS_ERROR:
-        window.AddRow(PopupButton('Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True,
-                                  pad=((20, 0), 3)))
+        window.AddRow(
+            PopupButton(
+                'Error', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
+            )
+        )
     elif button_type is POPUP_BUTTONS_OK_CANCEL:
-        window.AddRow(PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
-                      PopupButton('Cancel', size=(6, 1), button_color=button_color))
+        window.AddRow(
+            PopupButton('OK', size=(6, 1), button_color=button_color, focus=True, bind_return_key=True),
+            PopupButton('Cancel', size=(6, 1), button_color=button_color),
+        )
     elif button_type is POPUP_BUTTONS_NO_BUTTONS:
         pass
     else:
-        window.AddRow(PopupButton('OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True,
-                                  pad=((20, 0), 3)))
+        window.AddRow(
+            PopupButton(
+                'OK', size=(5, 1), button_color=button_color, focus=True, bind_return_key=True, pad=((20, 0), 3)
+            )
+        )
 
     if non_blocking:
         button, values = window.Read(timeout=0)
@@ -7428,9 +9759,22 @@ def MsgBox(*args):
 
 
 # --------------------------- PopupNoButtons ---------------------------
-def PopupNoButtons(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-                   auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                   no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupNoButtons(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Show a Popup but without any buttons
     :param args:
@@ -7449,18 +9793,43 @@ def PopupNoButtons(*args, button_color=None, background_color=None, text_color=N
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=POPUP_BUTTONS_NO_BUTTONS,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=POPUP_BUTTONS_NO_BUTTONS,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 # --------------------------- PopupNonBlocking ---------------------------
-def PopupNonBlocking(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                     auto_close=False, auto_close_duration=None, non_blocking=True, icon=DEFAULT_WINDOW_ICON,
-                     line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                     location=(None, None)):
+def PopupNonBlocking(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Show Popup box and immediately return (does not block)
     :param args:
@@ -7480,20 +9849,46 @@ def PopupNonBlocking(*args, button_type=POPUP_BUTTONS_OK, button_color=None, bac
     :param location:
     :return:
     """
-    return Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    return Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 PopupNoWait = PopupNonBlocking
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup  ---------------------------
-def PopupQuick(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-               auto_close=True, auto_close_duration=2, non_blocking=True, icon=DEFAULT_WINDOW_ICON, line_width=None,
-               font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupQuick(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=2,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Show Popup box that doesn't block and closes itself
     :param args:
@@ -7513,19 +9908,43 @@ def PopupQuick(*args, button_type=POPUP_BUTTONS_OK, button_color=None, backgroun
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 # --------------------------- PopupQuick - a NonBlocking, Self-closing Popup with no titlebar and no buttons ---------------------------
-def PopupQuickMessage(*args, button_type=POPUP_BUTTONS_NO_BUTTONS, button_color=None, background_color=None,
-                      text_color=None,
-                      auto_close=True, auto_close_duration=2, non_blocking=True, icon=DEFAULT_WINDOW_ICON,
-                      line_width=None,
-                      font=None, no_titlebar=True, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupQuickMessage(
+    *args,
+    button_type=POPUP_BUTTONS_NO_BUTTONS,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=2,
+    non_blocking=True,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=True,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Show Popup box that doesn't block and closes itself
     :param args:
@@ -7545,17 +9964,42 @@ def PopupQuickMessage(*args, button_type=POPUP_BUTTONS_NO_BUTTONS, button_color=
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 # --------------------------- PopupNoTitlebar ---------------------------
-def PopupNoTitlebar(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                    auto_close=False, auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON,
-                    line_width=None, font=None, grab_anywhere=True, keep_on_top=False, location=(None, None)):
+def PopupNoTitlebar(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    grab_anywhere=True,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display a Popup without a titlebar.   Enables grab anywhere so you can move it
     :param args:
@@ -7574,11 +10018,23 @@ def PopupNoTitlebar(*args, button_type=POPUP_BUTTONS_OK, button_color=None, back
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=True, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=True,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 PopupNoFrame = PopupNoTitlebar
@@ -7587,10 +10043,23 @@ PopupAnnoying = PopupNoTitlebar
 
 
 # --------------------------- PopupAutoClose ---------------------------
-def PopupAutoClose(*args, button_type=POPUP_BUTTONS_OK, button_color=None, background_color=None, text_color=None,
-                   auto_close=True, auto_close_duration=DEFAULT_AUTOCLOSE_TIME, non_blocking=False, icon=DEFAULT_WINDOW_ICON,
-                   line_width=None, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                   location=(None, None)):
+def PopupAutoClose(
+    *args,
+    button_type=POPUP_BUTTONS_OK,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=True,
+    auto_close_duration=DEFAULT_AUTOCLOSE_TIME,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Popup that closes itself after some time period
     :param args:
@@ -7610,20 +10079,45 @@ def PopupAutoClose(*args, button_type=POPUP_BUTTONS_OK, button_color=None, backg
     :param location:
     :return:
     """
-    Popup(*args, button_color=button_color, background_color=background_color, text_color=text_color,
-          button_type=button_type,
-          auto_close=auto_close, auto_close_duration=auto_close_duration, non_blocking=non_blocking, icon=icon,
-          line_width=line_width,
-          font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_color=button_color,
+        background_color=background_color,
+        text_color=text_color,
+        button_type=button_type,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 PopupTimed = PopupAutoClose
 
 
 # --------------------------- PopupError ---------------------------
-def PopupError(*args, button_color=DEFAULT_ERROR_BUTTON_COLOR, background_color=None, text_color=None, auto_close=False,
-               auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-               no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupError(
+    *args,
+    button_color=DEFAULT_ERROR_BUTTON_COLOR,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Popup with colored button and 'Error' as button text
     :param args:
@@ -7642,16 +10136,42 @@ def PopupError(*args, button_color=DEFAULT_ERROR_BUTTON_COLOR, background_color=
     :param location:
     :return:
     """
-    Popup(*args, button_type=POPUP_BUTTONS_ERROR, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_type=POPUP_BUTTONS_ERROR,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 # --------------------------- PopupCancel ---------------------------
-def PopupCancel(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-                auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupCancel(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display Popup with "cancelled" button text
     :param args:
@@ -7670,16 +10190,42 @@ def PopupCancel(*args, button_color=None, background_color=None, text_color=None
     :param location:
     :return:
     """
-    Popup(*args, button_type=POPUP_BUTTONS_CANCELLED, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_type=POPUP_BUTTONS_CANCELLED,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 # --------------------------- PopupOK ---------------------------
-def PopupOK(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-            auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-            no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupOK(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display Popup with OK button only
     :param args:
@@ -7698,16 +10244,42 @@ def PopupOK(*args, button_color=None, background_color=None, text_color=None, au
     :param location:
     :return:
     """
-    Popup(*args, button_type=POPUP_BUTTONS_OK, background_color=background_color, text_color=text_color,
-          non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color, auto_close=auto_close,
-          auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere,
-          keep_on_top=keep_on_top, location=location)
+    Popup(
+        *args,
+        button_type=POPUP_BUTTONS_OK,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 # --------------------------- PopupOKCancel ---------------------------
-def PopupOKCancel(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-                  auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-                  no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupOKCancel(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display popup with OK and Cancel buttons
     :param args:
@@ -7726,16 +10298,42 @@ def PopupOKCancel(*args, button_color=None, background_color=None, text_color=No
     :param location:
     :return: OK, Cancel or None
     """
-    return Popup(*args, button_type=POPUP_BUTTONS_OK_CANCEL, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    return Popup(
+        *args,
+        button_type=POPUP_BUTTONS_OK_CANCEL,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 # --------------------------- PopupYesNo ---------------------------
-def PopupYesNo(*args, button_color=None, background_color=None, text_color=None, auto_close=False,
-               auto_close_duration=None, non_blocking=False, icon=DEFAULT_WINDOW_ICON, line_width=None, font=None,
-               no_titlebar=False, grab_anywhere=False, keep_on_top=False, location=(None, None)):
+def PopupYesNo(
+    *args,
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    auto_close=False,
+    auto_close_duration=None,
+    non_blocking=False,
+    icon=DEFAULT_WINDOW_ICON,
+    line_width=None,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display Popup with Yes and No buttons
     :param args:
@@ -7754,10 +10352,23 @@ def PopupYesNo(*args, button_color=None, background_color=None, text_color=None,
     :param location:
     :return: Yes, No or None
     """
-    return Popup(*args, button_type=POPUP_BUTTONS_YES_NO, background_color=background_color, text_color=text_color,
-                 non_blocking=non_blocking, icon=icon, line_width=line_width, button_color=button_color,
-                 auto_close=auto_close, auto_close_duration=auto_close_duration, font=font, no_titlebar=no_titlebar,
-                 grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    return Popup(
+        *args,
+        button_type=POPUP_BUTTONS_YES_NO,
+        background_color=background_color,
+        text_color=text_color,
+        non_blocking=non_blocking,
+        icon=icon,
+        line_width=line_width,
+        button_color=button_color,
+        auto_close=auto_close,
+        auto_close_duration=auto_close_duration,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
 
 ##############################################################################
@@ -7768,9 +10379,23 @@ def PopupYesNo(*args, button_color=None, background_color=None, text_color=None,
 # --------------------------- PopupGetFolder ---------------------------
 
 
-def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(None, None), button_color=None,
-                   background_color=None, text_color=None, icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False,
-                   grab_anywhere=False, keep_on_top=False, location=(None, None), initial_folder=None):
+def PopupGetFolder(
+    message,
+    title=None,
+    default_path='',
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    initial_folder=None,
+):
     """
     Display popup with text entry field and browse button. Browse for folder
     :param message:
@@ -7789,7 +10414,6 @@ def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(
     :return: Contents of text field. None if closed using X or cancelled
     """
 
-
     if no_window:
         app = wx.App(False)
         frame = wx.Frame()
@@ -7803,17 +10427,26 @@ def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(
             folder_name = dialog.GetPath()
         return folder_name
 
-
-
-    layout = [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
-              [InputText(default_text=default_path, size=size, key='_INPUT_'), FolderBrowse(initial_folder=initial_folder)],
-              [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))]]
+    layout = [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
+        [InputText(default_text=default_path, size=size, key='_INPUT_'), FolderBrowse(initial_folder=initial_folder)],
+        [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))],
+    ]
 
     _title = title if title is not None else message
-    window = Window(title=_title, layout=layout, icon=icon, auto_size_text=True, button_color=button_color,
-                    background_color=background_color,
-                    font=font, no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top,
-                    location=location)
+    window = Window(
+        title=_title,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        background_color=background_color,
+        font=font,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.Close()
@@ -7824,14 +10457,29 @@ def PopupGetFolder(message, title=None, default_path='', no_window=False, size=(
         return path
 
 
-
-
 # --------------------------- PopupGetFile ---------------------------
 
-def PopupGetFile(message, title=None, default_path='', default_extension='', save_as=False, file_types=(('ALL Files', '*'),),
-                 no_window=False, size=(None, None), button_color=None, background_color=None, text_color=None,
-                 icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False, grab_anywhere=False, keep_on_top=False,
-                 location=(None, None), initial_folder=None):
+
+def PopupGetFile(
+    message,
+    title=None,
+    default_path='',
+    default_extension='',
+    save_as=False,
+    file_types=(('ALL Files', '*'),),
+    no_window=False,
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+    initial_folder=None,
+):
     """
         Display popup with text entry field and browse button. Browse for file
     :param message:
@@ -7860,8 +10508,7 @@ def PopupGetFile(message, title=None, default_path='', default_extension='', sav
         qt_types = convert_tkinter_filetypes_to_wx(file_types)
         style = wx.FD_SAVE if save_as else wx.FD_OPEN
         if initial_folder:
-            dialog = wx.FileDialog(frame, defaultDir=initial_folder, wildcard=qt_types,
-                                   style=style)
+            dialog = wx.FileDialog(frame, defaultDir=initial_folder, wildcard=qt_types, style=style)
         else:
             dialog = wx.FileDialog(frame, wildcard=qt_types, style=style)
         if dialog.ShowModal() == wx.ID_OK:
@@ -7870,18 +10517,33 @@ def PopupGetFile(message, title=None, default_path='', default_extension='', sav
             file_name = ''
         return file_name
 
-    browse_button = SaveAs(file_types=file_types, initial_folder=initial_folder) if save_as else FileBrowse(
-        file_types=file_types, initial_folder=initial_folder)
+    browse_button = (
+        SaveAs(file_types=file_types, initial_folder=initial_folder)
+        if save_as
+        else FileBrowse(file_types=file_types, initial_folder=initial_folder)
+    )
 
-    layout = [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
-              [InputText(default_text=default_path, size=(30,1), key='_INPUT_'), browse_button],
-              [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))]]
+    layout = [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
+        [InputText(default_text=default_path, size=(30, 1), key='_INPUT_'), browse_button],
+        [Button('Ok', size=(60, 20), bind_return_key=True), Button('Cancel', size=(60, 20))],
+    ]
 
     _title = title if title is not None else message
 
-    window = Window(title=_title, layout=layout, icon=icon, auto_size_text=True, button_color=button_color, font=font,
-                    background_color=background_color,
-                    no_titlebar=no_titlebar, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, location=location)
+    window = Window(
+        title=_title,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        font=font,
+        background_color=background_color,
+        no_titlebar=no_titlebar,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        location=location,
+    )
 
     button, values = window.Read()
     window.Close()
@@ -7892,13 +10554,25 @@ def PopupGetFile(message, title=None, default_path='', default_extension='', sav
         return path
 
 
-
-
 # --------------------------- PopupGetText ---------------------------
 
-def PopupGetText(message, title=None, default_text='', password_char='', size=(None, None), button_color=None,
-                 background_color=None, text_color=None, icon=DEFAULT_WINDOW_ICON, font=None, no_titlebar=False,
-                 grab_anywhere=False, keep_on_top=False, location=(None, None)):
+
+def PopupGetText(
+    message,
+    title=None,
+    default_text='',
+    password_char='',
+    size=(None, None),
+    button_color=None,
+    background_color=None,
+    text_color=None,
+    icon=DEFAULT_WINDOW_ICON,
+    font=None,
+    no_titlebar=False,
+    grab_anywhere=False,
+    keep_on_top=False,
+    location=(None, None),
+):
     """
     Display Popup with text entry field
     :param message:
@@ -7917,15 +10591,27 @@ def PopupGetText(message, title=None, default_text='', password_char='', size=(N
     :return: Text entered or None if window was closed
     """
 
-    layout = [[Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
-              [InputText(default_text=default_text, size=size, key='_INPUT_', password_char=password_char)],
-              [CloseButton('Ok', size=(60, 20), bind_return_key=True), CloseButton('Cancel', size=(60, 20))]]
+    layout = [
+        [Text(message, auto_size_text=True, text_color=text_color, background_color=background_color)],
+        [InputText(default_text=default_text, size=size, key='_INPUT_', password_char=password_char)],
+        [CloseButton('Ok', size=(60, 20), bind_return_key=True), CloseButton('Cancel', size=(60, 20))],
+    ]
 
     _title = title if title is not None else message
 
-    window = Window(title=_title, layout=layout, icon=icon, auto_size_text=True, button_color=button_color, no_titlebar=no_titlebar,
-                    background_color=background_color, grab_anywhere=grab_anywhere, keep_on_top=keep_on_top, font=font,
-                    location=location)
+    window = Window(
+        title=_title,
+        layout=layout,
+        icon=icon,
+        auto_size_text=True,
+        button_color=button_color,
+        no_titlebar=no_titlebar,
+        background_color=background_color,
+        grab_anywhere=grab_anywhere,
+        keep_on_top=keep_on_top,
+        font=font,
+        location=location,
+    )
 
     button, values = window.Read()
     window.Close()
@@ -7934,8 +10620,6 @@ def PopupGetText(message, title=None, default_text='', password_char='', size=(N
     else:
         path = values['_INPUT_']
         return path
-
-
 
 
 # ------------------------ PEP8-ify The SDK ------------------------#
@@ -7978,7 +10662,7 @@ timer_start = TimerStart
 timer_stop = TimerStop
 
 
-#------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
+# ------------------------ Set the "Official PySimpleGUI Theme Colors" ------------------------
 theme(CURRENT_LOOK_AND_FEEL)
 
 # theme_previewer()
@@ -7999,47 +10683,59 @@ theme(CURRENT_LOOK_AND_FEEL)
 
 def main():
 
-    def VerLine(version, description, justification='r', size=(30,1)):
-        return [T(version, justification=justification, font='Any 12', text_color='yellow', size=size), T(description, font='Any 12')]
+    def VerLine(version, description, justification='r', size=(30, 1)):
+        return [
+            T(version, justification=justification, font='Any 12', text_color='yellow', size=size),
+            T(description, font='Any 12'),
+        ]
+
     ver = version.split('\n')[0]
 
     # ChangeLookAndFeel('Light Brown 11')
-    frame_contents = [[T('Inside my frame')],
-                      [Input(size=(5,1))],
-                      [Input()]]
+    frame_contents = [[T('Inside my frame')], [Input(size=(5, 1))], [Input()]]
     layout = [
-              [Text('Welcome to PySimpleGUI!', font='Arial 15', text_color='yellow')],
-                VerLine(ver, 'PySimpleGUI Version'),
+        [Text('Welcome to PySimpleGUI!', font='Arial 15', text_color='yellow')],
+        VerLine(ver, 'PySimpleGUI Version'),
+        VerLine(os.path.dirname(os.path.abspath(__file__)), 'PySimpleGUI Location', justification='l', size=(30, 2)),
+        VerLine(sys.version, 'Python Version', justification='l', size=(40, 2)),
+        [Text('You should be importing this module rather than running it', justification='l', size=(50, 1))],
+        [Text('Here is your sample input window....')],
+        [Frame('FRAME with Centered Contents', frame_contents, element_justification='c')],
+        [InputText('Source', focus=True, size_px=(200, 80)), FileBrowse()],
+        [InputText('Dest'), FolderBrowse()],
+        [Checkbox('Checkbox 1', size=(15, 1)), Checkbox('Checkbox 2')],
+        [Radio('Radio 1', 'group', size=(15, 1)), Radio('Radio 2', 'group')],
+        [Multiline('Multiline Input', do_not_clear=True, size=(40, 4), enable_events=True)],
+        [MultilineOutput('Multiline Output', size=(40, 5), text_color='blue')],
+        [
+            Combo(
+                values=['Combo 1', 'Combo 2', 'Combo 3'],
+                default_value='Combo 2',
+                key='_COMBO_',
+                enable_events=True,
+                readonly=False,
+                tooltip='Combo box',
+                disabled=False,
+                font='Courier 18',
+                size=(12, 1),
+            )
+        ],
+        [Spin(values=['Spin a', 'Spin b', 'Spin c'], font='ANY 15', key='_SPIN_', size=(10, 1), enable_events=True)],
+        [Button('Ok'), Button('Exit')],
+    ]
 
-                VerLine(os.path.dirname(os.path.abspath(__file__)), 'PySimpleGUI Location', justification='l', size=(30, 2)),
-                VerLine(sys.version, 'Python Version', justification='l', size=(40, 2)),
-
-              [Text('You should be importing this module rather than running it', justification='l', size=(50, 1))],
-              [Text('Here is your sample input window....')],
-                [Frame('FRAME with Centered Contents', frame_contents, element_justification='c')],
-              [InputText('Source', focus=True, size_px=(200,80)), FileBrowse()],
-              [InputText('Dest'), FolderBrowse()],
-              [Checkbox('Checkbox 1', size=(15,1)), Checkbox('Checkbox 2')],
-              [Radio('Radio 1', 'group', size=(15,1)), Radio('Radio 2', 'group')],
-              [Multiline('Multiline Input', do_not_clear=True, size=(40,4), enable_events=True)],
-
-              [MultilineOutput('Multiline Output', size=(40,5), text_color='blue')],
-              [Combo(values=['Combo 1', 'Combo 2', 'Combo 3'], default_value='Combo 2', key='_COMBO_',
-                        enable_events=True, readonly=False, tooltip='Combo box', disabled=False, font='Courier 18',
-                        size=(12, 1))],
-              [Spin(values=['Spin a', 'Spin b', 'Spin c'], font='ANY 15', key='_SPIN_', size=(10, 1), enable_events=True)],
-              [Button('Ok'), Button('Exit')]]
-
-    window = Window('Demo window..', layout,
-                    # default_element_size=(35,1),
-                    auto_size_text=True,
-                    auto_size_buttons=True,
-                    no_titlebar=False,
-                    disable_close=False,
-                    disable_minimize=True,
-                    grab_anywhere=True,
-                    # element_justification='r'
-                    )
+    window = Window(
+        'Demo window..',
+        layout,
+        # default_element_size=(35,1),
+        auto_size_text=True,
+        auto_size_buttons=True,
+        no_titlebar=False,
+        disable_close=False,
+        disable_minimize=True,
+        grab_anywhere=True,
+        # element_justification='r'
+    )
 
     while True:
         event, values = window.Read()

--- a/FreeSimpleGUIWx/setup.py
+++ b/FreeSimpleGUIWx/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,14 +10,12 @@ keywords = PySimpleGui fork GUI UI tkinter Qt WxPython Remi wrapper simple easy 
 url = https://github.com/spyoungtech/FreeSimpleGui
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
     Topic :: Multimedia :: Graphics
     Operating System :: OS Independent


### PR DESCRIPTION
- Applies `black` formatting to FreeSimpleGUI library code and pre-commit config
- adds `flake8` to pre-commit configuration 
- fixes over 300 (non-formatting) flake8 violations in the main FreeSimpleGUI library
- Removes a lot of dead code
- Removes unneeded compat code targeting Python 3.4 (code was already syntax-incompatible with Python<3.6 anyhow)