### PR TITLE
gh-45 address errors for tcl/tk 9 used by homebrew users on MacOS

### DIFF
--- a/FreeSimpleGUI/window.py
+++ b/FreeSimpleGUI/window.py
@@ -2467,7 +2467,10 @@ class Window:
 
         if self.thread_strvar is None:
             self.thread_strvar = tk.StringVar()
-            self.thread_strvar.trace('w', self._window_tkvar_changed_callback)
+            if tk.TkVersion < 9:
+                self.thread_strvar.trace('w', self._window_tkvar_changed_callback)
+            else:
+                self.thread_strvar.trace_add('write', self._window_tkvar_changed_callback)
 
     def write_event_value(self, key, value):
         """


### PR DESCRIPTION
Resolves #45 

Although official builds of Python bundle tcl/tk 8.6 and virtually every third party build of Python and every distribution of tcl/tk for such builds use tcl/tk 8.6, for some reason, the homebrew formulae for `python-tk` versions 3.12 and 3.13 are not bound to tcl/tk 8, meaning users of homebrew may end up with a tcl/tk version that is not compatible. Specifically, the `trace` method is not supported in tcl 9, though the `tkinter` module in Python continues to offer this API (although deprecated).

This PR works around this problem.

Similar incompatibilities with tcl/tk 9 may continue to exist. This only addresses this one instance. It does not imply tcl/tk 9 is supported.