### PR TITLE
Add external TTK themes capabilities

### DIFF
--- a/FreeSimpleGUI/__init__.py
+++ b/FreeSimpleGUI/__init__.py
@@ -4433,7 +4433,7 @@ def _change_ttk_theme(style, theme_name):
 
     if ADDITIONAL_TTK_STYLING_PATHS:
         if not hasattr(style.master, '_additional_styling_loaded'):
-            style.tk.call("source", str(ADDITIONAL_TTK_STYLING_PATHS))
+            style.tk.call('source', str(ADDITIONAL_TTK_STYLING_PATHS))
             style.master._additional_styling_loaded = True  # type: ignore
 
     if theme_name not in style.theme_names():

--- a/FreeSimpleGUI/__init__.py
+++ b/FreeSimpleGUI/__init__.py
@@ -4432,7 +4432,7 @@ def _change_ttk_theme(style, theme_name):
     global ttk_theme_in_use
 
     if ADDITIONAL_TTK_STYLING_PATHS:
-        if not hasattr(style.master, "_additional_styling_loaded"):
+        if not hasattr(style.master, '_additional_styling_loaded'):
             style.tk.call("source", str(ADDITIONAL_TTK_STYLING_PATHS))
             style.master._additional_styling_loaded = True  # type: ignore
 

--- a/FreeSimpleGUI/__init__.py
+++ b/FreeSimpleGUI/__init__.py
@@ -190,7 +190,7 @@ THEME_XPNATIVE = 'xpnative'
 DEFAULT_TTK_THEME = THEME_DEFAULT
 ttk_theme_in_use = None
 # TTK_THEME_LIST = ('default', 'winnative', 'clam', 'alt', 'classic', 'vista', 'xpnative')
-
+ADDITIONAL_TTK_STYLING_PATHS = None
 
 USE_TTK_BUTTONS = None
 
@@ -4430,6 +4430,12 @@ def _add_right_click_menu(element, toplevel_form):
 
 def _change_ttk_theme(style, theme_name):
     global ttk_theme_in_use
+
+    if ADDITIONAL_TTK_STYLING_PATHS:
+        if not hasattr(style.master, "_additional_styling_loaded"):
+            style.tk.call("source", str(ADDITIONAL_TTK_STYLING_PATHS))
+            style.master._additional_styling_loaded = True  # type: ignore
+
     if theme_name not in style.theme_names():
         _error_popup_with_traceback(
             f'You are trying to use TTK theme "{theme_name}"',


### PR DESCRIPTION
Abstract: Tkinter looks quite old.
There are some really nice looking themes (like SunnyValley Themes), see https://github.com/rdbende/Sun-Valley-ttk-theme or https://github.com/rdbende/Azure-ttk-theme

Themes are installed via:
```
python -m pip install sv_ttk
```

While they can be loaded manually after a window.finalise() call, it becomes a real burden to manually theme all FreeSimpleGUI widgets one by one.

Here's a patch that allows to specify alternative paths for ttk themes.
This allows loading __any__ ttk theme you want directly into FreeSimpleGUI and avoid errors like `Tkinter error: "can't find package ttk::theme::sv_ttk". Is this a headless server ?` when trying to manually load said themes.

Abstract code to show what is possible:
```python
import os 
import FreeSimpleGUI as sg
import sv_ttk # noqa # we don't need to access this, only import to retrieve module path

# Load custom sv_ttk light theme
sg.ADDITIONAL_TTK_STYLING_PATHS = path = os.path.join(os.path.dirname(sv_ttk.__file__), "sv.tcl")
sg.DEFAULT_TTK_THEME = f"sun-valley-light"

layout = [
    [sg.Text("Sun Valley Light Theme Test")],
    [sg.InputCombo(("Option 1", "Option 2", "Option 3"), default_value="Option 1")],
    [sg.Button("OK"), sg.Button("Cancel")]
]

window = sg.Window("Sun Valley Light Theme Example", layout)
while True:
    event, values = window.read()
    if event in (sg.WIN_CLOSED, "Cancel"):
        break
window.close()
```

| Before|After|
|-------|------| 
|<img width="204" height="140" alt="{CBD3A866-2513-4B9F-95B4-2EB1BBE2C097}" src="https://github.com/user-attachments/assets/72dc1bc2-b0bd-4f9e-9aab-250832a5ba7f" />|<img width="202" height="153" alt="{721B562C-5508-43E8-9CB0-252121A851E4}" src="https://github.com/user-attachments/assets/56cba55e-df8d-4e53-8c45-841dd8f4c162" />| 

Of course, this is just a demonstration of a combobox, but almost all widgets gain from these themes.


