### PR TITLE
Fix exit() not existing when running Python with -S flag

### DIFF
--- a/FreeSimpleGUI/window.py
+++ b/FreeSimpleGUI/window.py
@@ -1087,7 +1087,7 @@ class Window:
                 Window._root_running_mainloop.mainloop()
             except:
                 print('**** EXITING ****')
-                exit(-1)
+                sys.exit(-1)
             # print('Out main')
             self.CurrentlyRunningMainloop = False
             # if self.LastButtonClicked != TIMEOUT_KEY:


### PR DESCRIPTION
As stated in https://github.com/Nuitka/Nuitka/issues/3097, Python does not natively include `exit()` function, which is added by site module.
Using `sys.exit()` is the way.