### PR TITLE
Fix exception handling in global PySimpleGUI settings

### DIFF
--- a/FreeSimpleGUI/__init__.py
+++ b/FreeSimpleGUI/__init__.py
@@ -15523,7 +15523,8 @@ def main_global_pysimplegui_settings():
                         pysimplegui_user_settings.set(json.dumps(('-ttk scroll-', key[1])), value)
 
             # Upgrade Service Settings
-            pysimplegui_user_settings.set('-upgrade show only critical-', values['-UPGRADE SHOW ONLY CRITICAL-'])
+            if '-UPGRADE SHOW ONLY CRITICAL-' in values:
+                pysimplegui_user_settings.set('-upgrade show only critical-', values['-UPGRADE SHOW ONLY CRITICAL-'])
 
             theme(new_theme)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,14 @@
+import unittest
+
+import FreeSimpleGUI as sg
+
+
+class MyTestCase(unittest.TestCase):
+    def test_open_and_close_global_psg_settings(self):
+        sg.popup_ok("In the settings window (next window) press OK button to continue the test.")
+        ok_pressed = sg.main_global_pysimplegui_settings()
+        self.assertEqual(ok_pressed, True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This bug was already repored by @dimmv2 in #69 but not fixed.

Reproduce: run fsgsettings

> Traceback (most recent call last):
>   File "<frozen runpy>", line 198, in _run_module_as_main
>   File "<frozen runpy>", line 88, in _run_code
>   File "...\.venv\Scripts\fsgsettings.exe\__main__.py", line 10, in <module>
>     sys.exit(main_global_pysimplegui_settings())
>              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
>   File "...\FreeSimpleGUI\__init__.py", line 15506, in main_global_pysimplegui_settings
>     pysimplegui_user_settings.set('-upgrade show only critical-', values['-UPGRADE SHOW ONLY CRITICAL-'])
>                                                                   ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> KeyError: '-UPGRADE SHOW ONLY CRITICAL-'


--
PySimpleGUI long version =  5.1.0
PySimpleGUI Version  5.1.0 
tcl ver = 8.6 tkinter version = 8.6 
Python Version 3.13.5 (main, Jun 12 2025, 12:42:35) [MSC v.1943 64 bit (AMD64)]
tcl detailed version = 8.6.12