### PR TITLE
Fix button size calculation in PopupButton for foreign langs

### DIFF
--- a/FreeSimpleGUI/__init__.py
+++ b/FreeSimpleGUI/__init__.py
@@ -9690,7 +9690,7 @@ def popup(
                 [
                     PopupButton(
                         custom_text,
-                        size=(len(custom_text)+1, 1),
+                        size=(len(custom_text) + 1, 1),
                         button_color=button_color,
                         focus=True,
                         bind_return_key=True,
@@ -9702,7 +9702,7 @@ def popup(
                 [
                     PopupButton(
                         custom_text[0],
-                        size=(len(custom_text[0])+1, 1),
+                        size=(len(custom_text[0]) + 1, 1),
                         button_color=button_color,
                         focus=True,
                         bind_return_key=True,
@@ -9717,9 +9717,9 @@ def popup(
                         button_color=button_color,
                         focus=True,
                         bind_return_key=True,
-                        size=(len(custom_text[0])+1, 1),
+                        size=(len(custom_text[0]) + 1, 1),
                     ),
-                    PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[1])+1, 1)),
+                    PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[1]) + 1, 1)),
                 ]
             ]
     elif button_type == POPUP_BUTTONS_YES_NO:

--- a/FreeSimpleGUI/__init__.py
+++ b/FreeSimpleGUI/__init__.py
@@ -9690,7 +9690,7 @@ def popup(
                 [
                     PopupButton(
                         custom_text,
-                        size=(len(custom_text), 1),
+                        size=(len(custom_text)+1, 1),
                         button_color=button_color,
                         focus=True,
                         bind_return_key=True,
@@ -9702,7 +9702,7 @@ def popup(
                 [
                     PopupButton(
                         custom_text[0],
-                        size=(len(custom_text[0]), 1),
+                        size=(len(custom_text[0])+1, 1),
                         button_color=button_color,
                         focus=True,
                         bind_return_key=True,
@@ -9717,9 +9717,9 @@ def popup(
                         button_color=button_color,
                         focus=True,
                         bind_return_key=True,
-                        size=(len(custom_text[0]), 1),
+                        size=(len(custom_text[0])+1, 1),
                     ),
-                    PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[1]), 1)),
+                    PopupButton(custom_text[1], button_color=button_color, size=(len(custom_text[1])+1, 1)),
                 ]
             ]
     elif button_type == POPUP_BUTTONS_YES_NO:


### PR DESCRIPTION
So using sg.popup("something", custom_text("Non", "Oui"))) would produce wrong sized buttons depending on used polices and systems. There is no specific rule as when text will be wrapped, mostly it's about one character since button size is done by len(text) calculation.

<img width="562" height="121" alt="{DBB7C573-8C80-4791-BD92-915CAAFA712D}" src="https://github.com/user-attachments/assets/536f0457-470b-49fa-8831-ecabc7c4f4cf" />

Adding +1 to button size in order to deal with most of those problems

<img width="561" height="124" alt="{A9583885-7429-41D8-B9ED-169602E473A6}" src="https://github.com/user-attachments/assets/702d25ff-c949-4eb5-884b-6a5f4e35e9cc" />
