### PR TITLE
Pyside6

### DIFF
--- a/FreeSimpleGUIQt/FreeSimpleGUIQt/FreeSimpleGUIQt.py
+++ b/FreeSimpleGUIQt/FreeSimpleGUIQt/FreeSimpleGUIQt.py
@@ -31,7 +31,7 @@ except:
 # Copyright 2020 PySimpleGUI.org
 
 
-from PySide2.QtWidgets import (
+from PySide6.QtWidgets import (
     QApplication,
     QLabel,
     QWidget,
@@ -44,7 +44,7 @@ from PySide2.QtWidgets import (
     QDial,
     QTableWidget,
 )
-from PySide2.QtWidgets import (
+from PySide6.QtWidgets import (
     QSlider,
     QCheckBox,
     QRadioButton,
@@ -55,7 +55,7 @@ from PySide2.QtWidgets import (
     QDialog,
     QAbstractItemView,
 )
-from PySide2.QtWidgets import (
+from PySide6.QtWidgets import (
     QSpacerItem,
     QFrame,
     QGroupBox,
@@ -72,22 +72,22 @@ from PySide2.QtWidgets import (
     QTreeWidgetItemIterator,
     QProgressBar,
 )
-from PySide2.QtWidgets import (
+from PySide6.QtWidgets import (
     QTableWidgetItem,
     QGraphicsView,
     QGraphicsScene,
     QGraphicsItemGroup,
     QMenu,
     QMenuBar,
-    QAction,
     QSystemTrayIcon,
     QColorDialog,
 )
-from PySide2.QtGui import QPainter, QPixmap, QPen, QColor, QBrush, QPainterPath, QFont, QImage, QIcon
-from PySide2.QtCore import Qt, QEvent, QSize
-import PySide2.QtGui as QtGui
-import PySide2.QtCore as QtCore
-import PySide2.QtWidgets as QtWidgets
+from PySide6.QtGui import QPainter, QPixmap, QPen, QColor, QBrush, QPainterPath, QFont, QImage, QIcon, QAction
+
+from PySide6.QtCore import Qt, QEvent, QSize
+import PySide6.QtGui as QtGui
+import PySide6.QtCore as QtCore
+import PySide6.QtWidgets as QtWidgets
 
 using_pyqt5 = False
 

--- a/FreeSimpleGUIQt/readme.md
+++ b/FreeSimpleGUIQt/readme.md
@@ -14,9 +14,8 @@ Welcome to the Alpha Release of FreeSimpleGUI for Qt!
 
 You can use the exact same code that you are running on the older, tkinter, version of FreeSimpleGUI.
 
-FreeSimpleGUIQt uses **PySide2** OR **PyQt5** for access to Qt.  **PyQt5 has been having  a number of problems recently however so tread lightly.**
+FreeSimpleGUIQt uses **PySide6** as of version 2.0.0 -- Version 1.0 used PySide2
 
-## To minimize potential problems and broken features, if at all possible, use pyside2 instead of PyQt5.
 
 ## Porting your FreeSimpleGUI code to FreeSimpleGUIQt
 
@@ -46,18 +45,11 @@ Fonts should be in the format (font family, size).  You can use the older string
 
  pip3 install --upgrade --no-cache-dir FreeSimpleGUIQt
 
-### Installing PySide2 for Python 3
+### PySide dependency
 
-It is _highly_ recommended that you use PySide2.  The code will attempt to use PyQt5 is pyside2 isn't found.  PyQt5 is **not** recommended.
-
-To install Pyside2:
-
-```pip install PySide2```
-
-
-**PyQt5 is no longer supported.  Only PySide2 is supported**
-
-Too many differences were causing a lot of headaches.  Supporting just 1 Qt port is difficult enough.  Parsing out the differences between pyside2 and pyqt5 was simply getting to be too much
+As of version 2.0.0 this project depends on PySide6, which in turn requires Python3.9 or greater. Version 1.0 of this project 
+used PySide2, which supports Python versions up to 3.10. The correct version of FreeSimpleGUIQt and respective 
+required version of PySide will be installed automatically when you install `FreeSimpleGUIQt` using `pip`.
 
 
 
@@ -77,10 +69,6 @@ Here is the window you should see:
 ![image](https://user-images.githubusercontent.com/46163555/71421852-7c6ad400-264b-11ea-9adc-15f6aa4248e8.png)
 
 
-
-
-## Prerequisites Python 3
-PySide2 or PyQt5   (experimental)
 
 
 ## Using  - Python 3

--- a/FreeSimpleGUIQt/readme.md
+++ b/FreeSimpleGUIQt/readme.md
@@ -47,8 +47,8 @@ Fonts should be in the format (font family, size).  You can use the older string
 
 ### PySide dependency
 
-As of version 2.0.0 this project depends on PySide6, which in turn requires Python3.9 or greater. Version 1.0 of this project 
-used PySide2, which supports Python versions up to 3.10. The correct version of FreeSimpleGUIQt and respective 
+As of version 2.0.0 this project depends on PySide6, which in turn requires Python3.9 or greater. Version 1.0 of this project
+used PySide2, which supports Python versions up to 3.10. The correct version of FreeSimpleGUIQt and respective
 required version of PySide will be installed automatically when you install `FreeSimpleGUIQt` using `pip`.
 
 

--- a/FreeSimpleGUIQt/setup.cfg
+++ b/FreeSimpleGUIQt/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = FreeSimpleGUIQt
-version = 1.0.0
+version = 2.0.0
 maintainer = Spencer Phillip Young
 maintainer_email = spencer.young@spyoung.com
 description = The free-forever Python GUI framework.

--- a/FreeSimpleGUIQt/setup.cfg
+++ b/FreeSimpleGUIQt/setup.cfg
@@ -25,3 +25,5 @@ include_package_data = True
 
 install_requires =
     pyside6
+
+python_requires = >=3.9

--- a/FreeSimpleGUIQt/setup.cfg
+++ b/FreeSimpleGUIQt/setup.cfg
@@ -10,14 +10,11 @@ keywords = PySimpleGui fork GUI UI tkinter Qt WxPython Remi wrapper simple easy 
 url = https://github.com/spyoungtech/FreeSimpleGui
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
     Topic :: Multimedia :: Graphics
     Operating System :: OS Independent
@@ -27,4 +24,4 @@ packages = FreeSimpleGUIQt
 include_package_data = True
 
 install_requires =
-    pyside2
+    pyside6


### PR DESCRIPTION
Migrate from PySide2 (which only supports up to Python 3.10) to PySide6, which supports Python 3.9-3.13

[Porting guide](https://doc.qt.io/qtforpython-6/faq/porting_from2.html)

So far, I've just changed the imports which allows simple applications to run. I will need to read the porting guide and review the FreeSimpleGUIQt code to identify any other possible required changes.

Relates to #56 #13 
