### PR TITLE
Add error handling for scroll region configuration

### DIFF
--- a/FreeSimpleGUI/elements/column.py
+++ b/FreeSimpleGUI/elements/column.py
@@ -141,7 +141,10 @@ class TkScrollableFrame(tk.Frame):
 
     def set_scrollregion(self, event=None):
         """Set the scroll region on the canvas"""
-        self.canvas.configure(scrollregion=self.canvas.bbox('all'))
+        try:
+            self.canvas.configure(scrollregion=self.canvas.bbox('all'))
+        except tk.TclError:
+            pass
 
 
 class Column(Element):


### PR DESCRIPTION
Handle potential TclError when setting scroll region:

When using complex UIs, async closing the window might trigger the following error because of a race condition where scrolling is set after canvas is destroyed

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "c:\Python312-64\Lib\tkinter\__init__.py", line 1968, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "C:\GIT\venv\Lib\site-packages\FreeSimpleGUI\elements\column.py", line 144, in set_scrollregion
    self.canvas.configure(scrollregion=self.canvas.bbox('all'))
                                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Python312-64\Lib\tkinter\__init__.py", line 2820, in bbox
    self.tk.call((self._w, 'bbox') + args)) or None
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_tkinter.TclError: invalid command name ".!toplevel5.!frame.!notebook.!frame.!frame2.!notebook.!frame4.!frame3.!frame.!frame8.!tkscrollableframe.!canvas"
Exception in Tkinter callback
Traceback (most recent call last):
  File "c:\Python312-64\Lib\tkinter\__init__.py", line 1968, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "C:\GIT\venv\Lib\site-packages\FreeSimpleGUI\elements\column.py", line 144, in set_scrollregion
    self.canvas.configure(scrollregion=self.canvas.bbox('all'))
                                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Python312-64\Lib\tkinter\__init__.py", line 2820, in bbox
    self.tk.call((self._w, 'bbox') + args)) or None
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_tkinter.TclError: invalid command name ".!toplevel5.!frame.!notebook.!frame.!frame2.!notebook.!frame4.!frame3.!frame.!frame8.!tkscrollableframe2.!canvas"
Exception in Tkinter callback
Traceback (most recent call last):
  File "c:\Python312-64\Lib\tkinter\__init__.py", line 1968, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "C:\GIT\venv\Lib\site-packages\FreeSimpleGUI\elements\column.py", line 144, in set_scrollregion
    self.canvas.configure(scrollregion=self.canvas.bbox('all'))
                                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Python312-64\Lib\tkinter\__init__.py", line 2820, in bbox
    self.tk.call((self._w, 'bbox') + args)) or None
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_tkinter.TclError: invalid command name ".!toplevel5.!frame.!notebook.!frame2.!frame.!notebook.!frame4.!frame2.!frame.!frame8.!tkscrollableframe.!canvas"
```