### PR TITLE
fix for echo_stdout_stderr attribute

### DIFF
--- a/FreeSimpleGUI/elements/multiline.py
+++ b/FreeSimpleGUI/elements/multiline.py
@@ -493,9 +493,9 @@ class Multiline(Element):
         try:
             self.update(txt, append=True)
             if self.echo_stdout_stderr:
-                if hasattr(Window, "_original_stdout") and Window._original_stdout:
+                if hasattr(Window, '_original_stdout') and Window._original_stdout:
                     Window._original_stdout.write(txt)
-                elif hasattr(Window, "_original_stderr") and Window._original_stderr:
+                elif hasattr(Window, '_original_stderr') and Window._original_stderr:
                     Window._original_stderr.write(txt)
         except:
             pass

--- a/FreeSimpleGUI/elements/multiline.py
+++ b/FreeSimpleGUI/elements/multiline.py
@@ -484,19 +484,19 @@ class Multiline(Element):
 
     def write(self, txt):
         """
-        Called by Python (not tkinter?) when stdout or stderr wants to write
+        Called by Python when stdout or stderr has been redirected and wants to write
+        Mirrors output to the console if echo_stdout_stderr is enabled
 
         :param txt: text of output
         :type txt:  (str)
         """
         try:
             self.update(txt, append=True)
-            # if need to echo, then send the same text to the destinatoin that isn't thesame as this one
             if self.echo_stdout_stderr:
-                if sys.stdout != self:
-                    sys.stdout.write(txt)
-                elif sys.stderr != self:
-                    sys.stderr.write(txt)
+                if hasattr(Window, "_original_stdout") and Window._original_stdout:
+                    Window._original_stdout.write(txt)
+                elif hasattr(Window, "_original_stderr") and Window._original_stderr:
+                    Window._original_stderr.write(txt)
         except:
             pass
 


### PR DESCRIPTION
- The echo_stdout_stderr attribute had no effect on the Multiline element when reroute_stdout AND reroute_stderr were True, which is the case for the default Output element. 
- Everything got redirected to the Multiline element without echoing the text to the console. 
- These changes do not change the behavior when only reroute_stdout OR only reroute_stderr is True.
- It now checks if the Window has the _original_stdout / _original_stderr attribute and then writes the  text to it when echo_stdout_stderr is True.
