### PR TITLE
Add drop_whitespace parameter to all text based popups

### DIFF
--- a/FreeSimpleGUI/__init__.py
+++ b/FreeSimpleGUI/__init__.py
@@ -10081,6 +10081,7 @@ def popup_non_blocking(
     relative_location=(None, None),
     image=None,
     modal=False,
+    drop_whitespace=True,
 ):
     """
     Show Popup window and immediately return (does not block)
@@ -10145,6 +10146,7 @@ def popup_non_blocking(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10169,6 +10171,7 @@ def popup_quick(
     relative_location=(None, None),
     image=None,
     modal=False,
+    drop_whitespace=True,
 ):
     """
     Show Popup box that doesn't block and closes itself
@@ -10235,6 +10238,7 @@ def popup_quick(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10259,6 +10263,7 @@ def popup_quick_message(
     relative_location=(None, None),
     image=None,
     modal=False,
+    drop_whitespace=True,
 ):
     """
     Show Popup window with no titlebar, doesn't block, and auto closes itself.
@@ -10324,6 +10329,7 @@ def popup_quick_message(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10347,6 +10353,7 @@ def popup_no_titlebar(
     relative_location=(None, None),
     image=None,
     modal=True,
+    drop_whitespace=True,
 ):
     """
     Display a Popup without a titlebar.   Enables grab anywhere so you can move it
@@ -10410,6 +10417,7 @@ def popup_no_titlebar(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10434,6 +10442,7 @@ def popup_auto_close(
     relative_location=(None, None),
     image=None,
     modal=True,
+    drop_whitespace=True,
 ):
     """Popup that closes itself after some time period
 
@@ -10499,6 +10508,7 @@ def popup_auto_close(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10522,6 +10532,7 @@ def popup_error(
     relative_location=(None, None),
     image=None,
     modal=True,
+    drop_whitespace=True,
 ):
     """
     Popup with colored button and 'Error' as button text
@@ -10586,6 +10597,7 @@ def popup_error(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10609,6 +10621,7 @@ def popup_cancel(
     relative_location=(None, None),
     image=None,
     modal=True,
+    drop_whitespace=True,
 ):
     """
     Display Popup with "cancelled" button text
@@ -10672,6 +10685,7 @@ def popup_cancel(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10695,6 +10709,7 @@ def popup_ok(
     relative_location=(None, None),
     image=None,
     modal=True,
+    drop_whitespace=True,
 ):
     """
     Display Popup with OK button only
@@ -10758,6 +10773,7 @@ def popup_ok(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10781,6 +10797,7 @@ def popup_ok_cancel(
     relative_location=(None, None),
     image=None,
     modal=True,
+    drop_whitespace=True,
 ):
     """
     Display popup with OK and Cancel buttons
@@ -10844,6 +10861,7 @@ def popup_ok_cancel(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 
@@ -10867,6 +10885,7 @@ def popup_yes_no(
     relative_location=(None, None),
     image=None,
     modal=True,
+    drop_whitespace=True,
 ):
     """
     Display Popup with Yes and No buttons
@@ -10930,6 +10949,7 @@ def popup_yes_no(
         relative_location=relative_location,
         image=image,
         modal=modal,
+        drop_whitespace=drop_whitespace,
     )
 
 


### PR DESCRIPTION
As per #78 , adds `drop_whitespace` parameter to the `popup_non_blocking`, `popup_quick`, `popup_quick_message`, `popup_no_titlebar`, `popup_auto_close`, `popup_error`, `popup_cancel`, `popup_ok`, `popup_ok_cancel` and `popup_yes_no` popups. Defaults to `True` as per the existing parameter in `popup`