### PR TITLE
Fix for typo in import for different fsg* commands

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ packages =
 include_package_data = True
 [options.entry_points]
 gui_scripts =
-    fsgissue=FreeSimpleGui.FreeSimpleGui:main_open_github_issue
-    fsgmain=FreeSimpleGui.FreeSimpleGui:_main_entry_point
-    fsghelp=FreeSimpleGui.FreeSimpleGui:main_sdk_help
-    fsgver=FreeSimpleGui.FreeSimpleGui:main_get_debug_data
-    fsgsettings=FreeSimpleGui.FreeSimpleGui:main_global_pysimplegui_settings
+    fsgissue=FreeSimpleGUI:main_open_github_issue
+    fsgmain=FreeSimpleGUI:_main_entry_point
+    fsghelp=FreeSimpleGUI:main_sdk_help
+    fsgver=FreeSimpleGUI:main_get_debug_data
+    fsgsettings=FreeSimpleGUI:main_global_pysimplegui_settings


### PR DESCRIPTION
Fixes for  issue #42
This update setup.cfg file, fixing typo in imports for fsg* commands 